### PR TITLE
Support auto-reconnecting websocket failures

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -576,6 +576,14 @@ RTMClient.prototype._handleMostRecentMsgReply = function _handleMostRecentMsgRep
 RTMClient.prototype.handleWsError = function handleWsError(err) {
   this.logger('debug', err);
   this.emit(CLIENT_EVENTS.WS_ERROR, err);
+  this.connected = false;
+  if (this.autoReconnect) {
+    if (!this._connecting) {
+      this.reconnect();
+    }
+  } else {
+    this.disconnect('websocket error with auto-reconnect false on the RTM client');
+  }
 };
 
 


### PR DESCRIPTION
Support auto-reconnecting on websocket failures.

Fixes: https://github.com/slackhq/node-slack-sdk/issues/240
