### PR TITLE
proxyURL consistency in ws.js

### DIFF
--- a/lib/clients/transports/ws.js
+++ b/lib/clients/transports/ws.js
@@ -18,7 +18,7 @@ var wsTransport = function wsTransport(socketUrl, opts) {
   var wsOpts = {};
 
   if (wsTransportOpts.proxyURL) {
-    wsOpts.agent = new HttpsProxyAgent(wsTransportOpts.proxyUrl);
+    wsOpts.agent = new HttpsProxyAgent(wsTransportOpts.proxyURL);
   }
 
   return new WebSocket(socketUrl, wsOpts);


### PR DESCRIPTION
- [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
- [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
- [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
- [ ] I've written tests to cover the new code and functionality included in this PR.
- [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
#### PR Summary

`wsTransport` documents `opts.proxyURL` as a string that can be provided as an argument to set the proxy for `HttpsProxyAgent`. However, after checking to see if `wsTransportOpts.proxyURL` is set, `wsTransportOpts.proxyUrl` was used instead. This changes `proxyUrl` to `proxyURL` to stay consistent with the documentation and conditional check.
#### Related Issues

No issues currently describing this problem.
#### Test strategy

No test strategy for this PR.
