### PR TITLE
Incomingwebhooks: support iconurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ wh.send({
   username: 'Custom Name'
 });
 
+// You can use a URL to an image instead of an Emoji
+// If you specify both an emoji and a URL. It will favour the URL
+wh.send({
+  text: 'Some text',
+  channel: 'custom-channel',
+  iconUrl: 'https://octodex.github.com/images/original.png',
+  username: 'Custom Name'
+});
+
 // You can send attachments as well
 // See https://api.slack.com/docs/attachments
 wh.send({

--- a/lib/clients/incoming-webhook/client.js
+++ b/lib/clients/incoming-webhook/client.js
@@ -11,6 +11,9 @@ var noop = require('lodash').noop;
  *      If no username is specified, the one chosen when creating the webhook will be used.
  * @param {string} defaults.iconEmoji The default emoji to use when sending a webhook.
  *      If no iconEmoji is specified, the one chosen when creating the webhook will be used.
+ * @param {string} defaults.iconUrl The default image to use when sending a webhook.
+ *      If no iconUrl is specified, the one chosen when creating the webhook will be used.
+ *      If you specifiy both an Emoji and an URL use the URL
  * @param {string} defaults.channel The default channel to use when sending a webhook.
  *      If no channel is specified, the one chosen when creating the webhook will be used.
  * @param {string} defaults.text The default text to use when sending a webhook.
@@ -27,6 +30,7 @@ function IncomingWebhook(slackUrl, defaults) {
   this.defaults = {
     username: _defaults.username,
     iconEmoji: _defaults.iconEmoji,
+    iconUrl: _defaults.iconUrl,
     channel: _defaults.channel,
     text: _defaults.text
   };
@@ -60,6 +64,7 @@ IncomingWebhook.prototype._formatData = function _formatData(message) {
   var data = {
     username: this.defaults.username,
     icon_emoji: this.defaults.iconEmoji,
+    iconUrl: this.defaults.iconUrl,
     channel: this.defaults.channel,
     text: this.defaults.text
   };
@@ -69,7 +74,11 @@ IncomingWebhook.prototype._formatData = function _formatData(message) {
   } else if (isObject(message)) {
     if (message.text) data.text = message.text;
     if (message.username) data.username = message.username;
-    if (message.iconEmoji) data.icon_emoji = message.iconEmoji;
+    if (message.iconUrl) {
+      data.icon_url = message.iconUrl;
+    } else if (message.iconEmoji) {
+      data.icon_emoji = message.iconEmoji;
+    }
     if (message.channel) data.channel = message.channel;
     if (message.attachments) data.attachments = message.attachments;
   }

--- a/test/clients/incoming-webhook/client.js
+++ b/test/clients/incoming-webhook/client.js
@@ -29,6 +29,38 @@ describe('Incoming Webhook', function () {
       expect(wh.defaults.text).to.equal(opts.text);
     });
 
+    it('should accept supplied defaults when present iconUrl specific', function () {
+      var opts = {
+        username: 'a bot name',
+        iconUrl: 'http://flickr.com/icons/bobby.jpg',
+        channel: 'channel-name',
+        text: 'some text'
+      };
+      var wh = new IncomingWebhook('slackWebhookUrl', opts);
+
+      expect(wh.defaults.username).to.equal(opts.username);
+      expect(wh.defaults.iconUrl).to.equal(opts.iconUrl);
+      expect(wh.defaults.channel).to.equal(opts.channel);
+      expect(wh.defaults.text).to.equal(opts.text);
+    });
+
+    it('should accept supplied defaults when present iconUrl and iconEmoji present', function () {
+      var opts = {
+        username: 'a bot name',
+        iconEmoji: ':robot_face:',
+        iconUrl: 'http://flickr.com/icons/bobby.jpg',
+        channel: 'channel-name',
+        text: 'some text'
+      };
+      var wh = new IncomingWebhook('slackWebhookUrl', opts);
+
+      expect(wh.defaults.username).to.equal(opts.username);
+      expect(wh.defaults.iconEmoji).to.equal(opts.iconEmoji);
+      expect(wh.defaults.iconUrl).to.equal(opts.iconUrl);
+      expect(wh.defaults.channel).to.equal(opts.channel);
+      expect(wh.defaults.text).to.equal(opts.text);
+    });
+
     it('should discard unusable properties', function () {
       var opts = {
         foo: 'bar'
@@ -36,6 +68,24 @@ describe('Incoming Webhook', function () {
       var wh = new IncomingWebhook('slackWebhookUrl', opts);
 
       expect(wh.defaults.bar).to.equal(undefined);
+    });
+
+    it('should favour iconUrl if both iconUrl and iconEmoji are set', function () {
+      var opts = {
+        username: 'a bot name',
+        iconEmoji: ':robot_face:',
+        iconUrl: 'http://flickr.com/icons/bobby.jpg',
+        channel: 'channel-name',
+        text: 'some text'
+      };
+
+      var wh = new IncomingWebhook('slackWebhookUrl', opts);
+
+      expect(wh.defaults.username).to.equal(opts.username);
+      expect(wh.defaults.iconUrl).to.equal(opts.iconUrl);
+      expect(wh.defaults.channel).to.equal(opts.channel);
+      expect(wh.defaults.text).to.equal(opts.text);
+      expect(wh.defaults.iconEmoji).to.equal(undefined);
     });
 
     it('does not require a defaults object', function () {


### PR DESCRIPTION
- [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
- [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
- [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
- [x] I've written tests to cover the new code and functionality included in this PR.
- [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
#### PR Summary

> Added support for IncomingWebhooks to use an IconUrl instead of an Emoji
> If you provide both, favour the Url
#### Related Issues

> N/A
#### Test strategy

> Revised the test to check defaults are set for icon/emoji, for one or the other or both present
> Added a test to cover favouring the IconUrl over an Emoji
> Revise the documentation
