### PR TITLE
Add files.comments and usergroups.users alias

### DIFF
--- a/lib/clients/web/client.js
+++ b/lib/clients/web/client.js
@@ -43,6 +43,9 @@ WebAPIClient.prototype._createFacets = function _createFacets() {
   // Add a dm alias for the im and mpim facets
   this.dm = this.im;
   this.mpdm = this.mpim;
+  // Alias for subfacets
+  this.files.comments = this['files.comments'];
+  this.usergroups.users = this['usergroups.users'];
 };
 
 


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This makes it possible to access the files.comments and usergroups.users facets as if they were encapsulated in their parent:

`WebClient['files.comments']` becomes `WebClient.files.comments`

#### Related Issues
Fixes #255