### PR TITLE
Add more error reporting information to the Web Client callback responses

### DIFF
--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -102,12 +102,17 @@ var handleHttpResponse = function handleHttpResponse(body, headers, client, apiC
   }
 
   if (!jsonResponse.ok) {
-      jsonError = new Error(jsonResponse.error);
-      client.logger('error', jsonResponse.error);
+    jsonError = new Error(jsonResponse.error);
+    client.logger('error', jsonResponse.error);
   }
 
-  jsonResponse.scopes = (headers['X-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
-  jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
+  jsonResponse.scopes = (headers['X-OAuth-Scopes'] === undefined) ?
+    [] :
+    headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
+  jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ?
+    [] :
+    headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
+
 
   try {
     apiCb(jsonError, jsonResponse);

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -111,7 +111,7 @@ var handleHttpResponse = function handleHttpResponse(body, headers, client, apiC
     headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
   jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ?
     [] :
-    headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
+    headers['X-Accepted-OAuth-Scopes'].trim().split(/\s*,\s*/);
 
 
   try {

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -106,12 +106,12 @@ var handleHttpResponse = function handleHttpResponse(body, headers, client, apiC
     client.logger('error', jsonResponse.error);
   }
 
-  jsonResponse.scopes = (headers['X-OAuth-Scopes'] === undefined) ?
+  jsonResponse.scopes = (headers['x-oauth-scopes'] === undefined) ?
     [] :
-    headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
-  jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ?
+    headers['x-oauth-scopes'].trim().split(/\s*,\s*/);
+  jsonResponse.acceptedScopes = (headers['x-accepted-oauth-scopes'] === undefined) ?
     [] :
-    headers['X-Accepted-OAuth-Scopes'].trim().split(/\s*,\s*/);
+    headers['x-accepted-oauth-scopes'].trim().split(/\s*,\s*/);
 
 
   try {

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -87,25 +87,30 @@ var handleHttpErr = function handleHttpErr(retryOp, apiCb, statusCode) {
  */
 var handleHttpResponse = function handleHttpResponse(body, headers, client, apiCb) {
   var jsonResponse;
-  var jsonParseErr;
+  var jsonError;
 
   try {
     jsonResponse = JSON.parse(body);
   } catch (parseErr) {
     // TODO(leah): Emit an event here?
-    jsonParseErr = new Error('unable to parse Slack API Response');
+    jsonError = new Error('unable to parse Slack API Response');
     return false;
   }
 
-  if (!jsonParseErr && jsonResponse.warning) {
+  if (!jsonError && jsonResponse.warning) {
     client.logger('warn', jsonResponse.warning);
+  }
+
+  if (!jsonResponse.ok) {
+      jsonError = new Error(jsonResponse.error);
+      client.logger('error', jsonResponse.error);
   }
 
   jsonResponse.scopes = (headers['X-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
   jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
 
   try {
-    apiCb(jsonParseErr, jsonResponse);
+    apiCb(jsonError, jsonResponse);
   } catch (callbackErr) {
     // Never retry requests that fail in the callback
     client.logger('error', callbackErr);

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -85,7 +85,7 @@ var handleHttpErr = function handleHttpErr(retryOp, apiCb, statusCode) {
  * @param apiCb
  * @returns {boolean}
  */
-var handleHttpResponse = function handleHttpResponse(body, client, apiCb) {
+var handleHttpResponse = function handleHttpResponse(body, headers, client, apiCb) {
   var jsonResponse;
   var jsonParseErr;
 
@@ -100,6 +100,9 @@ var handleHttpResponse = function handleHttpResponse(body, client, apiCb) {
   if (!jsonParseErr && jsonResponse.warning) {
     client.logger('warn', jsonResponse.warning);
   }
+
+  jsonResponse.scopes = (headers['X-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
+  jsonResponse.acceptedScopes = (headers['X-Accepted-OAuth-Scopes'] === undefined) ? [] : headers['X-OAuth-Scopes'].trim().split(/\s*,\s*/);
 
   try {
     apiCb(jsonParseErr, jsonResponse);
@@ -139,7 +142,7 @@ var handleTransportResponse = function handleTransportResponse(
       callQueueCb = handleHttpErr(retryArgs.retryOp, retryArgs.task.cb, statusCode);
     }
   } else {
-    callQueueCb = handleHttpResponse(body, retryArgs.client, retryArgs.task.cb);
+    callQueueCb = handleHttpResponse(body, headers, retryArgs.client, retryArgs.task.cb);
   }
 
   // This is always an empty callback, even if there's an error, as it's used to signal the

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -131,8 +131,8 @@ describe('Default transport', function () {
   it('should report scope information when present', function (done) {
     // See https://api.slack.com/docs/oauth-scopes#working_with_scopes
     var headers = {
-      'X-OAuth-Scopes': 'foo, bar,baz ,qux',
-      'X-Accepted-OAuth-Scopes': 'a, i,u ,e'
+      'x-oauth-scopes': 'foo, bar,baz ,qux',
+      'x-accepted-oauth-scopes': 'a, i,u ,e'
     };
     var body = '{"test": 10}';
     var client = {

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -66,7 +66,7 @@ describe('Web API Client', function () {
     var client = new WebAPIClient('test-token', { transport: mockTransport });
 
     client._makeAPICall('test', args, null, function (err, res) {
-      expect(res).to.deep.equal({ test: 10 });
+      expect(res.test).to.equal(10);
       done();
     });
   });


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Adds the scoping information from the headers to callback response, and puts API errors into the callback error

#### Related Issues
Fixes #291 and #292 

#### Test strategy
TBD