### PR TITLE
Add explicit support for `users.profile.*`. Fixes #279

### DIFF
--- a/lib/clients/web/client.js
+++ b/lib/clients/web/client.js
@@ -46,6 +46,7 @@ WebAPIClient.prototype._createFacets = function _createFacets() {
   // Alias for subfacets
   this.files.comments = this['files.comments'];
   this.usergroups.users = this['usergroups.users'];
+  this.users.profile = this['users.profile'];
 };
 
 

--- a/lib/clients/web/facets/index.js
+++ b/lib/clients/web/facets/index.js
@@ -22,5 +22,6 @@ module.exports = {
   TeamFacet: require('./team.js'),
   UsergroupsFacet: require('./usergroups.js'),
   UsergroupsUsersFacet: require('./usergroups.users.js'),
-  UsersFacet: require('./users.js')
+  UsersFacet: require('./users.js'),
+  UsersProfileFacet: require('./users.profile.js')
 };

--- a/lib/clients/web/facets/users.profile.js
+++ b/lib/clients/web/facets/users.profile.js
@@ -9,8 +9,8 @@
 
 
 function UsersProfileFacet(makeAPICall) {
-    this.name = 'users.profile';
-    this.makeAPICall = makeAPICall;
+  this.name = 'users.profile';
+  this.makeAPICall = makeAPICall;
 }
 
 
@@ -23,21 +23,22 @@ function UsersProfileFacet(makeAPICall) {
  * @param {function=} optCb Optional callback, if not using promises.
  */
 UsersProfileFacet.prototype.get = function get(opts, optCb) {
-    return this.makeAPICall('users.profile.get', null, opts, optCb);
+  return this.makeAPICall('users.profile.get', null, opts, optCb);
 };
 
 /**
  * This method is used to set the profile information for a user.
  * @see {@link https://api.slack.com/methods/users.profile.set|users.profile.set}
  *
- * @param {?} user - ID of user to change. This argument may only be specified by team admins on paid teams.
+ * @param {?} user - ID of user to change. This argument may only be specified by team admins on
+ *   paid teams.
  * @param {?} profile - Collection of key:value pairs presented as a URL-encoded JSON hash.
  * @param {?} name - Name of a single key to set. Usable only if profile is not passed.
  * @param {?} value - Value to set a single key to. Usable only if profile is not passed.
  * @param {function=} optCb Optional callback, if not using promises.
  */
 UsersProfileFacet.prototype.set = function get(opts, optCb) {
-    return this.makeAPICall('users.profile.set', null, opts, optCb);
+  return this.makeAPICall('users.profile.set', null, opts, optCb);
 };
 
 

--- a/lib/clients/web/facets/users.profile.js
+++ b/lib/clients/web/facets/users.profile.js
@@ -22,7 +22,7 @@ function UsersProfileFacet(makeAPICall) {
  * @param {?} include_labels - Include labels for each ID in custom profile fields
  * @param {function=} optCb Optional callback, if not using promises.
  */
-UsersFacet.prototype.get = function get(opts, optCb) {
+UsersProfileFacet.prototype.get = function get(opts, optCb) {
     return this.makeAPICall('users.profile.get', null, opts, optCb);
 };
 
@@ -36,7 +36,7 @@ UsersFacet.prototype.get = function get(opts, optCb) {
  * @param {?} value - Value to set a single key to. Usable only if profile is not passed.
  * @param {function=} optCb Optional callback, if not using promises.
  */
-UsersFacet.prototype.set = function get(opts, optCb) {
+UsersProfileFacet.prototype.set = function get(opts, optCb) {
     return this.makeAPICall('users.profile.set', null, opts, optCb);
 };
 

--- a/lib/clients/web/facets/users.profile.js
+++ b/lib/clients/web/facets/users.profile.js
@@ -1,0 +1,44 @@
+/**
+ * API Facet to make calls to methods in the users.profile namespace.
+ *
+ * This provides functions to call:
+ *   - get: {@link https://api.slack.com/methods/users.profile.get|users.profile.get}
+ *   - set: {@link https://api.slack.com/methods/users.profile.set|users.profile.set}
+ *
+ */
+
+
+function UsersProfileFacet(makeAPICall) {
+    this.name = 'users.profile';
+    this.makeAPICall = makeAPICall;
+}
+
+
+/**
+ * This method is used to get the profile information for a user.
+ * @see {@link https://api.slack.com/methods/users.profile.get|users.profile.get}
+ *
+ * @param {?} user - User to retrieve profile info for
+ * @param {?} include_labels - Include labels for each ID in custom profile fields
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+UsersFacet.prototype.get = function get(opts, optCb) {
+    return this.makeAPICall('users.profile.get', null, opts, optCb);
+};
+
+/**
+ * This method is used to set the profile information for a user.
+ * @see {@link https://api.slack.com/methods/users.profile.set|users.profile.set}
+ *
+ * @param {?} user - ID of user to change. This argument may only be specified by team admins on paid teams.
+ * @param {?} profile - Collection of key:value pairs presented as a URL-encoded JSON hash.
+ * @param {?} name - Name of a single key to set. Usable only if profile is not passed.
+ * @param {?} value - Value to set a single key to. Usable only if profile is not passed.
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+UsersFacet.prototype.set = function get(opts, optCb) {
+    return this.makeAPICall('users.profile.set', null, opts, optCb);
+};
+
+
+module.exports = UsersProfileFacet;


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Allows direct calls to `users.profile.get` and `users.profile.set`

#### Related Issues
Fixes #279 

#### Test strategy
TBD