### PR TITLE
Remove repeated sentence in auth docs

### DIFF
--- a/docs/_pages/auth.md
+++ b/docs/_pages/auth.md
@@ -10,7 +10,7 @@ headings:
 ## Handling tokens and other sensitive data
 
 Slack tokens are the keys to your&mdash;or your customers'&mdash;teams. Keep them secret. Keep them safe. One way to do that is
-to never explicitly hardcode them. One way to do that is to never explicitly hardcode them.
+to never explicitly hardcode them.
                                    
 Try to avoid this when possible:
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Simply updating the docs to remove a repeated sentence. It was a pretty important one so the possibility exists it could have been there for emphasis but it just seemed like a typo 😉 

#### Related Issues
n/a

#### Test strategy
n/a