### PR TITLE
Added missing RTM_EVENTS var in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ have a look at the [Bot Users documentation](https://api.slack.com/bot-users).
 ```js
 var RtmClient = require('@slack/client').RtmClient;
 var CLIENT_EVENTS = require('@slack/client').CLIENT_EVENTS;
+var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
 
 var bot_token = process.env.SLACK_BOT_TOKEN || '';
 

--- a/docs/_pages/bots.md
+++ b/docs/_pages/bots.md
@@ -60,6 +60,7 @@ can do that by sending a message over the RTM connection as such.
 ```js
 var RtmClient = require('@slack/client').RtmClient;
 var RTM_CLIENT_EVENTS = require('@slack/client').CLIENT_EVENTS.RTM;
+var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
 
 var bot_token = process.env.SLACK_BOT_TOKEN || '';
 


### PR DESCRIPTION
#### PR Summary
> Added missing RTM_EVENTS var in RTM send message docs

#### Related Issues
> Fixes #317

✅  I've read and understood the Contributing guidelines
✅  I've read and agree to the Code of Conduct
✅  I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
✅  I've a descriptive title and added any useful information for the reviewer.
✅ I've read, agree to, and signed the CLA