### PR TITLE
Revert #318

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ have a look at the [Bot Users documentation](https://api.slack.com/bot-users).
 ```js
 var RtmClient = require('@slack/client').RtmClient;
 var CLIENT_EVENTS = require('@slack/client').CLIENT_EVENTS;
-var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
 
 var bot_token = process.env.SLACK_BOT_TOKEN || '';
 

--- a/docs/_pages/bots.md
+++ b/docs/_pages/bots.md
@@ -60,7 +60,6 @@ can do that by sending a message over the RTM connection as such.
 ```js
 var RtmClient = require('@slack/client').RtmClient;
 var RTM_CLIENT_EVENTS = require('@slack/client').CLIENT_EVENTS.RTM;
-var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
 
 var bot_token = process.env.SLACK_BOT_TOKEN || '';
 

--- a/docs/_pages/bots.md
+++ b/docs/_pages/bots.md
@@ -103,15 +103,16 @@ and that we receive over the RTM connection. We can subscribe to `message` event
 
 ```js
 var RtmClient = require('@slack/client').RtmClient;
-
+var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
 var bot_token = process.env.SLACK_BOT_TOKEN || '';
 
 var rtm = new RtmClient(bot_token);
-rtm.start();
 
 rtm.on(RTM_EVENTS.MESSAGE, function handleRtmMessage(message) {
   console.log('Message:', message); //this is no doubt the lamest possible message handler, but you get the idea
 });
+
+rtm.start();
 ```
 
 --------


### PR DESCRIPTION
#318 was an accidental edit. `RTM_EVENTS` isn't relevant to that section of the docs.