### PR TITLE
user is undefined when name is not a current user

### DIFF
--- a/lib/data-store/memory-data-store.js
+++ b/lib/data-store/memory-data-store.js
@@ -132,7 +132,7 @@ SlackMemoryDataStore.prototype.getDMById = function getDMById(dmId) {
 /** @inheritdoc */
 SlackMemoryDataStore.prototype.getDMByName = function getDMByName(name) {
   var user = this.getUserByName(name);
-  return find(this.dms, ['user', user.id]);
+  return (user) ? find(this.dms, ['user', user.id]) : undefined;
 };
 
 /** @inheritdoc */


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [N/A] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Calling SlackMemoryDataStore.prototype.getDMByName with a name that is not a current user should return undefined, but currently throws a TypeError.

return find(this.dms, ['user', user.id]);
                                                   ^
TypeError: Cannot read property 'id' of undefined

Simple fix to check for existence or user prior to doing search and appropriately returning undefined if it does not.

#### Related Issues
Did not open issue.

#### Test strategy
No additional or changed functionality, searching for name that is not a current user.
