### PR TITLE
Include user_auth_required in chat.js unfurl

### DIFF
--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -130,13 +130,15 @@ ChatFacet.prototype.update = function update(ts, channel, text, opts, optCb) {
  * @param {?} ts - Timestamp of the message to be updated.
  * @param {?} channel - Channel of the message to be updated.
  * @param {string} unfurls - a map of URLs to structured message attachments
+ * @param {Boolean} userAuthRequired  - Pass true to require user authorization.
  * @param {function=} optCb Optional callback, if not using promises.
  */
-ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, optCb) {
+ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, userAuthRequired, optCb) {
   var requiredArgs = {
     ts: ts,
     channel: channel,
-    unfurls: unfurls
+    unfurls: unfurls,
+    user_auth_required: userAuthRequired
   };
 
   return this.makeAPICall('chat.unfurl', requiredArgs, {}, optCb);

--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -134,11 +134,15 @@ ChatFacet.prototype.update = function update(ts, channel, text, opts, optCb) {
  * @param {function=} optCb Optional callback, if not using promises.
  */
 ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, userAuthRequired, optCb) {
-  var requiredArgs = {
+  const requiredArgs = !!userAuthRequired ? {
     ts: ts,
     channel: channel,
     unfurls: unfurls,
-    user_auth_required: userAuthRequired
+    user_auth_required: true,
+  } : {
+    ts: ts,
+    channel: channel,
+    unfurls: unfurls,
   };
 
   return this.makeAPICall('chat.unfurl', requiredArgs, {}, optCb);

--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -135,7 +135,6 @@ ChatFacet.prototype.update = function update(ts, channel, text, opts, optCb) {
  * @param {function=} optCb Optional callback, if not using promises.
  */
 ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, opts, optCb) {
-
   var requiredArgs = {
     ts: ts,
     channel: channel,

--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -130,22 +130,19 @@ ChatFacet.prototype.update = function update(ts, channel, text, opts, optCb) {
  * @param {?} ts - Timestamp of the message to be updated.
  * @param {?} channel - Channel of the message to be updated.
  * @param {string} unfurls - a map of URLs to structured message attachments
- * @param {Boolean} userAuthRequired  - Pass true to require user authorization.
+ * @param {Object=} opts
+ * @param {?} opts.user_auth_required - Pass true to require user authorization.
  * @param {function=} optCb Optional callback, if not using promises.
  */
-ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, userAuthRequired, optCb) {
-  const requiredArgs = !!userAuthRequired ? {
+ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, opts, optCb) {
+
+  var requiredArgs = {
     ts: ts,
     channel: channel,
-    unfurls: unfurls,
-    user_auth_required: true,
-  } : {
-    ts: ts,
-    channel: channel,
-    unfurls: unfurls,
+    unfurls: unfurls
   };
 
-  return this.makeAPICall('chat.unfurl', requiredArgs, {}, optCb);
+  return this.makeAPICall('chat.unfurl', requiredArgs, opts, optCb);
 };
 
 module.exports = ChatFacet;


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> The slack unfurl API offers the use of an optional `auth_user_required` field: https://api.slack.com/docs/message-link-unfurling#authenticated_unfurls. This change makes `authUserRequired` a required parameter to `.unfurl`.

#### Related Issues
> NA

#### Test strategy
> NA