### PR TITLE
Enable to set link_names option of incoming webhook

### DIFF
--- a/docs/_reference/BaseAPIClient.md
+++ b/docs/_reference/BaseAPIClient.md
@@ -9,7 +9,6 @@ permalink: /reference/BaseAPIClient
     * [new BaseAPIClient(token, opts)](#new_BaseAPIClient_new)
     * [.slackAPIUrl](#BaseAPIClient+slackAPIUrl) : <code>string</code>
     * [.transport](#BaseAPIClient+transport) : <code>function</code>
-    * [.userAgent](#BaseAPIClient+userAgent) : <code>string</code>
     * [.retryConfig](#BaseAPIClient+retryConfig)
     * [.logger](#BaseAPIClient+logger) : <code>function</code>
     * [._createFacets()](#BaseAPIClient+_createFacets)
@@ -27,7 +26,6 @@ Base client for both the RTM and web APIs.
 | token | <code>string</code> | The Slack API token to use with this client. |
 | opts | <code>Object</code> |  |
 | opts.slackAPIUrl | <code>String</code> | The Slack API URL. |
-| opts.userAgent | <code>String</code> | The user-agent to use, defaults to node-slack. |
 | opts.transport | <code>function</code> | Function to call to make an HTTP call to the Slack API. |
 | [opts.logLevel] | <code>string</code> | The log level for the logger. |
 | [opts.logger] | <code>function</code> | Function to use for log calls, takes (logLevel, logString) params. |
@@ -41,10 +39,6 @@ Base client for both the RTM and web APIs.
 <a name="BaseAPIClient+transport"></a>
 
 ### baseAPIClient.transport : <code>function</code>
-**Kind**: instance property of <code>[BaseAPIClient](#BaseAPIClient)</code>  
-<a name="BaseAPIClient+userAgent"></a>
-
-### baseAPIClient.userAgent : <code>string</code>
 **Kind**: instance property of <code>[BaseAPIClient](#BaseAPIClient)</code>  
 <a name="BaseAPIClient+retryConfig"></a>
 

--- a/docs/_reference/IncomingWebhook.md
+++ b/docs/_reference/IncomingWebhook.md
@@ -21,6 +21,7 @@ permalink: /reference/IncomingWebhook
 | defaults.iconEmoji | <code>string</code> | The default emoji to use when sending a webhook.      If no iconEmoji is specified, the one chosen when creating the webhook will be used. |
 | defaults.channel | <code>string</code> | The default channel to use when sending a webhook.      If no channel is specified, the one chosen when creating the webhook will be used. |
 | defaults.text | <code>string</code> | The default text to use when sending a webhook. |
+| defaults.linkNames | <code>string</code> | The default setting for the link_names format option to use when sending a webhook.      If no value is specified, the one chosen when creating the webhook will be used. |
 
 <a name="IncomingWebhook+send"></a>
 

--- a/docs/_reference/SlackDataStore.md
+++ b/docs/_reference/SlackDataStore.md
@@ -20,6 +20,7 @@ permalink: /reference/SlackDataStore
     * [.getGroupByName(name)](#SlackDataStore+getGroupByName) ⇒ <code>Object</code>
     * [.getDMById(dmId)](#SlackDataStore+getDMById) ⇒ <code>Object</code>
     * [.getDMByName(name)](#SlackDataStore+getDMByName) ⇒ <code>Object</code>
+    * [.getDMByUserId(id)](#SlackDataStore+getDMByUserId) ⇒ <code>Object</code>
     * [.getBotById(botId)](#SlackDataStore+getBotById) ⇒ <code>Object</code>
     * [.getBotByName(name)](#SlackDataStore+getBotByName) ⇒ <code>Object</code>
     * [.getBotByUserId(userId)](#SlackDataStore+getBotByUserId) ⇒ <code>Object</code>
@@ -186,6 +187,17 @@ Returns the DM object between the registered user and the user with the supplied
 | Param |
 | --- |
 | name | 
+
+<a name="SlackDataStore+getDMByUserId"></a>
+
+### slackDataStore.getDMByUserId(id) ⇒ <code>Object</code>
+Returns the DM object between the registered user and the user with the supplied id.
+
+**Kind**: instance method of <code>[SlackDataStore](#SlackDataStore)</code>  
+
+| Param |
+| --- |
+| id | 
 
 <a name="SlackDataStore+getBotById"></a>
 

--- a/docs/_reference/SlackMemoryDataStore.md
+++ b/docs/_reference/SlackMemoryDataStore.md
@@ -23,6 +23,7 @@ permalink: /reference/SlackMemoryDataStore
     * [.getGroupByName()](#SlackMemoryDataStore+getGroupByName)
     * [.getDMById()](#SlackMemoryDataStore+getDMById)
     * [.getDMByName()](#SlackMemoryDataStore+getDMByName)
+    * [.getDMByUserId()](#SlackMemoryDataStore+getDMByUserId)
     * [.getBotById()](#SlackMemoryDataStore+getBotById)
     * [.getBotByName()](#SlackMemoryDataStore+getBotByName)
     * [.getBotByUserId()](#SlackMemoryDataStore+getBotByUserId)
@@ -114,6 +115,10 @@ permalink: /reference/SlackMemoryDataStore
 <a name="SlackMemoryDataStore+getDMByName"></a>
 
 ### slackMemoryDataStore.getDMByName()
+**Kind**: instance method of <code>[SlackMemoryDataStore](#SlackMemoryDataStore)</code>  
+<a name="SlackMemoryDataStore+getDMByUserId"></a>
+
+### slackMemoryDataStore.getDMByUserId()
 **Kind**: instance method of <code>[SlackMemoryDataStore](#SlackMemoryDataStore)</code>  
 <a name="SlackMemoryDataStore+getBotById"></a>
 

--- a/examples/example-incoming-webhook.js
+++ b/examples/example-incoming-webhook.js
@@ -22,6 +22,7 @@ whWithDefaults.send({
   text: 'Some text',
   iconEmoji: ':robot_face:',
   channel: 'custom-channel',
+  linkNames: '1',
   attachments: [
     // attachment data
     // see https://api.slack.com/docs/attachments

--- a/lib/clients/incoming-webhook/client.js
+++ b/lib/clients/incoming-webhook/client.js
@@ -14,7 +14,8 @@ var noop = require('lodash').noop;
  * @param {string} defaults.channel The default channel to use when sending a webhook.
  *      If no channel is specified, the one chosen when creating the webhook will be used.
  * @param {string} defaults.text The default text to use when sending a webhook.
- * @param {string} defaults.link_names Do not link names and mention as default.
+ * @param {string} defaults.linkNames The default setting for the link_names format option to use when sending a webhook.
+ *      If no value is specified, the one chosen when creating the webhook will be used.
  * @constructor
  */
 function IncomingWebhook(slackUrl, defaults) {

--- a/lib/clients/incoming-webhook/client.js
+++ b/lib/clients/incoming-webhook/client.js
@@ -14,6 +14,7 @@ var noop = require('lodash').noop;
  * @param {string} defaults.channel The default channel to use when sending a webhook.
  *      If no channel is specified, the one chosen when creating the webhook will be used.
  * @param {string} defaults.text The default text to use when sending a webhook.
+ * @param {string} defaults.link_names Do not link names and mention as default.
  * @constructor
  */
 function IncomingWebhook(slackUrl, defaults) {
@@ -29,6 +30,7 @@ function IncomingWebhook(slackUrl, defaults) {
     iconEmoji: _defaults.iconEmoji,
     iconUrl: _defaults.iconUrl,
     channel: _defaults.channel,
+    linkNames: _defaults.linkNames,
     text: _defaults.text
   };
 
@@ -63,6 +65,7 @@ IncomingWebhook.prototype._formatData = function _formatData(message) {
     icon_emoji: this.defaults.iconEmoji,
     icon_url: this.defaults.iconUrl,
     channel: this.defaults.channel,
+    link_names: this.defaults.linkNames,
     text: this.defaults.text
   };
 
@@ -74,6 +77,7 @@ IncomingWebhook.prototype._formatData = function _formatData(message) {
     if (message.iconEmoji) data.icon_emoji = message.iconEmoji;
     if (message.iconUrl) data.icon_url = message.iconUrl;
     if (message.channel) data.channel = message.channel;
+    if (message.linkNames) data.link_names = message.linkNames;
     if (message.attachments) data.attachments = message.attachments;
   }
 

--- a/test/clients/incoming-webhook/client.js
+++ b/test/clients/incoming-webhook/client.js
@@ -19,6 +19,7 @@ describe('Incoming Webhook', function () {
         username: 'a bot name',
         iconEmoji: ':robot_face:',
         channel: 'channel-name',
+        linkNames: '1',
         text: 'some text'
       };
       var wh = new IncomingWebhook('slackWebhookUrl', opts);
@@ -26,6 +27,7 @@ describe('Incoming Webhook', function () {
       expect(wh.defaults.username).to.equal(opts.username);
       expect(wh.defaults.iconEmoji).to.equal(opts.iconEmoji);
       expect(wh.defaults.channel).to.equal(opts.channel);
+      expect(wh.defaults.linkNames).to.equal(opts.linkNames);
       expect(wh.defaults.text).to.equal(opts.text);
     });
 
@@ -166,7 +168,8 @@ describe('Incoming Webhook', function () {
           text: 'Some text',
           username: 'A username',
           channel: 'a-channel',
-          iconEmoji: ':robot_face:'
+          iconEmoji: ':robot_face:',
+          linkNames: '1'
         }, function () {
           expect(transport.calledOnce).to.equal(true);
           expect(transport.calledWithMatch({
@@ -174,7 +177,8 @@ describe('Incoming Webhook', function () {
               text: 'Some text',
               username: 'A username',
               channel: 'a-channel',
-              icon_emoji: ':robot_face:'
+              icon_emoji: ':robot_face:',
+              link_names: '1'
             }
           })).to.equal(true);
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> e.g. New functionality for producing whatsits.

Now implementation does not allow to use `link_names` option of incoming webhook.
The detail of `link_names` is described Slack API reference. https://api.slack.com/incoming-webhooks

If we don't specify `link_names`, `@foobar` (mentioned user ID) is only highlighted (it means `@foobar` is NOT mentioned and don't get notifications).

#### Related Issues

No issues.

#### Test strategy

Change test/clients/incoming-webhook/client.js with `linkNames` option.