### PR TITLE
Add support for rtm.connect

### DIFF
--- a/docs/_reference/BaseAPIClient.md
+++ b/docs/_reference/BaseAPIClient.md
@@ -9,7 +9,6 @@ permalink: /reference/BaseAPIClient
     * [new BaseAPIClient(token, opts)](#new_BaseAPIClient_new)
     * [.slackAPIUrl](#BaseAPIClient+slackAPIUrl) : <code>string</code>
     * [.transport](#BaseAPIClient+transport) : <code>function</code>
-    * [.userAgent](#BaseAPIClient+userAgent) : <code>string</code>
     * [.retryConfig](#BaseAPIClient+retryConfig)
     * [.logger](#BaseAPIClient+logger) : <code>function</code>
     * [._createFacets()](#BaseAPIClient+_createFacets)
@@ -27,7 +26,6 @@ Base client for both the RTM and web APIs.
 | token | <code>string</code> | The Slack API token to use with this client. |
 | opts | <code>Object</code> |  |
 | opts.slackAPIUrl | <code>String</code> | The Slack API URL. |
-| opts.userAgent | <code>String</code> | The user-agent to use, defaults to node-slack. |
 | opts.transport | <code>function</code> | Function to call to make an HTTP call to the Slack API. |
 | [opts.logLevel] | <code>string</code> | The log level for the logger. |
 | [opts.logger] | <code>function</code> | Function to use for log calls, takes (logLevel, logString) params. |
@@ -41,10 +39,6 @@ Base client for both the RTM and web APIs.
 <a name="BaseAPIClient+transport"></a>
 
 ### baseAPIClient.transport : <code>function</code>
-**Kind**: instance property of <code>[BaseAPIClient](#BaseAPIClient)</code>  
-<a name="BaseAPIClient+userAgent"></a>
-
-### baseAPIClient.userAgent : <code>string</code>
 **Kind**: instance property of <code>[BaseAPIClient](#BaseAPIClient)</code>  
 <a name="BaseAPIClient+retryConfig"></a>
 

--- a/docs/_reference/RTMClient.md
+++ b/docs/_reference/RTMClient.md
@@ -45,6 +45,7 @@ permalink: /reference/RTMClient
 | opts.socketFn | <code>function</code> | A function to call, passing in a websocket URL, that should     return a websocket instance connected to that URL. |
 | opts.dataStore | <code>object</code> | A store to cache Slack info, e.g. channels, users etc. in.     If you don't want a store, pass false or null as the value for this. |
 | opts.autoReconnect | <code>boolean</code> | Whether or not to automatically reconnect when the connection     closes. |
+| opts.useRtmConnect | <code>boolean</code> | True to use rtm.connect rather than rtm.start |
 | opts.maxReconnectionAttempts | <code>number</code> |  |
 | opts.reconnectionBackoff | <code>number</code> |  |
 | opts.wsPingInterval | <code>number</code> |  |
@@ -103,10 +104,9 @@ Begin an RTM session.
 
 **Kind**: instance method of <code>[RTMClient](#RTMClient)</code>  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| opts | <code>object</code> |  |
-| opts.useConnect | <code>boolean</code> | True to use `rtm.connect` rather than `rtm.start` |
+| Param | Type |
+| --- | --- |
+| opts | <code>object</code> | 
 
 <a name="RTMClient+login"></a>
 

--- a/docs/_reference/RTMClient.md
+++ b/docs/_reference/RTMClient.md
@@ -99,11 +99,14 @@ The timer repeatedly pinging the server to let it know the client is still alive
 <a name="RTMClient+start"></a>
 
 ### rtmClient.start(opts)
+Begin an RTM session.
+
 **Kind**: instance method of <code>[RTMClient](#RTMClient)</code>  
 
-| Param | Type |
-| --- | --- |
-| opts | <code>object</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| opts | <code>object</code> |  |
+| opts.useConnect | <code>boolean</code> | True to use `rtm.connect` rather than `rtm.start` |
 
 <a name="RTMClient+login"></a>
 

--- a/docs/_reference/SlackDataStore.md
+++ b/docs/_reference/SlackDataStore.md
@@ -20,6 +20,7 @@ permalink: /reference/SlackDataStore
     * [.getGroupByName(name)](#SlackDataStore+getGroupByName) ⇒ <code>Object</code>
     * [.getDMById(dmId)](#SlackDataStore+getDMById) ⇒ <code>Object</code>
     * [.getDMByName(name)](#SlackDataStore+getDMByName) ⇒ <code>Object</code>
+    * [.getDMByUserId(id)](#SlackDataStore+getDMByUserId) ⇒ <code>Object</code>
     * [.getBotById(botId)](#SlackDataStore+getBotById) ⇒ <code>Object</code>
     * [.getBotByName(name)](#SlackDataStore+getBotByName) ⇒ <code>Object</code>
     * [.getBotByUserId(userId)](#SlackDataStore+getBotByUserId) ⇒ <code>Object</code>
@@ -186,6 +187,17 @@ Returns the DM object between the registered user and the user with the supplied
 | Param |
 | --- |
 | name | 
+
+<a name="SlackDataStore+getDMByUserId"></a>
+
+### slackDataStore.getDMByUserId(id) ⇒ <code>Object</code>
+Returns the DM object between the registered user and the user with the supplied id.
+
+**Kind**: instance method of <code>[SlackDataStore](#SlackDataStore)</code>  
+
+| Param |
+| --- |
+| id | 
 
 <a name="SlackDataStore+getBotById"></a>
 

--- a/docs/_reference/SlackMemoryDataStore.md
+++ b/docs/_reference/SlackMemoryDataStore.md
@@ -23,6 +23,7 @@ permalink: /reference/SlackMemoryDataStore
     * [.getGroupByName()](#SlackMemoryDataStore+getGroupByName)
     * [.getDMById()](#SlackMemoryDataStore+getDMById)
     * [.getDMByName()](#SlackMemoryDataStore+getDMByName)
+    * [.getDMByUserId()](#SlackMemoryDataStore+getDMByUserId)
     * [.getBotById()](#SlackMemoryDataStore+getBotById)
     * [.getBotByName()](#SlackMemoryDataStore+getBotByName)
     * [.getBotByUserId()](#SlackMemoryDataStore+getBotByUserId)
@@ -114,6 +115,10 @@ permalink: /reference/SlackMemoryDataStore
 <a name="SlackMemoryDataStore+getDMByName"></a>
 
 ### slackMemoryDataStore.getDMByName()
+**Kind**: instance method of <code>[SlackMemoryDataStore](#SlackMemoryDataStore)</code>  
+<a name="SlackMemoryDataStore+getDMByUserId"></a>
+
+### slackMemoryDataStore.getDMByUserId()
 **Kind**: instance method of <code>[SlackMemoryDataStore](#SlackMemoryDataStore)</code>  
 <a name="SlackMemoryDataStore+getBotById"></a>
 

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -14,7 +14,6 @@ var isUndefined = require('lodash').isUndefined;
 var forEach = require('lodash').forEach;
 var noop = require('lodash').noop;
 var keys = require('lodash').keys;
-var omit = require('lodash').omit;
 
 var RTM_API_EVENTS = require('../events/rtm').EVENTS;
 var RTM_CLIENT_INTERNAL_EVENT_TYPES = [
@@ -47,6 +46,7 @@ var wsSocketFn = require('../transports/ws');
  *     If you don't want a store, pass false or null as the value for this.
  * @param {boolean} opts.autoReconnect Whether or not to automatically reconnect when the connection
  *     closes.
+ * @param {boolean} opts.useRtmConnect True to use rtm.connect rather than rtm.start
  * @param {number} opts.maxReconnectionAttempts
  * @param {number} opts.reconnectionBackoff
  * @param {number} opts.wsPingInterval
@@ -102,6 +102,13 @@ function RTMClient(token, opts) {
    * @private
    */
   this._msgChannelLookup = {};
+
+  /**
+   * If true, we'll use rtm.connect everywhere in place of rtm.start
+   * @type {boolean}
+   * @private
+   */
+  this._useRtmConnect = clientOpts.useRtmConnect;
 
   if (clientOpts.dataStore instanceof DataStore) {
     this.registerDataStore(clientOpts.dataStore);
@@ -220,7 +227,6 @@ RTMClient.prototype._createFacets = function _createFacets() {
 /**
  * Begin an RTM session.
  * @param {object} opts
- * @param {boolean} opts.useConnect True to use `rtm.connect` rather than `rtm.start`
  */
 RTMClient.prototype.start = function start(opts) {
   // Check whether the client is currently attempting to connect to the RTM API.
@@ -229,10 +235,10 @@ RTMClient.prototype.start = function start(opts) {
     this.emit(CLIENT_EVENTS.CONNECTING);
     this._connecting = true;
 
-    if (opts && opts.useConnect) {
+    if (this._useRtmConnect) {
       this._rtm.connect(bind(this._onStart, this));
     } else {
-      this._rtm.start(omit(opts, 'useConnect'), bind(this._onStart, this));
+      this._rtm.start(opts, bind(this._onStart, this));
     }
   }
 };

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -14,6 +14,7 @@ var isUndefined = require('lodash').isUndefined;
 var forEach = require('lodash').forEach;
 var noop = require('lodash').noop;
 var keys = require('lodash').keys;
+var omit = require('lodash').omit;
 
 var RTM_API_EVENTS = require('../events/rtm').EVENTS;
 var RTM_CLIENT_INTERNAL_EVENT_TYPES = [
@@ -217,8 +218,9 @@ RTMClient.prototype._createFacets = function _createFacets() {
 
 
 /**
- *
+ * Begin an RTM session.
  * @param {object} opts
+ * @param {boolean} opts.useConnect True to use `rtm.connect` rather than `rtm.start`
  */
 RTMClient.prototype.start = function start(opts) {
   // Check whether the client is currently attempting to connect to the RTM API.
@@ -227,10 +229,13 @@ RTMClient.prototype.start = function start(opts) {
     this.emit(CLIENT_EVENTS.CONNECTING);
     this._connecting = true;
 
-    this._rtm.start(opts, bind(this._onStart, this));
+    if (opts && opts.useConnect) {
+      this._rtm.connect(bind(this._onStart, this));
+    } else {
+      this._rtm.start(omit(opts, 'useConnect'), bind(this._onStart, this));
+    }
   }
 };
-
 
 /**
  * @deprecated since version 2.0.0, use start() instead.

--- a/lib/clients/web/facets/rtm.js
+++ b/lib/clients/web/facets/rtm.js
@@ -29,4 +29,16 @@ RtmFacet.prototype.start = function start(opts, optCb) {
 };
 
 
+/**
+ * Starts a Real Time Messaging session using the lighter-weight rtm.connect.
+ * This will give us a WebSocket URL without the payload of `rtm.start`.
+ * @see {@link https://api.slack.com/methods/rtm.connect|rtm.connect}
+ *
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+RtmFacet.prototype.connect = function connect(optCb) {
+  return this.makeAPICall('rtm.connect', null, null, optCb);
+};
+
+
 module.exports = RtmFacet;

--- a/lib/data-store/data-store.js
+++ b/lib/data-store/data-store.js
@@ -394,6 +394,7 @@ SlackDataStore.prototype.getChannelOrGroupByName = function getChannelOrGroupByN
  * @param {Object} data
  */
 SlackDataStore.prototype.cacheRtmStart = function cacheRtmStart(data) {
+  var self;
   this.clear();
 
   forEach(data.users || [], bind(function cacheRtmUser(user) {
@@ -413,7 +414,13 @@ SlackDataStore.prototype.cacheRtmStart = function cacheRtmStart(data) {
     this.setBot(bot);
   }, this));
 
-  this.getUserById(data.self.id).update(data.self);
+  self = this.getUserById(data.self.id);
+  if (self) {
+    self.update(data.self);
+  } else {
+    // If we got here from an rtm.connect, we may not have any users
+    this.setUser(new models.User(data.self));
+  }
   this.setTeam(data.team);
 };
 

--- a/test/clients/rtm/client.js
+++ b/test/clients/rtm/client.js
@@ -125,13 +125,16 @@ describe('RTM API Client', function () {
 
     it('should support connecting to a socket via rtm.connect', function (done) {
       var rtm;
-      var useConnect = true;
+      var useRtmConnect = true;
       var wssPort = 5225;
       var fakeSlackUrl = 'https://slack.com:' + wssPort + '/api';
 
-      setUpTest(wssPort, fakeSlackUrl, useConnect);
-      rtm = createRtmClient({ slackAPIUrl: fakeSlackUrl });
-      rtm.start({ useConnect: useConnect });
+      setUpTest(wssPort, fakeSlackUrl, useRtmConnect);
+      rtm = createRtmClient({
+        slackAPIUrl: fakeSlackUrl,
+        useRtmConnect: useRtmConnect
+      });
+      rtm.start();
 
       rtm.on(RTM_CLIENT_EVENTS.AUTHENTICATED, function (data) {
         expect(data.self.id).to.equal('U02QYTVLJ');

--- a/test/fixtures/rtm.connect.json
+++ b/test/fixtures/rtm.connect.json
@@ -1,0 +1,13 @@
+{
+    "ok": true,
+    "url": "ws://localhost:5225",
+    "team": {
+        "id": "T02QYTVLG",
+        "name": "SF UTES",
+        "domain": "sfutes"
+    },
+    "self": {
+        "id": "U02QYTVLJ",
+        "name": "hess"
+    }
+}


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> This PR adds support for using [`rtm.connect`](https://api.slack.com/methods/rtm.connect) instead of `rtm.start`, allowing us to connect to a socket without any unnecessary overhead.