### PR TITLE
Messages are out of order due to behaviour of priorityQueue

### DIFF
--- a/lib/clients/client.js
+++ b/lib/clients/client.js
@@ -59,7 +59,7 @@ function BaseAPIClient(token, opts) {
    * @type {Object}
    * @private
    */
-  this.requestQueue = async.priorityQueue(
+  this.requestQueue = async.queue(
     bind(this._callTransport, this),
     clientOpts.maxRequestConcurrency || 3
   );

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -72,6 +72,39 @@ describe('Web API Client', function () {
     });
   });
 
+  it('should make API calls in the order they are executed', function (done) {
+    var args1 = {
+      headers: {},
+      statusCode: 200,
+      body: '{"test": 10}'
+    };
+
+    var args2 = {
+      headers: {},
+      statusCode: 200,
+      body: '{"test": 20}'
+    };
+
+    var client = new WebAPIClient('test-token', { transport: mockTransport });
+    sinon.spy(client, 'transport');
+
+    client._makeAPICall('test', args1, null, function(){
+      expect(client.transport.callCount).to.equal(1);
+      expect(client.transport.args[0][0].data.body).to.equal('{"test": 10}');
+      expect(client.transport.args.length).to.equal(1);
+
+    })
+    client._makeAPICall('test', args2, null, function(){
+      expect(client.transport.callCount).to.equal(2);
+      expect(client.transport.args[0][0].data.body).to.equal('{"test": 10}');
+      expect(client.transport.args[1][0].data.body).to.equal('{"test": 20}');
+      expect(client.transport.args.length).to.equal(2);
+
+    })
+    done()
+
+  });
+
   it('should not crash when no callback is supplied to an API request', function () {
     var client = new WebAPIClient('test-token', { transport: mockTransport });
 
@@ -91,6 +124,7 @@ describe('Web API Client', function () {
         retryConfig: retryPolicies.TEST_RETRY_POLICY
       });
       sinon.spy(client, 'transport');
+
 
       client._makeAPICall('test', {}, null, function () {
         expect(client.transport.callCount).to.equal(2);

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -88,21 +88,19 @@ describe('Web API Client', function () {
     var client = new WebAPIClient('test-token', { transport: mockTransport });
     sinon.spy(client, 'transport');
 
-    client._makeAPICall('test', args1, null, function(){
+    client._makeAPICall('test', args1, null, function () {
       expect(client.transport.callCount).to.equal(1);
       expect(client.transport.args[0][0].data.body).to.equal('{"test": 10}');
       expect(client.transport.args.length).to.equal(1);
-
-    })
-    client._makeAPICall('test', args2, null, function(){
+    });
+    client._makeAPICall('test', args2, null, function () {
       expect(client.transport.callCount).to.equal(2);
       expect(client.transport.args[0][0].data.body).to.equal('{"test": 10}');
       expect(client.transport.args[1][0].data.body).to.equal('{"test": 20}');
       expect(client.transport.args.length).to.equal(2);
 
-    })
-    done()
-
+    });
+    done();
   });
 
   it('should not crash when no callback is supplied to an API request', function () {

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -123,7 +123,6 @@ describe('Web API Client', function () {
       });
       sinon.spy(client, 'transport');
 
-
       client._makeAPICall('test', {}, null, function () {
         expect(client.transport.callCount).to.equal(2);
         done();


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).


#### PR Summary
The client uses a priorityQueue from an old version of async.

For some reason this implementation puts items with the same
priority ahead of existing tasks with the same priority.

See: https://github.com/caolan/async/blob/621f13805aa326865b85dbbf7128baf7146ab976/lib/async.js#L1030

Since this is not being used as a priority queue anyways(no priority
is being passed to the queue) we can fix this by simply switching
to a normal queue. Problem solved :)


#### Related Issues
>. Fixes https://github.com/slackapi/hubot-slack/issues/379

#### Test strategy
>Sent two messages and then compared their order. Also ran this without my changes to the code and it failed. 

