### PR TITLE
Ensure we reconnect with the same options passed to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,13 @@ var bot_token = process.env.SLACK_BOT_TOKEN || '';
 
 var rtm = new RtmClient(bot_token);
 
-// The client will emit an RTM.AUTHENTICATED event on successful connection, with the `rtm.start` payload if you want to cache it
-rtm.on(CLIENT_EVENTS.RTM.AUTHENTICATED, function (rtmStartData) {
+let channel;
+
+// The client will emit an RTM.AUTHENTICATED event on successful connection, with the `rtm.start` payload
+rtm.on(CLIENT_EVENTS.RTM.AUTHENTICATED, (rtmStartData) => {
+  for (const c of rtmStartData.channels) {
+	  if (c.is_member && c.name ==='general') { channel = c.id }
+  }
   console.log(`Logged in as ${rtmStartData.self.name} of team ${rtmStartData.team.name}, but not yet connected to a channel`);
 });
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Read the [full documentation](https://slackapi.github.io/node-slack-sdk) for all the lovely details.
 
-So you want to build a Slack app with Node.js? We've got you covered. {{ site.product_name }} is aimed at making
+So you want to build a Slack app with Node.js? We've got you covered. `node-slack-sdk` is aimed at making
 building Slack apps ridiculously easy. This module will help you build on all aspects of the Slack platform,
 from dropping notifications in channels to fully interactive bots.
 
@@ -24,7 +24,7 @@ This library does not attempt to provide application level support, _e.g._ regex
 conversation stream.
 
 Most Slack apps are interested in posting messages into Slack channels, and generally working with our [Web API](https://api.slack.com/web). Read on
-to learn how to use {{ site.product_name }} to accomplish these tasks. Bots, on the other hand, are a bit more complex,
+to learn how to use `node-slack-sdk` to accomplish these tasks. Bots, on the other hand, are a bit more complex,
 so we have them covered in [Building Bots](https://slackapi.github.io/node-slack-sdk/bots).
 
 # Some Examples
@@ -47,11 +47,11 @@ var url = process.env.SLACK_WEBHOOK_URL || ''; //see section above on sensitive 
 var webhook = new IncomingWebhook(url);
 
 webhook.send('Hello there', function(err, res) {
-    if (err) {
-        console.log('Error:', err);
-    } else {
-        console.log('Message sent: ', res);
-    }
+  if (err) {
+    console.log('Error:', err);
+  } else {
+    console.log('Message sent: ', res);
+  }
 });
 ```
 
@@ -70,11 +70,11 @@ var token = process.env.SLACK_API_TOKEN || ''; //see section above on sensitive 
 
 var web = new WebClient(token);
 web.chat.postMessage('C1232456', 'Hello there', function(err, res) {
-    if (err) {
-        console.log('Error:', err);
-    } else {
-        console.log('Message sent: ', res);
-    }
+  if (err) {
+    console.log('Error:', err);
+  } else {
+    console.log('Message sent: ', res);
+  }
 });
 ```
 

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -160,6 +160,12 @@ RTMClient.prototype.activeTeamId = undefined;
 
 
 /**
+ * @type {SlackDataStore}
+ */
+RTMClient.prototype.dataStore = undefined;
+
+
+/**
  * The timer repeatedly pinging the server to let it know the client is still alive.
  * @type {?}
  */
@@ -175,7 +181,7 @@ RTMClient.prototype._lastPong = 0;
 
 
 /**
- *
+ * A running count of socket connection attempts.
  * @type {number}
  * @private
  */
@@ -191,17 +197,19 @@ RTMClient.prototype._connecting = false;
 
 
 /**
- * Whether the server is currently re-connecting.
+ * Options passed to `start`, for use when reconnecting.
+ * @type {object}
+ * @private
+ */
+RTMClient.prototype._startOpts = null;
+
+
+/**
+ * Whether the server is currently reconnecting.
  * @type {boolean}
  * @private
  */
 RTMClient.prototype._reconnecting = false;
-
-
-/**
- * @type {SlackDataStore}
- */
-RTMClient.prototype.dataStore = undefined;
 
 
 /** @inheritDoc */
@@ -234,6 +242,7 @@ RTMClient.prototype.start = function start(opts) {
     this.logger('verbose', 'attempting to connect via the RTM API');
     this.emit(CLIENT_EVENTS.CONNECTING);
     this._connecting = true;
+    this._startOpts = opts;
 
     if (this._useRtmConnect) {
       this._rtm.connect(bind(this._onStart, this));
@@ -350,7 +359,7 @@ RTMClient.prototype.disconnect = function disconnect(optErr, optCode) {
 
 
 /**
- *
+ * Attempts to reconnect to the websocket.
  */
 RTMClient.prototype.reconnect = function reconnect() {
   if (!this._reconnecting) {
@@ -367,7 +376,12 @@ RTMClient.prototype.reconnect = function reconnect() {
         'unable to connect to Slack RTM API, failed after max reconnection attempts'
       );
     }
-    setTimeout(bind(this.start, this), this._connAttempts * this.RECONNECTION_BACKOFF);
+
+    // Ensure we use the same arguments to `start` when reconnecting
+    setTimeout(
+      bind(this.start, this, this._startOpts),
+      this._connAttempts * this.RECONNECTION_BACKOFF
+    );
   }
 };
 

--- a/lib/clients/web/facets/rtm.js
+++ b/lib/clients/web/facets/rtm.js
@@ -18,10 +18,12 @@ function RtmFacet(makeAPICall) {
  * @see {@link https://api.slack.com/methods/rtm.start|rtm.start}
  *
  * @param {Object=} opts
- * @param {?} opts.simple_latest - Return timestamp only for latest message object of each channel
- *   (improves performance).
- * @param {?} opts.no_unreads - Skip unread counts for each channel (improves performance).
- * @param {?} opts.mpim_aware - Returns MPIMs to the client in the API response.
+ * @param {Boolean} opts.simple_latest - Return timestamp only for latest message object of each
+ *                                       channel (improves performance).
+ * @param {Boolean} opts.no_unreads - Skip unread counts for each channel (improves performance).
+ * @param {Boolean} opts.no_latest - Exclude latest timestamps for channels, groups, mpims, and
+ *                                   ims. Automatically sets no_unreads to 1
+ * @param {Boolean} opts.mpim_aware - Returns MPIMs to the client in the API response.
  * @param {function=} optCb Optional callback, if not using promises.
  */
 RtmFacet.prototype.start = function start(opts, optCb) {


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> This PR handles an issue with the RTM client wherein reconnects do not use the same arguments originally given to `rtm.start`. So, if you specify something like `simple_latest`, it'll work the first time, but reset to default once you reconnect.

#### Related Issues
> There was no issue filed for this bug. This PR fixes an unrelated issue with the README, see #300.

#### Test strategy
> I added a test that reproduces this case.