### PR TITLE
Support for presence subscriptions

### DIFF
--- a/docs/_reference/RTMClient.md
+++ b/docs/_reference/RTMClient.md
@@ -33,6 +33,7 @@ permalink: /reference/RTMClient
     * [.sendMessage(text, channelId, [optCb])](#RTMClient+sendMessage)
     * [.updateMessage(message, [optCb])](#RTMClient+updateMessage)
     * [.sendTyping(channelId)](#RTMClient+sendTyping)
+    * [.subscribePresence(userIds)](#RTMClient+subscribePresence)
     * [.send(message, [optCb])](#RTMClient+send)
 
 <a name="new_RTMClient_new"></a>
@@ -274,6 +275,18 @@ Sends a typing indicator to indicate that the user with `activeUserId` is typing
 | Param | Type | Description |
 | --- | --- | --- |
 | channelId | <code>string</code> | The id of the channel|group|DM to send this message to. |
+
+<a name="RTMClient+subscribePresence"></a>
+
+### rtmClient.subscribePresence(userIds)
+Subscribes this socket to presence changes for only the given `userIds`.
+This requires `presence_sub` to have been passed as an argument to `start`.
+
+**Kind**: instance method of <code>[RTMClient](#RTMClient)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userIds | <code>Array</code> | The user IDs to subscribe to |
 
 <a name="RTMClient+send"></a>
 

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -718,6 +718,19 @@ RTMClient.prototype.sendTyping = function sendTyping(channelId) {
 
 
 /**
+ * Subscribes this socket to presence changes for only the given `userIds`.
+ * This requires `presence_sub` to have been passed as an argument to `start`.
+ * @param {Array} userIds The user IDs to subscribe to
+ */
+RTMClient.prototype.subscribePresence = function subscribePresence(userIds) {
+  this.send({
+    type: 'presence_sub',
+    ids: userIds
+  }, noop);
+};
+
+
+/**
  * Sends a message over the websocket to the server.
  * @param {*} message The message to send back to the server.
  * @param {Function=} optCb

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -250,12 +250,13 @@ RTMClient.prototype.start = function start(opts) {
     this._startOpts = opts;
 
     if (this._useRtmConnect) {
-      this._rtm.connect(bind(this._onStart, this));
+      this._rtm.connect(opts, bind(this._onStart, this));
     } else {
       this._rtm.start(opts, bind(this._onStart, this));
     }
   }
 };
+
 
 /**
  * @deprecated since version 2.0.0, use start() instead.

--- a/lib/clients/web/facets/rtm.js
+++ b/lib/clients/web/facets/rtm.js
@@ -38,8 +38,8 @@ RtmFacet.prototype.start = function start(opts, optCb) {
  *
  * @param {function=} optCb Optional callback, if not using promises.
  */
-RtmFacet.prototype.connect = function connect(optCb) {
-  return this.makeAPICall('rtm.connect', null, null, optCb);
+RtmFacet.prototype.connect = function connect(opts, optCb) {
+  return this.makeAPICall('rtm.connect', null, opts, optCb);
 };
 
 

--- a/lib/clients/web/facets/rtm.js
+++ b/lib/clients/web/facets/rtm.js
@@ -17,14 +17,13 @@ function RtmFacet(makeAPICall) {
  * Starts a Real Time Messaging session.
  * @see {@link https://api.slack.com/methods/rtm.start|rtm.start}
  *
- * @param {Object=} opts
- * @param {Boolean} opts.simple_latest - Return timestamp only for latest message object of each
- * channel (improves performance).
- * @param {Boolean} opts.no_unreads - Skip unread counts for each channel (improves performance).
- * @param {Boolean} opts.no_latest - Exclude latest timestamps for channels, groups, mpims, and
- * ims. Automatically sets no_unreads to 1
- * @param {Boolean} opts.mpim_aware - Returns MPIMs to the client in the API response.
- * @param {function=} optCb Optional callback, if not using promises.
+ * @param {Object} opts
+ * @param {Boolean} opts.simple_latest  Return timestamp only for latest message object of each
+ *                                      channel (improves performance).
+ * @param {Boolean} opts.no_unreads     Skip unread counts for each channel (improves performance).
+ * @param {Boolean} opts.mpim_aware     Returns MPIMs to the client in the API response.
+ * @param {Boolean} opts.presence_sub   Support presence subscriptions on this socket connection.
+ * @param {Function} optCb              Optional callback, if not using promises.
  */
 RtmFacet.prototype.start = function start(opts, optCb) {
   return this.makeAPICall('rtm.start', null, opts, optCb);
@@ -36,7 +35,9 @@ RtmFacet.prototype.start = function start(opts, optCb) {
  * This will give us a WebSocket URL without the payload of `rtm.start`.
  * @see {@link https://api.slack.com/methods/rtm.connect|rtm.connect}
  *
- * @param {function=} optCb Optional callback, if not using promises.
+ * @param {Object} opts
+ * @param {Boolean} opts.presence_sub   Support presence subscriptions on this socket connection.
+ * @param {Function} optCb              Optional callback, if not using promises.
  */
 RtmFacet.prototype.connect = function connect(opts, optCb) {
   return this.makeAPICall('rtm.connect', null, opts, optCb);

--- a/test/clients/rtm/send-message.js
+++ b/test/clients/rtm/send-message.js
@@ -28,6 +28,17 @@ describe('RTM API Client', function () {
           done();
         });
     });
+
+    it('should send a presence_sub message when subscribePresence is called', function () {
+      var rtm = createRtmClient();
+      var userIds = ['VinDiesel'];
+      sinon.spy(rtm, 'send');
+      rtm.subscribePresence(userIds);
+      expect(rtm.send.calledWith({
+        type: 'presence_sub',
+        ids: userIds
+      })).to.equal(true);
+    });
   });
 
   describe('Message Response Handling', function () {


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This PR adds support for presence subscriptions, to further reduce socket traffic. Both `rtm.connect` and `rtm.start` now support this parameter. It also adds a helper method to the client:

``` js
// Now you'll only receive presence_change events for this user
rtm.subscribePresence(['W1NTZGLCW']) 
```

#### Related Issues
> No issue filed related to this.

#### Test strategy
One new test was added:
```
✓ should send a presence_sub message when subscribePresence is called
```