### PR TITLE
Support a "retry now" method

### DIFF
--- a/docs/_reference/BaseAPIClient.md
+++ b/docs/_reference/BaseAPIClient.md
@@ -7,12 +7,13 @@ permalink: /reference/BaseAPIClient
 
 * [BaseAPIClient](#BaseAPIClient)
     * [new BaseAPIClient(token, opts)](#new_BaseAPIClient_new)
-    * [.slackAPIUrl](#BaseAPIClient+slackAPIUrl) : <code>string</code>
+    * [.slackAPIUrl](#BaseAPIClient+slackAPIUrl) : <code>String</code>
     * [.transport](#BaseAPIClient+transport) : <code>function</code>
     * [.retryConfig](#BaseAPIClient+retryConfig)
     * [.logger](#BaseAPIClient+logger) : <code>function</code>
     * [._createFacets()](#BaseAPIClient+_createFacets)
     * [.registerDataStore(dataStore)](#BaseAPIClient+registerDataStore)
+    * [.clearQueue()](#BaseAPIClient+clearQueue)
     * [._callTransport(task, queueCb)](#BaseAPIClient+_callTransport)
 
 <a name="new_BaseAPIClient_new"></a>
@@ -23,18 +24,18 @@ Base client for both the RTM and web APIs.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| token | <code>string</code> | The Slack API token to use with this client. |
+| token | <code>String</code> | The Slack API token to use with this client |
 | opts | <code>Object</code> |  |
-| opts.slackAPIUrl | <code>String</code> | The Slack API URL. |
-| opts.transport | <code>function</code> | Function to call to make an HTTP call to the Slack API. |
-| [opts.logLevel] | <code>string</code> | The log level for the logger. |
-| [opts.logger] | <code>function</code> | Function to use for log calls, takes (logLevel, logString) params. |
-| opts.maxRequestConcurrency | <code>Number</code> | The max # of concurrent requests to make to Slack's     API's, defaults to 3. |
-| opts.retryConfig | <code>Object</code> | The configuration to use for the retry operation,     {@see https://github.com/SEAPUNK/node-retry} |
+| opts.slackAPIUrl | <code>String</code> | The Slack API URL |
+| opts.transport | <code>function</code> | Function to call to make an HTTP call to the Slack API |
+| opts.logLevel | <code>String</code> | The log level for the logger |
+| opts.logger | <code>function</code> | Function to use for log calls, takes (logLevel, logString) |
+| opts.maxRequestConcurrency | <code>Number</code> | Max number of concurrent requests to make to Slack's API's, defaults to 3 |
+| opts.retryConfig | <code>Object</code> | The configuration to use for the retry operation, {@see https://github.com/SEAPUNK/node-retry} |
 
 <a name="BaseAPIClient+slackAPIUrl"></a>
 
-### baseAPIClient.slackAPIUrl : <code>string</code>
+### baseAPIClient.slackAPIUrl : <code>String</code>
 **Kind**: instance property of <code>[BaseAPIClient](#BaseAPIClient)</code>  
 <a name="BaseAPIClient+transport"></a>
 
@@ -71,6 +72,12 @@ Attaches a data-store to the client instance.
 | --- | --- |
 | dataStore | <code>[SlackDataStore](#SlackDataStore)</code> | 
 
+<a name="BaseAPIClient+clearQueue"></a>
+
+### baseAPIClient.clearQueue()
+Empties the request queue and returns it to a clean slate.
+
+**Kind**: instance method of <code>[BaseAPIClient](#BaseAPIClient)</code>  
 <a name="BaseAPIClient+_callTransport"></a>
 
 ### baseAPIClient._callTransport(task, queueCb)

--- a/docs/_reference/RTMClient.md
+++ b/docs/_reference/RTMClient.md
@@ -21,7 +21,7 @@ permalink: /reference/RTMClient
     * [.nextMessageId()](#RTMClient+nextMessageId)
     * [.connect(socketUrl)](#RTMClient+connect)
     * [.disconnect(optReason, optCode)](#RTMClient+disconnect)
-    * [.reconnect()](#RTMClient+reconnect)
+    * [.reconnect(forceRetry)](#RTMClient+reconnect)
     * [.handleWsOpen()](#RTMClient+handleWsOpen)
     * [.handleWsMessage(wsMsg)](#RTMClient+handleWsMessage)
     * [._handleMessageAck(replyTo, message)](#RTMClient+_handleMessageAck)
@@ -151,10 +151,15 @@ Disconnects from the RTM API.
 
 <a name="RTMClient+reconnect"></a>
 
-### rtmClient.reconnect()
+### rtmClient.reconnect(forceRetry)
 Attempts to reconnect to the websocket by retrying the start method.
 
 **Kind**: instance method of <code>[RTMClient](#RTMClient)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| forceRetry | <code>Boolean</code> | True to force a reconnect now, even if one is in progress |
+
 <a name="RTMClient+handleWsOpen"></a>
 
 ### rtmClient.handleWsOpen()

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -17,6 +17,7 @@ function writeMarkdownFile(data, classes, index) {
                              '{{#class name=\"%s\"}}{{>docs-main}}{{/class}}',
                              className, className, className);
   var dmdStream;
+  // eslint-disable-next-line no-console
   console.log(util.format(
     'rendering %s, template: %s', className, template
   ));

--- a/lib/clients/client.js
+++ b/lib/clients/client.js
@@ -101,10 +101,11 @@ BaseAPIClient.prototype.registerDataStore = function registerDataStore(dataStore
  * Empties the request queue and returns it to a clean slate.
  */
 BaseAPIClient.prototype.clearQueue = function clearQueue() {
-  this.logger('info', 'Clearing the request queue', this.requestQueue.concurrency);
+  this.logger('info', 'Clearing the request queue');
+  this.requestQueue.kill();
 
-  // Initially tried to accomplish this with `requestQueue.kill`, but it leaves the queue blocked.
-  // See https://github.com/caolan/async/issues/1422.
+  // Initially tried to accomplish this with just `requestQueue.kill`, but it leaves the queue
+  // blocked. See https://github.com/caolan/async/issues/1422.
   this.requestQueue = async.queue(
     bind(this._callTransport, this),
     this.requestQueue.concurrency || 3

--- a/lib/clients/client.js
+++ b/lib/clients/client.js
@@ -1,7 +1,3 @@
-/**
- *
- */
-
 var EventEmitter = require('eventemitter3');
 var Promise = require('bluebird');
 var async = require('async');
@@ -22,16 +18,16 @@ var retryPolicies = require('./retry-policies');
 
 /**
  * Base client for both the RTM and web APIs.
- * @param {string} token The Slack API token to use with this client.
+ * @param {String} token            The Slack API token to use with this client
  * @param {Object} opts
- * @param {String} opts.slackAPIUrl The Slack API URL.
- * @param {Function} opts.transport Function to call to make an HTTP call to the Slack API.
- * @param {string=} opts.logLevel The log level for the logger.
- * @param {Function=} opts.logger Function to use for log calls, takes (logLevel, logString) params.
- * @param {Number} opts.maxRequestConcurrency The max # of concurrent requests to make to Slack's
- *     API's, defaults to 3.
+ * @param {String} opts.slackAPIUrl The Slack API URL
+ * @param {Function} opts.transport Function to call to make an HTTP call to the Slack API
+ * @param {String} opts.logLevel    The log level for the logger
+ * @param {Function} opts.logger    Function to use for log calls, takes (logLevel, logString)
+ * @param {Number} opts.maxRequestConcurrency Max number of concurrent requests to make to Slack's
+ * API's, defaults to 3
  * @param {Object} opts.retryConfig The configuration to use for the retry operation,
- *     {@see https://github.com/SEAPUNK/node-retry}
+ * {@see https://github.com/SEAPUNK/node-retry}
  * @constructor
  */
 function BaseAPIClient(token, opts) {
@@ -44,7 +40,7 @@ function BaseAPIClient(token, opts) {
    */
   this._token = token;
 
-  /** @type {string} */
+  /** @type {String} */
   this.slackAPIUrl = clientOpts.slackAPIUrl || 'https://slack.com/api/';
 
   /** @type {Function} */
@@ -58,7 +54,7 @@ function BaseAPIClient(token, opts) {
     retryPolicies.RETRY_FOREVER_EXPONENTIAL_CAPPED_RANDOM;
 
   /**
-   *
+   * Handles API requests. For RTM clients this is a one-at-a-time queue.
    * @type {Object}
    * @private
    */
@@ -102,6 +98,21 @@ BaseAPIClient.prototype.registerDataStore = function registerDataStore(dataStore
 
 
 /**
+ * Empties the request queue and returns it to a clean slate.
+ */
+BaseAPIClient.prototype.clearQueue = function clearQueue() {
+  this.logger('info', 'Clearing the request queue', this.requestQueue.concurrency);
+
+  // Initially tried to accomplish this with `requestQueue.kill`, but it leaves the queue blocked.
+  // See https://github.com/caolan/async/issues/1422.
+  this.requestQueue = async.queue(
+    bind(this._callTransport, this),
+    this.requestQueue.concurrency || 3
+  );
+};
+
+
+/**
  * Calls the supplied transport function and processes the results.
  *
  * This will also manage 429 responses and retry failed operations.
@@ -130,10 +141,11 @@ BaseAPIClient.prototype._callTransport = function _callTransport(task, queueCb) 
 /**
  * Makes a call to the Slack API.
  *
- * @param {String} endpoint The API endpoint to send to.
- * @param {Object=} apiArgs
- * @param {Object=} apiOptArgs
- * @param {function=} optCb The callback to run on completion.
+ * @param {String} endpoint   The API endpoint to send to
+ * @param {Object} apiArgs    Arguments to the API request
+ * @param {Object} apiOptArgs Optional arguments to the API request
+ * @param {Function} optCb    The callback to run on completion; note that if `apiOptArgs` is a
+ * callback, it will overwrite this parameter
  * @private
  */
 BaseAPIClient.prototype._makeAPICall = function _makeAPICall(endpoint, apiArgs, apiOptArgs, optCb) {

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -382,6 +382,7 @@ RTMClient.prototype.disconnect = function disconnect(optErr, optCode) {
 
 /**
  * Attempts to reconnect to the websocket by retrying the start method.
+ * @param {Boolean} forceRetry  True to force a reconnect now, even if one is in progress
  */
 RTMClient.prototype.reconnect = function reconnect(forceRetry) {
   if (!this._reconnecting || forceRetry) {
@@ -391,6 +392,9 @@ RTMClient.prototype.reconnect = function reconnect(forceRetry) {
 
     this._connAttempts++;
     this.logger('verbose', 'Reconnecting, on attempt', this._connAttempts);
+
+    // Subsequent requests are blocked waiting for the initial attempt, so let's clear it first
+    if (forceRetry) this.clearQueue();
 
     // Ensure we use the same arguments to `start` when reconnecting
     this.start(this._startOpts);

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -254,8 +254,11 @@ RTMClient.prototype.start = function start(opts) {
     } else {
       this._rtm.start(opts, bind(this._onStart, this));
     }
+  } else {
+    this.logger('verbose', 'Tried to connect when an attempt was in progress');
   }
 };
+
 
 /**
  * @deprecated since version 2.0.0, use start() instead.
@@ -343,6 +346,8 @@ RTMClient.prototype._safeDisconnect = function _safeDisconnect() {
     this.ws.removeAllListeners('close');
     this.ws.close();
   }
+  this._connecting = false;
+  this._reconnecting = false;
   this.authenticated = false;
   this.connected = false;
 };
@@ -378,17 +383,19 @@ RTMClient.prototype.disconnect = function disconnect(optErr, optCode) {
 /**
  * Attempts to reconnect to the websocket by retrying the start method.
  */
-RTMClient.prototype.reconnect = function reconnect() {
-  if (!this._reconnecting) {
+RTMClient.prototype.reconnect = function reconnect(forceRetry) {
+  if (!this._reconnecting || forceRetry) {
     this.emit(CLIENT_EVENTS.ATTEMPTING_RECONNECT);
-    this._reconnecting = true;
     this._safeDisconnect();
+    this._reconnecting = true;
 
     this._connAttempts++;
-    this.logger('warn', 'Reconnecting, on attempt', this._connAttempts);
+    this.logger('verbose', 'Reconnecting, on attempt', this._connAttempts);
 
     // Ensure we use the same arguments to `start` when reconnecting
     this.start(this._startOpts);
+  } else {
+    this.logger('verbose', 'Tried to reconnect when an attempt was in progress');
   }
 };
 
@@ -604,11 +611,9 @@ RTMClient.prototype.handleWsClose = function handleWsClose(code, reason) {
   this.emit(CLIENT_EVENTS.WS_CLOSE, code, reason);
 
   if (this.autoReconnect) {
-    if (!this._connecting) {
-      this.reconnect();
-    }
+    this.reconnect();
   } else {
-    this.disconnect('websocket closed with auto-reconnect false on the RTM client');
+    this.disconnect('Websocket closed and auto-reconnect is disabled');
   }
 };
 

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -90,8 +90,7 @@ var handleHttpResponse = function handleHttpResponse(body, headers, client, apiC
   try {
     jsonResponse = JSON.parse(body);
   } catch (parseErr) {
-    // TODO(leah): Emit an event here?
-    jsonError = new Error('unable to parse Slack API Response');
+    client.logger('error', 'Unable to parse Slack API Response', parseErr);
     return false;
   }
 
@@ -102,15 +101,15 @@ var handleHttpResponse = function handleHttpResponse(body, headers, client, apiC
   if (!jsonResponse.ok) {
     jsonError = new Error(jsonResponse.error);
     client.logger('error', 'Response not OK: ', jsonResponse.error);
+  } else {
+    jsonResponse.scopes = (headers['x-oauth-scopes'] === undefined) ?
+      [] :
+      headers['x-oauth-scopes'].trim().split(/\s*,\s*/);
+
+    jsonResponse.acceptedScopes = (headers['x-accepted-oauth-scopes'] === undefined) ?
+      [] :
+      headers['x-accepted-oauth-scopes'].trim().split(/\s*,\s*/);
   }
-
-  jsonResponse.scopes = (headers['x-oauth-scopes'] === undefined) ?
-    [] :
-    headers['x-oauth-scopes'].trim().split(/\s*,\s*/);
-  jsonResponse.acceptedScopes = (headers['x-accepted-oauth-scopes'] === undefined) ?
-    [] :
-    headers['x-accepted-oauth-scopes'].trim().split(/\s*,\s*/);
-
 
   try {
     apiCb(jsonError, jsonResponse);

--- a/lib/clients/transports/request.js
+++ b/lib/clients/transports/request.js
@@ -22,7 +22,7 @@ var handleRequestTranportRes = function handleRequestTranportRes(cb, err, respon
 };
 
 
-var getRequestTransportArgs = function getReqestTransportArgs(args) {
+var getRequestTransportArgs = function getRequestTransportArgs(args) {
   var transportArgs = {
     url: args.url,
     headers: args.headers

--- a/lib/clients/transports/ws.js
+++ b/lib/clients/transports/ws.js
@@ -4,7 +4,8 @@
 
 var HttpsProxyAgent = require('https-proxy-agent');
 var WebSocket = require('ws');
-var globalHelpers = require('../../helpers');
+var getVersionString = require('../../helpers').getVersionString;
+var getLogger = require('../../helpers').getLogger;
 
 /**
  *
@@ -17,14 +18,15 @@ var wsTransport = function wsTransport(socketUrl, opts) {
   var wsTransportOpts = opts || {};
   var wsOpts = {};
   var proxyURL = wsTransportOpts.proxyURL || process.env.https_proxy;
+  var logger = getLogger();
 
   if (proxyURL) {
-    console.log('Using https proxy: ' + proxyURL);
+    logger('info', 'Using https proxy: ' + proxyURL);
     wsOpts.agent = new HttpsProxyAgent(proxyURL);
   }
 
   wsOpts.headers = {
-    'User-Agent': globalHelpers.getVersionString()
+    'User-Agent': getVersionString()
   };
 
   return new WebSocket(socketUrl, wsOpts);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/slackapi/node-slack-sdk/issues"
   },
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^2.4.1",
     "bluebird": "^3.3.3",
     "eventemitter3": "^1.1.1",
     "https-proxy-agent": "^1.0.0",
@@ -30,7 +30,7 @@
     "lodash": "^4.13.1",
     "pkginfo": "^0.4.0",
     "request": "^2.64.0",
-    "retry": "^0.9.0",
+    "retry": "^0.10.1",
     "url-join": "0.0.1",
     "winston": "^2.1.1",
     "ws": "^1.0.1"

--- a/test/clients/rtm/retry-policy.js
+++ b/test/clients/rtm/retry-policy.js
@@ -129,5 +129,30 @@ describe('RTM API Client', function () {
         done();
       }, timeout);
     });
+
+    it('should support reconnecting immediately', function (done) {
+      testRetryPolicy({
+        retryConfig: {
+          minTimeout: 10,
+          maxTimeout: 10,
+          retries: 1
+        }
+      }, function (post) {
+        // Delay the response long enough that we timeout
+        return post
+          .delay(20)
+          .reply(200, { ok: true });
+      });
+
+      setTimeout(function () {
+        expect(rtm.transport.callCount).to.equal(1);
+        rtm.reconnect(true);
+
+        setImmediate(function () {
+          expect(rtm.transport.callCount).to.equal(2);
+          done();
+        });
+      }, 10);
+    });
   });
 });


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

## 🚧 Note 
Merge #349 first then rebase.

## PR Summary
This PR builds on the work in #349. Since we're using a "retry forever with exponential backoff" policy, we can hit the cap of 30 minutes relatively quickly. If we then regain network or wake from sleep, we want to be able to recreate the socket connection immediately rather than waiting for the next retry. This PR adds a `forceRetry` parameter to `rtm.reconnect` to support this.

Then, in my client-side code, I can do something like:

``` js
// If we have network when we resume from sleep, retry immediately
async handleWakeFromSleep() {
  const online = await isOnline({ timeout: 30000 });
  if (online) {
    this.rtm.reconnect(true);
  }
}
```

## Related Issues
No issues filed.

## Test strategy
One new test was added:
```
 ✓ should support reconnecting immediately
```