### PR TITLE
correct comments for `rtm._safeDisconnect()`

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -340,7 +340,6 @@ RTMClient.prototype._safeDisconnect = function _safeDisconnect() {
   }
   if (this.ws) {
     // Stop listening to the websocket's close event, so that the auto-reconnect logic doesn't fire
-    // twice.
     this.ws.removeAllListeners('close');
     this.ws.close();
   }


### PR DESCRIPTION
it seems that removing all the listeners will prevent *any* reconnect from happening. this is okay because it also seems like `_safeDisconnect()` is only called from places where an automatic reconnect wouldn't be wanted (it is called from `reconnect()`, which manually will kick of a new connection).

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).