### PR TITLE
add missing checks for autoReconnect property

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -441,8 +441,10 @@ RTMClient.prototype._handleWsMessageInternal = function _handleWsMessageInternal
   } else if (messageType === RTM_API_EVENTS.HELLO) {
     this._handleHello();
   } else if (messageType === RTM_API_EVENTS.TEAM_MIGRATION_STARTED) {
-    this.reconnect();
     this.emit(messageType, message);
+    if (this.autoReconnect) {
+      this.reconnect();
+    }
   }
 };
 
@@ -639,7 +641,7 @@ RTMClient.prototype._pingServer = function _pingServer() {
 
     // If we didn't receive a response to the last pong in some duration,
     // force a reconnect
-    if (pongInterval > this.MAX_PONG_INTERVAL) {
+    if (this.autoReconnect && pongInterval > this.MAX_PONG_INTERVAL) {
       this.reconnect();
     } else {
       this.send({ type: 'ping' }, noop);


### PR DESCRIPTION
the `autoReconnect` property isn't checked for a few conditions that trigger a reconnect

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
