### PR TITLE
add channels.replies facet to web api client

### DIFF
--- a/lib/clients/web/facets/channels.js
+++ b/lib/clients/web/facets/channels.js
@@ -13,6 +13,7 @@
  *   - list: {@link https://api.slack.com/methods/channels.list|channels.list}
  *   - mark: {@link https://api.slack.com/methods/channels.mark|channels.mark}
  *   - rename: {@link https://api.slack.com/methods/channels.rename|channels.rename}
+ *   - replies: {@link https://api.slack.com/methods/channels.replies|channels.replies}
  *   - setPurpose: {@link https://api.slack.com/methods/channels.setPurpose|channels.setPurpose}
  *   - setTopic: {@link https://api.slack.com/methods/channels.setTopic|channels.setTopic}
  *   - unarchive: {@link https://api.slack.com/methods/channels.unarchive|channels.unarchive}
@@ -210,6 +211,24 @@ ChannelsFacet.prototype.rename = function rename(channel, name, optCb) {
   };
 
   return this.makeAPICall('channels.rename', requiredArgs, null, optCb);
+};
+
+
+/**
+ * Retrieve a thread of messages posted to a channel.
+ * @see {@link https://api.slack.com/methods/channels.replies|channels.replies}
+ *
+ * @param {?} channel - Channel to fetch thread from
+ * @param {?} thread_ts - Unique identifier of a thread's parent message
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+ChannelsFacet.prototype.replies = function rename(channel, thread_ts, optCb) {
+  var requiredArgs = {
+    channel: channel,
+    thread_ts: thread_ts
+  };
+
+  return this.makeAPICall('channels.replies', requiredArgs, null, optCb);
 };
 
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
I simply added a missing facet, copying over what was appropriate from the official docs here: https://api.slack.com/methods/channels.replies

#### Related Issues
Fixes #378.

#### Test strategy
No tests were added since the existing tests don't target specific facets or API calls (hence why this omission wasn't caught in the first place).