### PR TITLE
adds MPIMs to the datastore on rtm.start

### DIFF
--- a/lib/data-store/data-store.js
+++ b/lib/data-store/data-store.js
@@ -409,11 +409,11 @@ SlackDataStore.prototype.cacheRtmStart = function cacheRtmStart(data) {
   forEach(data.groups || [], bind(function cacheRtmGroup(group) {
     this.setGroup(new models.Group(group));
   }, this));
-  forEach(data.mpims || [], bind(function cacheRtmGroup(group) {
+  forEach(data.mpims || [], bind(function cacheRtmMpim(mpim) {
     // MPIMs are basically groups (they have the same prefix)
     // NOTE: there is a Model class for MPDM, and it is used in the model helpers `getModelClass`
     //       so this could be introducing some inconsistencies in behavior.
-    this.setGroup(new models.Group(group));
+    this.setGroup(new models.Group(mpim));
   }, this));
   forEach(data.bots || [], bind(function cacheRtmBot(bot) {
     // Bots don't have a separate type currently, so treat them as simple objects

--- a/lib/data-store/data-store.js
+++ b/lib/data-store/data-store.js
@@ -409,6 +409,12 @@ SlackDataStore.prototype.cacheRtmStart = function cacheRtmStart(data) {
   forEach(data.groups || [], bind(function cacheRtmGroup(group) {
     this.setGroup(new models.Group(group));
   }, this));
+  forEach(data.mpims || [], bind(function cacheRtmGroup(group) {
+    // MPIMs are basically groups (they have the same prefix)
+    // NOTE: there is a Model class for MPDM, and it is used in the model helpers `getModelClass`
+    //       so this could be introducing some inconsistencies in behavior.
+    this.setGroup(new models.Group(group));
+  }, this));
   forEach(data.bots || [], bind(function cacheRtmBot(bot) {
     // Bots don't have a separate type currently, so treat them as simple objects
     this.setBot(bot);


### PR DESCRIPTION
previously, MPIMs would be missing from the RTM client's data store cache.

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).