### PR TITLE
JSON-encoding of 'profile' parameter

### DIFF
--- a/lib/clients/helpers.js
+++ b/lib/clients/helpers.js
@@ -37,6 +37,14 @@ var assignApiArgs = function assignApiArgs(target, source) {
         } else {
           target[key] = JSON.stringify(val);
         }
+      // For the web API, this should always be a JSON-encoded object, see:
+      //   https://api.slack.com/methods/users.profile.set or https://api.slack.com/methods/users.profile.get
+      } else if (key === 'profile') {
+        if (isString(val)) {
+          target[key] = val;
+        } else {
+          target[key] = JSON.stringify(val);
+        }
       } else if (key !== 'opts') {
         target[key] = val;
       }

--- a/test/clients/helpers.js
+++ b/test/clients/helpers.js
@@ -51,11 +51,31 @@ describe('Client Helpers', function () {
       });
     });
 
+    it('JSON encodes user profile if it is not already encoded', function () {
+      var required = { profile: { status_text: 'testing', status_emoji: ':construction_worker:' } };
+
+      expect(helpers.getAPICallData('test', required, null)).to.be.deep.equal({
+        profile: '{"status_text":"testing","status_emoji":":construction_worker:"}',
+        token: 'test'
+      });
+    });
+
     it('leaves attachments alone if they are already encoded', function () {
       var required = { attachments: '["a","b","c"]' };
 
       expect(helpers.getAPICallData('test', required, null)).to.be.deep.equal({
         attachments: '["a","b","c"]',
+        token: 'test'
+      });
+    });
+
+    it('leaves user profile alone if it is already encoded', function () {
+      var required = { profile:
+        '{"status_text":"testing","status_emoji":":construction_worker:"}'
+      };
+
+      expect(helpers.getAPICallData('test', required, null)).to.be.deep.equal({
+        profile: '{"status_text":"testing","status_emoji":":construction_worker:"}',
         token: 'test'
       });
     });


### PR DESCRIPTION
JSON-encode the profile parameter in a similar way to attachments and unfurls before sending them to the Web API.

fixes #360 

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).