### PR TITLE
exlcudes request v2.77.0 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "inherits": "^2.0.1",
     "lodash": "^4.13.1",
     "pkginfo": "^0.4.0",
-    "request": "^2.64.0",
+    "request": ">=2.0.0 <2.77.0",
     "retry": "^0.9.0",
     "url-join": "0.0.1",
     "winston": "^2.1.1",


### PR DESCRIPTION
this was a breaking change in a dependency, which unfortunately was
not treated as such with respect to semver.

in v2.77.0, request drops support for node versions 0.8.x - 4.x. this
package still supports node version 0.12.x, and therefore we need to
lock down the dependency version. as a cosequence, we will not
recieve bug fixes in that dependency, **this should motivate a
quicker deprecation of node 0.12**.

this should fix the failing builds that we are currently experiencing.

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
