### PR TITLE
Add some unrecoverable errors

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -23,7 +23,9 @@ var RTM_CLIENT_INTERNAL_EVENT_TYPES = [
 var UNRECOVERABLE_RTM_START_ERRS = [
   'not_authed',
   'invalid_auth',
-  'account_inactive'
+  'account_inactive',
+  'user_removed_from_team',
+  'team_disabled'
 ];
 var CLIENT_EVENTS = require('../events/client').RTM;
 var BaseAPIClient = require('../client');


### PR DESCRIPTION
##  Summary
This PR makes sure that `user_removed_from_team` and `team_disabled` are marked as unrecoverable errors during an `rtm.start` or `rtm.connect`. We were seeing cases in the desktop app wherein a user had been removed from the org but continued to retry the connection.

## Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
