### PR TITLE
3.14.1 Release

### DIFF
--- a/docs/_posts/2017-09-12-v3.14.1.md
+++ b/docs/_posts/2017-09-12-v3.14.1.md
@@ -2,4 +2,4 @@
 layout: changelog
 ---
   * Fixes an issue where newer versions of ``request`` were causing a linting error
-  * Adds additional error types
+  * Adds irrecoverable error types for the RTM client

--- a/docs/_posts/2017-09-12-v3.14.1.md
+++ b/docs/_posts/2017-09-12-v3.14.1.md
@@ -1,0 +1,5 @@
+---
+layout: changelog
+---
+  * Fixes an issue where newer versions of ``request`` were causing a linting error
+  * Adds additional error types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/client",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "A library for creating a Slack client",
   "main": "./index",
   "scripts": {


### PR DESCRIPTION
###  Summary

  * Fixes an issue where newer versions of ``request`` were causing a linting error
  * Adds additional error types

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
