### PR TITLE
Add a new transport that lets you define options on the request module

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   IncomingWebhook: require('./lib/clients/incoming-webhook/client'),
   LegacyRtmClient: require('./lib/clients/default/legacy-rtm'),
   MemoryDataStore: require('./lib/data-store/memory-data-store'),
+  requestOptionsTransport: require('./lib/clients/transports/request').requestOptionsTransport,
   CLIENT_EVENTS: {
     WEB: events.CLIENT_EVENTS.WEB,
     RTM: events.CLIENT_EVENTS.RTM

--- a/lib/clients/transports/request.js
+++ b/lib/clients/transports/request.js
@@ -5,8 +5,8 @@
 var HttpsProxyAgent = require('https-proxy-agent');
 var has = require('lodash').has;
 var partial = require('lodash').partial;
+var defaults = require('lodash').defaults;
 var request = require('request');
-
 
 var handleRequestTranportRes = function handleRequestTranportRes(cb, err, response, body) {
   var headers;
@@ -50,12 +50,18 @@ var proxiedRequestTransport = function proxiedRequestTransport(proxyURL) {
   };
 };
 
+var requestOptionsTransport = function requestOptionsTransport(options) {
+  return function _requestOptionsTransport(args, cb) {
+    var requestArgs = defaults(options, getRequestTransportArgs(args));
+    request.post(requestArgs, partial(handleRequestTranportRes, cb));
+  };
+};
 
 var requestTransport = function requestTransport(args, cb) {
   var requestArgs = getRequestTransportArgs(args);
   request.post(requestArgs, partial(handleRequestTranportRes, cb));
 };
 
-
 module.exports.proxiedRequestTransport = proxiedRequestTransport;
+module.exports.requestOptionsTransport = requestOptionsTransport;
 module.exports.requestTransport = requestTransport;

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -11,6 +11,7 @@ var retryPolicies = require('../../../lib/clients/retry-policies');
 var defaultHTTPResponseHandler =
   require('../../../lib/clients/transports/call-transport').handleHttpResponse;
 
+var requestTransport = require('../../../lib/clients/transports/request');
 
 var mockTransport = function (args, cb) {
   cb(args.data.err, args.headers, args.data.statusCode, args.data.body);
@@ -107,6 +108,37 @@ describe('Web API Client', function () {
     var client = new WebAPIClient('test-token', { transport: mockTransport });
 
     client._makeAPICall('test', { test: 'test' }, null, null);
+  });
+
+  it('should accept overriding of request options', function () {
+
+    // Add Basic Auth
+
+    var options = {
+      auth: {
+        user: 'slack',
+        pass: 'slack'
+      }
+    };
+
+    var requestOptionsTransport = requestTransport.requestOptionsTransport(options);
+
+    // Mock a result where Basic Auth was passed
+
+    nock('https://slack.com/api', {
+      reqheaders: {
+        'authorization': /Basic [0-9A-Za-z]+/i
+      }
+    })
+      .post('/test')
+      .reply(200, '{"test":"test"}');
+
+    var client = new WebAPIClient('test-token', { transport: requestOptionsTransport });
+
+    client._makeAPICall('test', {}, null, function (e, results) {
+      expect(results.test).to.equal('test');
+    });
+
   });
 
   describe('it should retry failed or rate-limited requests', function () {

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -123,17 +123,17 @@ describe('Web API Client', function () {
 
     var requestOptionsTransport = requestTransport.requestOptionsTransport(options);
 
+    var client = new WebAPIClient('test-token', { transport: requestOptionsTransport });
+
     // Mock a result where Basic Auth was passed
 
     nock('https://slack.com/api', {
       reqheaders: {
-        'authorization': /Basic [0-9A-Za-z]+/i
+        authorization: /Basic [0-9A-Za-z]+/i
       }
     })
       .post('/test')
       .reply(200, '{"test":"test"}');
-
-    var client = new WebAPIClient('test-token', { transport: requestOptionsTransport });
 
     client._makeAPICall('test', {}, null, function (e, results) {
       expect(results.test).to.equal('test');


### PR DESCRIPTION
###  Summary

The existing request transport doesn't allow you to override options on it. This defines a new transport that lets you override the options and exposes it from the library so that it can be instantiated and then passed into WebClient.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
