### PR TITLE
3.14.2 Release

### DIFF
--- a/docs/_posts/2017-09-12-v3.14.2.md
+++ b/docs/_posts/2017-09-12-v3.14.2.md
@@ -1,0 +1,4 @@
+---
+layout: changelog
+---
+  * Adds a new transport that lets you define options on the request module (#425 thanks @bertrandom!)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/client",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "A library for creating a Slack client",
   "main": "./index",
   "scripts": {


### PR DESCRIPTION
###  Summary

3.14.2 Release
 - Adds a new transport that lets you define options on the request module

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
