### PR TITLE
Add chat.getPermalink facet to the Web API client

### DIFF
--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -180,14 +180,14 @@ ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, opts, optCb) 
  * Retrieve a permalink URL for a specific extant message.
  * @see {@link https://api.slack.com/methods/chat.getPermalink|chat.getPermalink}
  *
- * @param {?} ts - A message's ts value, uniquely identifying it within a channel.
  * @param {?} channel - The ID of the conversation or channel containing the message.
+ * @param {?} ts - A message's ts value, uniquely identifying it within a channel.
  * @param {function=} optCb Optional callback, if not using promises.
  */
-ChatFacet.prototype.getPermalink = function delete_(ts, channel, optCb) {
+ChatFacet.prototype.getPermalink = function getPermalink(channel, ts, optCb) {
   var requiredArgs = {
-    message_ts: ts,
-    channel: channel
+    channel: channel,
+    message_ts: ts
   };
 
   return this.makeAPICall('chat.getPermalink', requiredArgs, null, optCb);

--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -180,13 +180,13 @@ ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, opts, optCb) 
  * Retrieve a permalink URL for a specific extant message.
  * @see {@link https://api.slack.com/methods/chat.getPermalink|chat.getPermalink}
  *
- * @param {?} message_ts - A message's ts value, uniquely identifying it within a channel.
+ * @param {?} ts - A message's ts value, uniquely identifying it within a channel.
  * @param {?} channel - The ID of the conversation or channel containing the message.
  * @param {function=} optCb Optional callback, if not using promises.
  */
-ChatFacet.prototype.getPermalink = function delete_(message_ts, channel, optCb) {
+ChatFacet.prototype.getPermalink = function delete_(ts, channel, optCb) {
   var requiredArgs = {
-    message_ts: message_ts,
+    message_ts: ts,
     channel: channel
   };
 

--- a/lib/clients/web/facets/chat.js
+++ b/lib/clients/web/facets/chat.js
@@ -7,6 +7,7 @@
  *   - postEphemeral: {@link https://api.slack.com/methods/chat.postEphemeral|chat.postEphemeral}
  *   - postMessage: {@link https://api.slack.com/methods/chat.postMessage|chat.postMessage}
  *   - update: {@link https://api.slack.com/methods/chat.update|chat.update}
+ *   - getPermalink: {@link https://api.slack.com/methods/chat.getPermalink|chat.getPermalink}
  *
  */
 
@@ -173,6 +174,23 @@ ChatFacet.prototype.unfurl = function unfurl(ts, channel, unfurls, opts, optCb) 
   };
 
   return this.makeAPICall('chat.unfurl', requiredArgs, opts, optCb);
+};
+
+/**
+ * Retrieve a permalink URL for a specific extant message.
+ * @see {@link https://api.slack.com/methods/chat.getPermalink|chat.getPermalink}
+ *
+ * @param {?} message_ts - A message's ts value, uniquely identifying it within a channel.
+ * @param {?} channel - The ID of the conversation or channel containing the message.
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+ChatFacet.prototype.getPermalink = function delete_(message_ts, channel, optCb) {
+  var requiredArgs = {
+    message_ts: message_ts,
+    channel: channel
+  };
+
+  return this.makeAPICall('chat.getPermalink', requiredArgs, null, optCb);
 };
 
 module.exports = ChatFacet;


### PR DESCRIPTION
###  Summary

Add a missing `chat.getPermalink` facet to the Web API client (https://api.slack.com/methods/chat.getPermalink)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
