### PR TITLE
Optionally allow a user ID to be passed into users.identity for WTA

### DIFF
--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -40,19 +40,24 @@ UsersFacet.prototype.getPresence = function getPresence(user, optCb) {
  * Get a user's identity.
  * @see {@link https://api.slack.com/methods/users.identity|users.identity}
  *
+ * @param {Object=} options
+ * @param {?} opts.user - When calling this method with a workspace token, set this to
+ * the user ID of the user to retrieve the identity of
  * @param {function=} optCb Optional callback, if not using promises.
  */
-UsersFacet.prototype.identity = function identity(user, optCb) {
+UsersFacet.prototype.identity = function identity(options, optCb) {
   var cb = null;
   var opts = {};
 
   cb = optCb;
 
-  if (user) {
-    if (isFunction(user)) {
-      cb = user;
+  if (options) {
+    if (isFunction(options)) {
+      cb = options;
     } else {
-      opts.user = user;
+      if (options.user) {
+        opts.user = options.user;
+      }
     }
   }
 

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -1,3 +1,5 @@
+var isFunction = require('lodash').isFunction;
+
 /**
  * API Facet to make calls to methods in the users namespace.
  *
@@ -40,8 +42,21 @@ UsersFacet.prototype.getPresence = function getPresence(user, optCb) {
  *
  * @param {function=} optCb Optional callback, if not using promises.
  */
-UsersFacet.prototype.identity = function identity(optCb) {
-  return this.makeAPICall('users.identity', null, null, optCb);
+UsersFacet.prototype.identity = function identity(user, optCb) {
+  var cb = null;
+  var opts = {};
+
+  cb = optCb;
+
+  if (user) {
+    if (isFunction(user)) {
+      cb = user;
+    } else {
+      opts.user = user;
+    }
+  }
+
+  return this.makeAPICall('users.identity', null, opts, cb);
 };
 
 


### PR DESCRIPTION
###  Summary

users.identity can now be passed a user ID when used with Workspace Token Apps. This allows an optional user ID to be passed into the method, while supporting the old function signature where this parameter used to be a callback.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
