### PR TITLE
replace dead link

### DIFF
--- a/lib/clients/web/client.js
+++ b/lib/clients/web/client.js
@@ -16,7 +16,7 @@ var facets = require('./facets/index');
  * @param token The Slack API token to use with this client.
  * @param {Object=} opts
  * @param {Object} opts.retryConfig The configuration to use for the retry operation,
- *     {@see https://github.com/SEAPUNK/node-retry}
+ *     {@see https://github.com/tim-kos/node-retry}
  * @constructor
  */
 function WebAPIClient(token, opts) {


### PR DESCRIPTION
###  Summary

This link has dead 👻 
https://github.com/SEAPUNK/node-retry

I've replaced with alive link.
https://github.com/tim-kos/node-retry

This link is correct because it is specified in `package.json`.
https://www.npmjs.com/package/retry

Thank you.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
