### PR TITLE
Add users.lookupByEmail facet to the Web API client

### DIFF
--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -81,14 +81,15 @@ UsersFacet.prototype.list = function list(opts, optCb) {
  * @see {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}
  *
  * @param {?} email - An email address belonging to a user in the workspace
+ * @param {Object=} opts
  * @param {function=} optCb Optional callback, if not using promises.
  */
-UsersFacet.prototype.lookupByEmail = function lookupByEmail(email, optCb) {
-    var requiredArgs = {
-        email: email
-    };
-
-    return this.makeAPICall('users.lookupByEmail', requiredArgs, null, optCb);
+UsersFacet.prototype.lookupByEmail = function lookupByEmail(email, opts, optCb) {
+  var requiredArgs = {
+    email: email
+  };
+  
+  return this.makeAPICall('users.lookupByEmail', requiredArgs, opts, optCb);
 };
 
 

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -6,6 +6,7 @@
  *   - identity: {@link https://api.slack.com/methods/users.identity|users.identity}
  *   - info: {@link https://api.slack.com/methods/users.info|users.info}
  *   - list: {@link https://api.slack.com/methods/users.list|users.list}
+ *   - lookupByEmail: {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}
  *   - setActive: {@link https://api.slack.com/methods/users.setActive|users.setActive}
  *   - setPresence: {@link https://api.slack.com/methods/users.setPresence|users.setPresence}
  *
@@ -73,6 +74,22 @@ UsersFacet.prototype.info = function info(user, optCb) {
  */
 UsersFacet.prototype.list = function list(opts, optCb) {
   return this.makeAPICall('users.list', null, opts, optCb);
+};
+
+/**
+ * Find a user with an email address.
+ .
+ * @see {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}
+ *
+ * @param {?} email - An email address belonging to a user in the workspace
+ * @param {function=} optCb Optional callback, if not using promises.
+ */
+UsersFacet.prototype.lookupByEmail = function lookupByEmail(email, optCb) {
+    var requiredArgs = {
+        email: email
+    };
+
+    return this.makeAPICall('users.lookupByEmail', requiredArgs, null, optCb);
 };
 
 

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -76,6 +76,7 @@ UsersFacet.prototype.list = function list(opts, optCb) {
   return this.makeAPICall('users.list', null, opts, optCb);
 };
 
+
 /**
  * Find a user with an email address.
  * @see {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -89,7 +89,7 @@ UsersFacet.prototype.lookupByEmail = function lookupByEmail(email, opts, optCb) 
   var requiredArgs = {
     email: email
   };
-  
+
   return this.makeAPICall('users.lookupByEmail', requiredArgs, opts, optCb);
 };
 

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -78,7 +78,6 @@ UsersFacet.prototype.list = function list(opts, optCb) {
 
 /**
  * Find a user with an email address.
- *
  * @see {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}
  *
  * @param {?} email - An email address belonging to a user in the workspace

--- a/lib/clients/web/facets/users.js
+++ b/lib/clients/web/facets/users.js
@@ -78,7 +78,7 @@ UsersFacet.prototype.list = function list(opts, optCb) {
 
 /**
  * Find a user with an email address.
- .
+ *
  * @see {@link https://api.slack.com/methods/users.lookupByEmail|users.lookupByEmail}
  *
  * @param {?} email - An email address belonging to a user in the workspace


### PR DESCRIPTION
###  Summary

Add a missing `users.lookupByEmail` facet to the Web API client (https://api.slack.com/methods/users.lookupByEmail)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
