### PR TITLE
passes optional arguments through to makeAPICall()

### DIFF
--- a/lib/clients/web/facets/conversations.js
+++ b/lib/clients/web/facets/conversations.js
@@ -117,7 +117,7 @@ ConversationsFacet.prototype.info = function info(channel, opts, optCb) {
     channel: channel
   };
 
-  return this.makeAPICall('conversations.info', requiredArgs, null, optCb);
+  return this.makeAPICall('conversations.info', requiredArgs, opts, optCb);
 };
 
 


### PR DESCRIPTION
###  Summary

This addresses a small issue raised in #421 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
