### PR TITLE
Fix RTM_CONNECTION_OPENED event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ rtm.on(CLIENT_EVENTS.RTM.AUTHENTICATED, (connectData) => {
   console.log(`Logged in as ${appData.selfId} of team ${connectData.team.id}`);
 });
 
-// The client will emit an RTM.RTM_CONNECTION_OPEN the connection is ready for
+// The client will emit an RTM.RTM_CONNECTION_OPENED the connection is ready for
 // sending and recieving messages
-rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPEN, () => {
+rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPENED, () => {
   console.log(`Ready`);
 });
 


### PR DESCRIPTION
###  Summary

Fixes a typo in README for RTM_CONNECTION_OPEN to be RTM_CONNECTION_OPENED.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
