### PR TITLE
Fixes a bug where args were being overridden by previous requests when using requestOptionsTransport

### DIFF
--- a/lib/clients/transports/request.js
+++ b/lib/clients/transports/request.js
@@ -6,6 +6,7 @@ var HttpsProxyAgent = require('https-proxy-agent');
 var has = require('lodash').has;
 var partial = require('lodash').partial;
 var defaults = require('lodash').defaults;
+var cloneDeep = require('lodash').cloneDeep;
 var request = require('request');
 
 var handleRequestTranportRes = function handleRequestTranportRes(cb, err, response, body) {
@@ -64,7 +65,8 @@ var proxiedRequestTransport = function proxiedRequestTransport(proxyURL) {
 
 var requestOptionsTransport = function requestOptionsTransport(options) {
   return function _requestOptionsTransport(args, cb) {
-    var requestArgs = defaults(options, getRequestTransportArgs(args));
+    var instanceOptions = cloneDeep(options);
+    var requestArgs = defaults(instanceOptions, getRequestTransportArgs(args));
     request.post(requestArgs, partial(handleRequestTranportRes, cb));
   };
 };


### PR DESCRIPTION
###  Summary

There's a bug when using the requestOptionsTransport where the options object starts storing arguments from previous requests. This makes a clone of the object so that even if it's mutated, a new one is used for each request.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
