### PR TITLE
adds ga-beacon for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/slackapi/node-slack-sdk.svg?branch=master)](https://travis-ci.org/slackapi/node-slack-sdk)
 [![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
 [![npm (scoped)](https://img.shields.io/npm/v/@slack/client.svg)](https://www.npmjs.com/package/@slack/client)
+[![Analytics](https://ga-beacon.appspot.com/UA-56978219-13?pixel&useReferer)](https://github.com/slackapi/ga-beacon)
 
 Visit the [full documentation](https://slackapi.github.io/node-slack-sdk) for all the lovely details.
 


### PR DESCRIPTION
###  Summary

Adds instrumentation to the README for analysis in Google Analytics

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
