### PR TITLE
docs issue: typo in webclient request concurrency section

### DIFF
--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -226,10 +226,8 @@ but you can configure this with the `maxRequestConcurrency` option.
 const { WebClient } = require('@slack/client');
 const token = process.env.SLACK_TOKEN;
 const web = new WebClient(token, {
-  retryConfig: {
-    // Allow up to 10 requests to be in-flight at a time
-    maxRequestConcurrency: 10,
-  },
+  // Allow up to 10 requests to be in-flight at a time
+  maxRequestConcurrency: 10,
 });
 ```
 


### PR DESCRIPTION
###  Summary

fixes #453 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
