### PR TITLE
fix RTM_CONNECTION_OPENED name in docs

### DIFF
--- a/docs/_pages/rtm_client.md
+++ b/docs/_pages/rtm_client.md
@@ -79,9 +79,9 @@ rtm.on(CLIENT_EVENTS.RTM.AUTHENTICATED, (connectData) => {
   console.log(`Logged in as ${appData.selfId} of team ${connectData.team.id}`);
 });
 
-// The client will emit an RTM.RTM_CONNECTION_OPEN the connection is ready for
+// The client will emit an RTM.RTM_CONNECTION_OPENED the connection is ready for
 // sending and recieving messages
-rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPEN, () => {
+rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPENED, () => {
   console.log(`Ready`);
 });
 
@@ -117,7 +117,7 @@ const web = new WebClient(token);
 // Load the current channels list asynchrously
 let channelListPromise = web.channels.list();
 
-rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPEN, () => {
+rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPENED, () => {
   console.log(`Ready`);
   // Wait for the channels list response
   channelsListPromise.then((res) => {
@@ -248,7 +248,7 @@ const timeTrackingChannelId = 'C123456';
 
 
 // RTM event handling
-rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPEN, () => {
+rtm.on(CLIENT_EVENTS.RTM.RTM_CONNECTION_OPENED, () => {
   rtm.subscribePresence(getTrackedUsers());
 });
 


### PR DESCRIPTION
###  Summary

Change `RTM_CONNECTINO_OPENED` event name in docs. #446 only fixes this in Readme file, but not in the [docs](https://slackapi.github.io/node-slack-sdk/rtm_api).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
