### PR TITLE
Fix ChatPostMessageArguments.as_user type

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -191,7 +191,7 @@ export type ChatPostEphemeralArguments = TokenOverridable & {
 export type ChatPostMessageArguments = TokenOverridable & {
   channel: string;
   text: string;
-  as_user?: string;
+  as_user?: boolean;
   attachments?: MessageAttachment[];
   icon_emoji?: string; // if specified, as_user must be false
   icon_url?: string;


### PR DESCRIPTION
###  Summary

Fixes the type of `ChatPostMessageArguments.as_user` per the [docs](https://api.slack.com/methods/chat.postMessage).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
