### PR TITLE
fix formatting in markdown

### DIFF
--- a/docs/_reference/WebClient.md
+++ b/docs/_reference/WebClient.md
@@ -5,216 +5,17 @@ permalink: /reference/WebClient
 ---
 A client for Slack's Web API
 
-This client provides a function for each [Web API method](https://api.slack.com/methods). They are each
+This client provides an alias for each [Web API method](https://api.slack.com/methods). Each method is
 a convenience wrapper for calling the [WebClient#apiCall](WebClient#apiCall) method using the method name as the first parameter.
 
-**Kind**: static class of [<code>@slack/client</code>](#module_@slack/client)  
-**Extends**: <code>EventEmitter</code>  
+**Kind**: static class of [<code>@slack/client</code>](#module_@slack/client)
+**Extends**: <code>EventEmitter</code>
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
 | [token] | <code>string</code> | Authentication and authorization token for accessing Slack Web API (usually begins with `xoxp`, `xoxb`, or `xoxa`) |
 | [slackApiUrl] | <code>string</code> | The base URL for reaching Slack's Web API. Consider changing this value for testing purposes. |
-| [api={
-    test: (this.apiCall.bind(this, 'api.test')) as Method<methods.APITestArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | api method family |
-| [apps={
-    permissions: {
-      info: (this.apiCall.bind(this, 'apps.permissions.info')) as Method<methods.AppsPermissionsInfoArguments>,
-      request: (this.apiCall.bind(this, 'apps.permissions.request')) as Method<methods.AppsPermissionsRequestArguments>,
-    },
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | apps method family |
-| [auth={
-    revoke: (this.apiCall.bind(this, 'auth.revoke')) as Method<methods.AuthRevokeArguments>,
-    test: (this.apiCall.bind(this, 'auth.test')) as Method<methods.AuthTestArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | auth method family |
-| [bots={
-    info: (this.apiCall.bind(this, 'bots.info')) as Method<methods.BotsInfoArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | bots method family |
-| [channels={
-    archive: (this.apiCall.bind(this, 'channels.archive')) as Method<methods.ChannelsArchiveArguments>,
-    create: (this.apiCall.bind(this, 'channels.create')) as Method<methods.ChannelsCreateArguments>,
-    history: (this.apiCall.bind(this, 'channels.history')) as Method<methods.ChannelsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'channels.info')) as Method<methods.ChannelsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'channels.invite')) as Method<methods.ChannelsInviteArguments>,
-    join: (this.apiCall.bind(this, 'channels.join')) as Method<methods.ChannelsJoinArguments>,
-    kick: (this.apiCall.bind(this, 'channels.kick')) as Method<methods.ChannelsKickArguments>,
-    leave: (this.apiCall.bind(this, 'channels.leave')) as Method<methods.ChannelsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'channels.list')) as Method<methods.ChannelsListArguments>,
-    mark: (this.apiCall.bind(this, 'channels.mark')) as Method<methods.ChannelsMarkArguments>,
-    rename: (this.apiCall.bind(this, 'channels.rename')) as Method<methods.ChannelsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'channels.replies')) as Method<methods.ChannelsRepliesArguments>,
-    setPurpose: (this.apiCall.bind(this, 'channels.setPurpose')) as Method<methods.ChannelsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'channels.setTopic')) as Method<methods.ChannelsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'channels.unarchive')) as Method<methods.ChannelsUnarchiveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | channels method family |
-| [chat={
-    delete: (this.apiCall.bind(this, 'chat.delete')) as Method<methods.ChatDeleteArguments>,
-    getPermalink: (this.apiCall.bind(this, 'chat.getPermalink')) as Method<methods.ChatGetPermalinkArguments>,
-    meMessage: (this.apiCall.bind(this, 'chat.meMessage')) as Method<methods.ChatMeMessageArguments>,
-    postEphemeral: (this.apiCall.bind(this, 'chat.postEphemeral')) as Method<methods.ChatPostEphemeralArguments>,
-    postMessage: (this.apiCall.bind(this, 'chat.postMessage')) as Method<methods.ChatPostMessageArguments>,
-    unfurl: (this.apiCall.bind(this, 'chat.unfurl')) as Method<methods.ChatUnfurlArguments>,
-    update: (this.apiCall.bind(this, 'chat.update')) as Method<methods.ChatUpdateArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | chat method family |
-| [conversations={
-    archive: (this.apiCall.bind(this, 'conversations.archive')) as Method<methods.ConversationsArchiveArguments>,
-    close: (this.apiCall.bind(this, 'conversations.close')) as Method<methods.ConversationsCloseArguments>,
-    create: (this.apiCall.bind(this, 'conversations.create')) as Method<methods.ConversationsCreateArguments>,
-    history: (this.apiCall.bind(this, 'conversations.history')) as Method<methods.ConversationsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'conversations.info')) as Method<methods.ConversationsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'conversations.invite')) as Method<methods.ConversationsInviteArguments>,
-    join: (this.apiCall.bind(this, 'conversations.join')) as Method<methods.ConversationsJoinArguments>,
-    kick: (this.apiCall.bind(this, 'conversations.kick')) as Method<methods.ConversationsKickArguments>,
-    leave: (this.apiCall.bind(this, 'conversations.leave')) as Method<methods.ConversationsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'conversations.list')) as Method<methods.ConversationsListArguments>,
-    members: (this.apiCall.bind(this, 'conversations.members')) as Method<methods.ConversationsMembersArguments>,
-    open: (this.apiCall.bind(this, 'conversations.open')) as Method<methods.ConversationsOpenArguments>,
-    rename: (this.apiCall.bind(this, 'conversations.rename')) as Method<methods.ConversationsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'conversations.replies')) as Method<methods.ConversationsRepliesArguments>,
-    setPurpose:
-      (this.apiCall.bind(this, 'conversations.setPurpose')) as Method<methods.ConversationsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'conversations.setTopic')) as Method<methods.ConversationsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'conversations.unarchive')) as Method<methods.ConversationsUnarchiveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | conversations method family |
-| [dialog={
-    open: (this.apiCall.bind(this, 'dialog.open')) as Method<methods.DialogOpenArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | dialog method family |
-| [dnd={
-    endDnd: (this.apiCall.bind(this, 'dnd.endDnd')) as Method<methods.DndEndDndArguments>,
-    endSnooze: (this.apiCall.bind(this, 'dnd.endSnooze')) as Method<methods.DndEndSnoozeArguments>,
-    info: (this.apiCall.bind(this, 'dnd.info')) as Method<methods.DndInfoArguments>,
-    setSnooze: (this.apiCall.bind(this, 'dnd.setSnooze')) as Method<methods.DndSetSnoozeArguments>,
-    teamInfo: (this.apiCall.bind(this, 'dnd.teamInfo')) as Method<methods.DndTeamInfoArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | dnd method family |
-| [emoji={
-    list: (this.apiCall.bind(this, 'emoji.list')) as Method<methods.EmojiListArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | emoji method family |
-| [files={
-    delete: (this.apiCall.bind(this, 'files.delete')) as Method<methods.FilesDeleteArguments>,
-    info: (this.apiCall.bind(this, 'files.info')) as Method<methods.FilesInfoArguments>,
-    list: (this.apiCall.bind(this, 'files.list')) as Method<methods.FilesListArguments>,
-    revokePublicURL:
-      (this.apiCall.bind(this, 'files.revokePublicURL')) as Method<methods.FilesRevokePublicURLArguments>,
-    sharedPublicURL:
-      (this.apiCall.bind(this, 'files.sharedPublicURL')) as Method<methods.FilesSharedPublicURLArguments>,
-    upload: (this.apiCall.bind(this, 'files.upload')) as Method<methods.FilesUploadArguments>,
-    comments: {
-      add: (this.apiCall.bind(this, 'files.comments.add')) as Method<methods.FilesCommentsAddArguments>,
-      delete: (this.apiCall.bind(this, 'files.comments.delete')) as Method<methods.FilesCommentsDeleteArguments>,
-      edit: (this.apiCall.bind(this, 'files.comments.edit')) as Method<methods.FilesCommentsEditArguments>,
-    },
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | files method family |
-| [groups={
-    archive: (this.apiCall.bind(this, 'groups.archive')) as Method<methods.GroupsArchiveArguments>,
-    create: (this.apiCall.bind(this, 'groups.create')) as Method<methods.GroupsCreateArguments>,
-    createChild: (this.apiCall.bind(this, 'groups.createChild')) as Method<methods.GroupsCreateChildArguments>,
-    history: (this.apiCall.bind(this, 'groups.history')) as Method<methods.GroupsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'groups.info')) as Method<methods.GroupsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'groups.invite')) as Method<methods.GroupsInviteArguments>,
-    kick: (this.apiCall.bind(this, 'groups.kick')) as Method<methods.GroupsKickArguments>,
-    leave: (this.apiCall.bind(this, 'groups.leave')) as Method<methods.GroupsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'groups.list')) as Method<methods.GroupsListArguments>,
-    mark: (this.apiCall.bind(this, 'groups.mark')) as Method<methods.GroupsMarkArguments>,
-    open: (this.apiCall.bind(this, 'groups.open')) as Method<methods.GroupsOpenArguments>,
-    rename: (this.apiCall.bind(this, 'groups.rename')) as Method<methods.GroupsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'groups.replies')) as Method<methods.GroupsRepliesArguments>,
-    setPurpose: (this.apiCall.bind(this, 'groups.setPurpose')) as Method<methods.GroupsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'groups.setTopic')) as Method<methods.GroupsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'groups.unarchive')) as Method<methods.GroupsUnarchiveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | groups method family |
-| [im={
-    close: (this.apiCall.bind(this, 'im.close')) as Method<methods.IMCloseArguments>,
-    history: (this.apiCall.bind(this, 'im.history')) as Method<methods.IMHistoryArguments>,
-    list: (this.apiCall.bind(this, 'im.list')) as Method<methods.IMListArguments>,
-    mark: (this.apiCall.bind(this, 'im.mark')) as Method<methods.IMMarkArguments>,
-    open: (this.apiCall.bind(this, 'im.open')) as Method<methods.IMOpenArguments>,
-    replies: (this.apiCall.bind(this, 'im.replies')) as Method<methods.IMRepliesArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | im method family |
-| [migration={
-    exchange: (this.apiCall.bind(this, 'migration.exchange')) as Method<methods.MigrationExchangeArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | migration method family |
-| [mpim={
-    close: (this.apiCall.bind(this, 'mpim.close')) as Method<methods.MPIMCloseArguments>,
-    history: (this.apiCall.bind(this, 'mpim.history')) as Method<methods.MPIMHistoryArguments>,
-    list: (this.apiCall.bind(this, 'mpim.list')) as Method<methods.MPIMListArguments>,
-    mark: (this.apiCall.bind(this, 'mpim.mark')) as Method<methods.MPIMMarkArguments>,
-    open: (this.apiCall.bind(this, 'mpim.open')) as Method<methods.MPIMOpenArguments>,
-    replies: (this.apiCall.bind(this, 'mpim.replies')) as Method<methods.MPIMRepliesArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | mpim method family |
-| [oauth={
-    access: (this.apiCall.bind(this, 'oauth.access')) as Method<methods.OAuthAccessArguments>,
-    token: (this.apiCall.bind(this, 'oauth.token')) as Method<methods.OAuthTokenArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | oauth method family |
-| [pins={
-    add: (this.apiCall.bind(this, 'pins.add')) as Method<methods.PinsAddArguments>,
-    list: (this.apiCall.bind(this, 'pins.list')) as Method<methods.PinsListArguments>,
-    remove: (this.apiCall.bind(this, 'pins.remove')) as Method<methods.PinsRemoveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | pins method family |
-| [reactions={
-    add: (this.apiCall.bind(this, 'reactions.add')) as Method<methods.ReactionsAddArguments>,
-    get: (this.apiCall.bind(this, 'reactions.get')) as Method<methods.ReactionsGetArguments>,
-    list: (this.apiCall.bind(this, 'reactions.list')) as Method<methods.ReactionsListArguments>,
-    remove: (this.apiCall.bind(this, 'reactions.remove')) as Method<methods.ReactionsRemoveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | reactions method family |
-| [reminders={
-    add: (this.apiCall.bind(this, 'reminders.add')) as Method<methods.RemindersAddArguments>,
-    complete: (this.apiCall.bind(this, 'reminders.complete')) as Method<methods.RemindersCompleteArguments>,
-    delete: (this.apiCall.bind(this, 'reminders.delete')) as Method<methods.RemindersDeleteArguments>,
-    info: (this.apiCall.bind(this, 'reminders.info')) as Method<methods.RemindersInfoArguments>,
-    list: (this.apiCall.bind(this, 'reminders.list')) as Method<methods.RemindersListArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | reminders method family |
-| [rtm={
-    connect: (this.apiCall.bind(this, 'rtm.connect')) as Method<methods.RTMConnectArguments>,
-    start: (this.apiCall.bind(this, 'rtm.start')) as Method<methods.RTMStartArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | rtm method family |
-| [search={
-    all: (this.apiCall.bind(this, 'search.all')) as Method<methods.SearchAllArguments>,
-    files: (this.apiCall.bind(this, 'search.files')) as Method<methods.SearchFilesArguments>,
-    messages: (this.apiCall.bind(this, 'search.messages')) as Method<methods.SearchMessagesArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | search method family |
-| [stars={
-    add: (this.apiCall.bind(this, 'stars.add')) as Method<methods.StarsAddArguments>,
-    list: (this.apiCall.bind(this, 'stars.list')) as Method<methods.StarsListArguments>,
-    remove: (this.apiCall.bind(this, 'stars.remove')) as Method<methods.StarsRemoveArguments>,
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | stars method family |
-| [team={
-    accessLogs: (this.apiCall.bind(this, 'team.accessLogs')) as Method<methods.TeamAccessLogsArguments>,
-    billableInfo: (this.apiCall.bind(this, 'team.billableInfo')) as Method<methods.TeamBillableInfoArguments>,
-    info: (this.apiCall.bind(this, 'team.info')) as Method<methods.TeamInfoArguments>,
-    integrationLogs: (this.apiCall.bind(this, 'team.integrationLogs')) as Method<methods.TeamIntegrationLogsArguments>,
-    profile: {
-      get: (this.apiCall.bind(this, 'team.profile.get')) as Method<methods.TeamProfileGetArguments>,
-    },
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | team method family |
-| [usergroups={
-    create: (this.apiCall.bind(this, 'usergroups.create')) as Method<methods.UsergroupsCreateArguments>,
-    disable: (this.apiCall.bind(this, 'usergroups.disable')) as Method<methods.UsergroupsDisableArguments>,
-    enable: (this.apiCall.bind(this, 'usergroups.enable')) as Method<methods.UsergroupsEnableArguments>,
-    list: (this.apiCall.bind(this, 'usergroups.list')) as Method<methods.UsergroupsListArguments>,
-    update: (this.apiCall.bind(this, 'usergroups.update')) as Method<methods.UsergroupsUpdateArguments>,
-    users: {
-      list: (this.apiCall.bind(this, 'usergroups.users.list')) as Method<methods.UsergroupsUsersListArguments>,
-      update: (this.apiCall.bind(this, 'usergroups.users.update')) as Method<methods.UsergroupsUsersUpdateArguments>,
-    },
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | usergroups method family |
-| [users={
-    deletePhoto: (this.apiCall.bind(this, 'users.deletePhoto')) as Method<methods.UsersDeletePhotoArguments>,
-    getPresence: (this.apiCall.bind(this, 'users.getPresence')) as Method<methods.UsersGetPresenceArguments>,
-    identity: (this.apiCall.bind(this, 'users.identity')) as Method<methods.UsersIdentityArguments>,
-    info: (this.apiCall.bind(this, 'users.info')) as Method<methods.UsersInfoArguments>,
-    list: (this.apiCall.bind(this, 'users.list')) as Method<methods.UsersListArguments>,
-    lookupByEmail: (this.apiCall.bind(this, 'users.lookupByEmail')) as Method<methods.UsersLookupByEmailArguments>,
-    setActive: (this.apiCall.bind(this, 'users.setActive')) as Method<methods.UsersSetActiveArguments>,
-    setPhoto: (this.apiCall.bind(this, 'users.setPhoto')) as Method<methods.UsersSetPhotoArguments>,
-    setPresence: (this.apiCall.bind(this, 'users.setPresence')) as Method<methods.UsersSetPresenceArguments>,
-    profile: {
-      get: (this.apiCall.bind(this, 'users.profile.get')) as Method<methods.UsersProfileGetArguments>,
-      set: (this.apiCall.bind(this, 'users.profile.set')) as Method<methods.UsersProfileSetArguments>,
-    },
-  }] | <code>module:@slack/client/dist/WebClient.__object</code> | users method family |
-
 
 * [.WebClient](#module_@slack/client.WebClient) ⇐ <code>EventEmitter</code>
     * [.apiCall(method, options)](#module_@slack/client.WebClient+apiCall) ⇒ [<code>Promise.&lt;WebAPICallResult&gt;</code>](#module_@slack/client.WebAPICallResult)
@@ -226,7 +27,7 @@ a convenience wrapper for calling the [WebClient#apiCall](WebClient#apiCall) met
 ### webClient.apiCall(method, options) ⇒ [<code>Promise.&lt;WebAPICallResult&gt;</code>](#module_@slack/client.WebAPICallResult)
 Generic method for calling a Web API method
 
-**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)  
+**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -236,22 +37,22 @@ Generic method for calling a Web API method
 <a name="module_@slack/client.WebClient+apiCall"></a>
 
 ### webClient.apiCall(method, options, callback)
-**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)  
+**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)
 
 | Param | Type |
 | --- | --- |
-| method | <code>string</code> | 
-| options | [<code>WebAPICallOptions</code>](#module_@slack/client.WebAPICallOptions) | 
-| callback | [<code>WebAPIResultCallback</code>](#module_@slack/client.WebAPIResultCallback) | 
+| method | <code>string</code> |
+| options | [<code>WebAPICallOptions</code>](#module_@slack/client.WebAPICallOptions) |
+| callback | [<code>WebAPIResultCallback</code>](#module_@slack/client.WebAPIResultCallback) |
 
 <a name="module_@slack/client.WebClient+apiCall"></a>
 
 ### webClient.apiCall(method, options, callback)
-**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)  
+**Kind**: instance method of [<code>WebClient</code>](#module_@slack/client.WebClient)
 
 | Param | Type |
 | --- | --- |
-| method | <code>string</code> | 
-| options | [<code>WebAPICallOptions</code>](#module_@slack/client.WebAPICallOptions) | 
-| callback | [<code>WebAPIResultCallback</code>](#module_@slack/client.WebAPIResultCallback) | 
+| method | <code>string</code> |
+| options | [<code>WebAPICallOptions</code>](#module_@slack/client.WebAPICallOptions) |
+| callback | [<code>WebAPIResultCallback</code>](#module_@slack/client.WebAPIResultCallback) |
 

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -19,7 +19,7 @@ import Method, * as methods from './methods'; // tslint:disable-line:import-name
 /**
  * A client for Slack's Web API
  *
- * This client provides a function for each {@link https://api.slack.com/methods|Web API method}. They are each
+ * This client provides an alias for each {@link https://api.slack.com/methods|Web API method}. Each method is
  * a convenience wrapper for calling the {@link WebClient#apiCall} method using the method name as the first parameter.
  */
 export class WebClient extends EventEmitter {

--- a/support/jsdoc/@slack-client.js
+++ b/support/jsdoc/@slack-client.js
@@ -338,7 +338,7 @@ export class WebAPIResultCallback {
 /**
  * A client for Slack's Web API
  * 
- * This client provides a function for each {@link https://api.slack.com/methods|Web API method}. They are each
+ * This client provides an alias for each {@link https://api.slack.com/methods|Web API method}. Each method is
  * a convenience wrapper for calling the {@link WebClient#apiCall} method using the method name as the first parameter.
  * @extends EventEmitter
  * @property {string} [token] Authentication and authorization token for accessing Slack Web API (usually begins with `xoxp`, `xoxb`, or `xoxa`)


### PR DESCRIPTION
###  Summary

Unfortunately, the method aliases on the WebClient do not render using `ts2jsdoc` properly. In order to avoid issues when converting the JSDoc to markdown, this PR manually removes those properties from the JSDoc.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
