### PR TITLE
IncomingWebhook response parse fix

### DIFF
--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -1,0 +1,33 @@
+require('mocha');
+const { IncomingWebhook } = require('./IncomingWebhook');
+const { assert } = require('chai');
+const nock = require('nock');
+
+const url = 'https://hooks.slack.com/services/FAKEWEBHOOK';
+
+describe('IncomingWebhook', function () {
+
+  describe('constructor()', function () {
+    it('should build a default wehbook given a URL', function () {
+      const webhook = new IncomingWebhook(url);
+      assert.instanceOf(webhook, IncomingWebhook);
+    });
+  });
+
+  describe('send()', function () {
+    beforeEach(function () {
+      this.webhook = new IncomingWebhook(url);
+    });
+
+    it('should send a simple message', function () {
+      const scope = nock('https://hooks.slack.com')
+        .post(/services/)
+        .reply(200, 'ok');
+      this.webhook.send('Hello', (error) => {
+        assert.notOk(error);
+      });
+    });
+
+  });
+
+});

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -18,7 +18,7 @@ export interface IncomingWebhookSendArguments extends IncomingWebhookDefaultArgu
 }
 
 export interface IncomingWebhookResultCallback {
-  (error: Error, result: any): void;
+  (error: Error): void;
 }
 
 /**
@@ -35,7 +35,7 @@ export class IncomingWebhook {
    */
   private defaults: IncomingWebhookDefaultArguments;
 
-  constructor(url: string, defaults: IncomingWebhookDefaultArguments) {
+  constructor(url: string, defaults: IncomingWebhookDefaultArguments = {}) {
     if (url === undefined) {
       throw new Error('Incoming webhook URL is required');
     }
@@ -60,13 +60,12 @@ export class IncomingWebhook {
       payload = Object.assign(payload, message);
     }
 
-    const implementation = () => {
-      return got.post(this.url, {
-        json: true,
-        body: payload,
-        retries: 0,
-      });
-    };
+    const implementation = () => got.post(this.url, {
+      body: JSON.stringify(payload),
+      retries: 0,
+    }).then(() => {
+      return;
+    });
 
     callbackify(implementation)(callback);
   }

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -1,6 +1,6 @@
 import got = require('got'); // tslint:disable-line:no-require-imports
 import { MessageAttachment } from './methods';
-import { callbackify } from 'util';
+import { callbackify } from './util';
 
 export interface IncomingWebhookDefaultArguments {
   username?: string;


### PR DESCRIPTION
###  Summary

The response from a successful `IncomingWebhook.send()` is Content-Type `text/html`, not `application/json` that the code assumed (and the docs stated). This PR fixes that.

fixes #479, fixes #477

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
