### PR TITLE
allow unspecified arguments, fixes #484

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -8,13 +8,17 @@ import { WebAPICallOptions, WebAPIResultCallback, WebAPICallResult } from './Web
  */
 export default interface Method<MethodArguments extends WebAPICallOptions> {
   // TODO: can we create a relationship between MethodArguments and a MethodResult type?
-  (options?: MethodArguments): Promise<WebAPICallResult>;
-  (options: MethodArguments, callback: WebAPIResultCallback): void;
+  (options?: MethodArguments & AuxiliaryArguments): Promise<WebAPICallResult>;
+  (options: MethodArguments & AuxiliaryArguments, callback: WebAPIResultCallback): void;
 }
 
 /*
  * Reusable "protocols" that some MethodArguments types can conform to
  */
+
+export interface AuxiliaryArguments {
+  [unknownArg: string]: any;
+}
 
 export interface TokenOverridable {
   token?: string;


### PR DESCRIPTION
###  Summary

Fixes #484.

This PR adds the ability to use arguments not specified in the `MethodArguments` types (auxiliary arguments). For example:

```ts
web.chat.postEphemeral({
    user: 'not me',
    channel: 'somewhere',
    text: 'wait, what did that say?',

    extra_argument: 'one that doesnt exist, in fact'
});
```

Note that this preserves static errors for *missing* arguments, so if `channel` in the above example was missing, an error will still be thrown (when using types, of course).

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).