### PR TITLE
exports method argument types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export {
   WebAPIResultCallback,
 } from './WebClient';
 
+export * from './methods';
+
 export {
   RTMClient,
   RTMClientOptions,

--- a/test/typescript/sources/method-argument-types.ts
+++ b/test/typescript/sources/method-argument-types.ts
@@ -1,0 +1,28 @@
+import { WebClient, ChatPostMessageArguments } from '../../../dist';
+
+const web = new WebClient('TOKEN');
+
+// calling a method directly with arbitrary arguments should work
+web.chat.postMessage({
+  channel: 'CHANNEL',
+  text: 'TEXT',
+  key: 'VALUE',
+});
+
+// calling a method directly with underspecified arguments should not work
+// typings:expect-error
+web.chat.postMessage({
+  channel: 'CHANNEL',
+});
+
+// assigning an object with a specific type that includes arbitrary arguments should not work
+const message: ChatPostMessageArguments = {
+  text: 'TEXT',
+  channel: 'CHANNEL',
+  // typings:expect-error
+  key: 'VALUE',
+};
+
+// this is just here to avoid the following error:
+// 'message' is declared but its value is never read.
+console.log(message);

--- a/test/typescript/test.ts
+++ b/test/typescript/test.ts
@@ -5,5 +5,9 @@ describe('typescript typings tests', () => {
   it('should allow WebClient to work without a token', () => {
     check([`${__dirname}/sources/webclient-no-token.ts`], `${__dirname}/tsconfig-strict.json`);
   });
+
+  it('should export method argument types and enforce strictness in the right ways', () => {
+    check([`${__dirname}/sources/method-argument-types.ts`], `${__dirname}/tsconfig-strict.json`);
+  });
 });
 


### PR DESCRIPTION
###  Summary

fixes #483

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
