### PR TITLE
more tightly specifies OAuthAccessArguments and OAuthTokenArguments

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -329,8 +329,19 @@ export type MPIMRepliesArguments = TokenOverridable & {};
   /*
    * `oauth.*`
    */
-export type OAuthAccessArguments = TokenOverridable & {};
-export type OAuthTokenArguments = TokenOverridable & {};
+export type OAuthAccessArguments = {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  redirect_uri?: string;
+};
+export type OAuthTokenArguments = {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  redirect_uri?: string;
+  single_channel?: boolean;
+};
 
   /*
    * `pins.*`


### PR DESCRIPTION
###  Summary

fixes #481

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
