### PR TITLE
Make IncomingWebhook `send` promisable

### DIFF
--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -30,14 +30,16 @@ describe('IncomingWebhook', function () {
       it('should return results in a Promise', function () {
         const result = this.webhook.send('Hello');
         assert(isPromise(result));
-        return result.then(() => {
+        return result.then((result) => {
+          assert.strictEqual(result.text, 'ok');
           this.scope.done();
         });
       });
 
       it('should deliver results in a callback', function (done) {
-        this.webhook.send('Hello', (error) => {
+        this.webhook.send('Hello', (error, result) => {
           assert.notOk(error);
+          assert.strictEqual(result.text, 'ok');
           this.scope.done();
           done();
         });
@@ -56,12 +58,14 @@ describe('IncomingWebhook', function () {
         assert(isPromise(result));
         result.catch((error) => {
           assert.ok(error);
+          assert.instanceOf(error, Error);
           done();
         });
       });
 
       it('should deliver the error in a callback', function (done) {
         this.webhook.send('Hello', (error) => {
+          assert.ok(error);
           assert.instanceOf(error, Error);
           done();
         });

--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -1,6 +1,7 @@
 require('mocha');
 const { IncomingWebhook } = require('./IncomingWebhook');
 const { assert } = require('chai');
+const isPromise = require('p-is-promise');
 const nock = require('nock');
 
 const url = 'https://hooks.slack.com/services/FAKEWEBHOOK';
@@ -19,15 +20,52 @@ describe('IncomingWebhook', function () {
       this.webhook = new IncomingWebhook(url);
     });
 
-    it('should send a simple message', function () {
-      const scope = nock('https://hooks.slack.com')
-        .post(/services/)
-        .reply(200, 'ok');
-      this.webhook.send('Hello', (error) => {
-        assert.notOk(error);
+    describe('when making a successful call', function () {
+      beforeEach(function () {
+        this.scope = nock('https://hooks.slack.com')
+          .post(/services/)
+          .reply(200, 'ok');
+      });
+
+      it('should return results in a Promise', function () {
+        const result = this.webhook.send('Hello');
+        assert(isPromise(result));
+        return result.then(() => {
+          this.scope.done();
+        });
+      });
+
+      it('should deliver results in a callback', function (done) {
+        this.webhook.send('Hello', (error) => {
+          assert.notOk(error);
+          this.scope.done();
+          done();
+        });
       });
     });
 
-  });
+    describe('when the call fails', function () {
+      beforeEach(function () {
+        this.scope = nock('https://hooks.slack.com')
+          .post(/services/)
+          .reply(500);
+      });
 
+      it('should return a Promise which rejects on error', function (done) {
+        const result = this.webhook.send('Hello');
+        assert(isPromise(result));
+        result.catch((error) => {
+          assert.ok(error);
+          done();
+        });
+      });
+
+      it('should deliver the error in a callback', function (done) {
+        this.webhook.send('Hello', (error) => {
+          assert.instanceOf(error, Error);
+          done();
+        });
+      });
+    });
+  });
 });

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -49,7 +49,10 @@ export class IncomingWebhook {
    * @param message the message (a simple string, or an object describing the message)
    * @param callback
    */
-  public send(message: string | IncomingWebhookSendArguments, callback: IncomingWebhookResultCallback): void {
+  public send(message: string | IncomingWebhookSendArguments): Promise<void>;
+  public send(message: string | IncomingWebhookSendArguments, callback: IncomingWebhookResultCallback): void;
+  public send(message: string | IncomingWebhookSendArguments,
+              callback?: IncomingWebhookResultCallback): Promise<void> | void {
     // NOTE: no support for proxy
     // NOTE: no support for TLS config
     let payload: IncomingWebhookSendArguments = this.defaults;
@@ -67,6 +70,10 @@ export class IncomingWebhook {
       return;
     });
 
-    callbackify(implementation)(callback);
+    if (callback !== undefined) {
+      callbackify(implementation)(callback);
+      return;
+    }
+    return implementation();
   }
 }

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -1,25 +1,7 @@
 import got = require('got'); // tslint:disable-line:no-require-imports
+import { CodedError, errorWithCode, ErrorCode } from './errors';
 import { MessageAttachment } from './methods';
 import { callbackify } from './util';
-
-export interface IncomingWebhookDefaultArguments {
-  username?: string;
-  icon_emoji?: string; // SEMVER:MAJOR used to be iconEmoji
-  icon_url?: string; // SEMVER:MAJOR used to be iconUrl
-  channel?: string;
-  text?: string;
-  link_names?: boolean; // SEMVER:MAJOR used to be linkNames
-}
-
-export interface IncomingWebhookSendArguments extends IncomingWebhookDefaultArguments {
-  attachments?: MessageAttachment[];
-  unfurl_links?: boolean;
-  unful_media?: boolean;
-}
-
-export interface IncomingWebhookResultCallback {
-  (error: Error): void;
-}
 
 /**
  * A client for Slack's Incoming Webhooks
@@ -49,10 +31,10 @@ export class IncomingWebhook {
    * @param message the message (a simple string, or an object describing the message)
    * @param callback
    */
-  public send(message: string | IncomingWebhookSendArguments): Promise<void>;
+  public send(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult>;
   public send(message: string | IncomingWebhookSendArguments, callback: IncomingWebhookResultCallback): void;
   public send(message: string | IncomingWebhookSendArguments,
-              callback?: IncomingWebhookResultCallback): Promise<void> | void {
+              callback?: IncomingWebhookResultCallback): Promise<IncomingWebhookResult> | void {
     // NOTE: no support for proxy
     // NOTE: no support for TLS config
     let payload: IncomingWebhookSendArguments = this.defaults;
@@ -66,9 +48,23 @@ export class IncomingWebhook {
     const implementation = () => got.post(this.url, {
       body: JSON.stringify(payload),
       retries: 0,
-    }).then(() => {
-      return;
-    });
+    })
+      .catch((error: got.GotError) => {
+        // Wrap errors in this packages own error types (abstract the implementation details' types)
+        switch (error.name) {
+          case 'RequestError':
+            throw requestErrorWithOriginal(error);
+          case 'ReadError':
+            throw readErrorWithOriginal(error);
+          case 'HTTPError':
+            throw httpErrorWithOriginal(error);
+          default:
+            throw error;
+        }
+      })
+      .then((response: got.Response<string>) => {
+        return this.buildResult(response);
+      });
 
     if (callback !== undefined) {
       callbackify(implementation)(callback);
@@ -76,4 +72,106 @@ export class IncomingWebhook {
     }
     return implementation();
   }
+
+  /**
+   * Processes an HTTP response into an IncomingWebhookResult.
+   * @param response
+   */
+  private buildResult(response: got.Response<string>): IncomingWebhookResult {
+    return {
+      text: response.body,
+    };
+  }
+}
+
+/*
+ * Exported types
+ */
+
+export interface IncomingWebhookDefaultArguments {
+  username?: string;
+  icon_emoji?: string; // SEMVER:MAJOR used to be iconEmoji
+  icon_url?: string; // SEMVER:MAJOR used to be iconUrl
+  channel?: string;
+  text?: string;
+  link_names?: boolean; // SEMVER:MAJOR used to be linkNames
+}
+
+export interface IncomingWebhookSendArguments extends IncomingWebhookDefaultArguments {
+  attachments?: MessageAttachment[];
+  unfurl_links?: boolean;
+  unful_media?: boolean;
+}
+
+export interface IncomingWebhookResult {
+  text: string;
+}
+
+export interface IncomingWebhookResultCallback {
+  (error: IncomingWebhookSendError, result: IncomingWebhookResult): void;
+}
+
+export type IncomingWebhookSendError = IncomingWebhookRequestError | IncomingWebhookReadError |
+                                       IncomingWebhookHTTPError;
+
+export interface IncomingWebhookRequestError extends CodedError {
+  code: ErrorCode.IncomingWebhookRequestError;
+  original: Error;
+}
+
+export interface IncomingWebhookReadError extends CodedError {
+  code: ErrorCode.IncomingWebhookReadError;
+  original: Error;
+}
+
+export interface IncomingWebhookHTTPError extends CodedError {
+  code: ErrorCode.IncomingWebhookHTTPError;
+  original: Error;
+}
+
+/*
+ * Helpers
+ */
+
+/**
+ * A factory to create IncomingWebhookRequestError objects
+ * @param original The original error
+ */
+function requestErrorWithOriginal(original: Error): IncomingWebhookRequestError {
+  const error = errorWithCode(
+    // `any` cast is used because the got definition file doesn't export the got.RequestError type
+    new Error(`A request error occurred: ${(original as any).code}`),
+    ErrorCode.IncomingWebhookRequestError,
+  ) as Partial<IncomingWebhookRequestError>;
+  error.original = original;
+  return (error as IncomingWebhookRequestError);
+}
+
+
+/**
+ * A factory to create IncomingWebhookReadError objects
+ * @param original The original error
+ */
+function readErrorWithOriginal(original: Error): IncomingWebhookReadError {
+  const error = errorWithCode(
+    new Error('A response read error occurred'),
+    ErrorCode.IncomingWebhookReadError,
+  ) as Partial<IncomingWebhookReadError>;
+  error.original = original;
+  return (error as IncomingWebhookReadError);
+}
+
+
+/**
+ * A factory to create IncomingWebhookHTTPError objects
+ * @param original The original error
+ */
+function httpErrorWithOriginal(original: Error): IncomingWebhookHTTPError {
+  const error = errorWithCode(
+    // `any` cast is used because the got definition file doesn't export the got.HTTPError type
+    new Error(`An HTTP protocol error occurred: statusCode = ${(original as any).statusCode}`),
+    ErrorCode.IncomingWebhookHTTPError,
+  ) as Partial<IncomingWebhookHTTPError>;
+  error.original = original;
+  return (error as IncomingWebhookHTTPError);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,6 +31,11 @@ export enum ErrorCode {
   KeepAliveConfigError = 'slackclient_keepalive_config_error',
   KeepAliveClientNotConnected = 'slackclient_keepalive_client_not_connected',
   KeepAliveInconsistentState = 'slackclient_keepalive_inconsistent_state',
+
+  // IncomingWebhook
+  IncomingWebhookRequestError = 'slackclient_incomingwebhook_request_error',
+  IncomingWebhookReadError = 'slackclient_incomingwebhook_read_error',
+  IncomingWebhookHTTPError = 'slackclient_incomingwebhook_http_error',
 }
 
 /**


### PR DESCRIPTION
###  Summary

Saw #501, decided the addition would be easy because `IncomingWebhook#send` was already defined as if it was planned to be promisable.

I also set up the tests to be similar to that of `WebClient` for testing the result of a method that can callback or promise.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
