### PR TITLE
Fill out remaining method arguments

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,3 +1,4 @@
+import { Stream } from 'stream';
 import { WebAPICallOptions, WebAPIResultCallback, WebAPICallResult } from './WebClient';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -372,7 +373,7 @@ export type FilesSharedPublicURLArguments = TokenOverridable & {
 export type FilesUploadArguments = TokenOverridable & {
   channels?: string; // comma-separated list of channels
   content?: string; // if absent, must provide `file`
-  file?: Buffer; // if absent, must provide `content`
+  file?: Buffer | Stream; // if absent, must provide `content`
   filename?: string;
   filetype?: string;
   initial_comment?: string;
@@ -739,7 +740,7 @@ export type UsersLookupByEmailArguments = TokenOverridable & {
 };
 export type UsersSetActiveArguments = TokenOverridable; // deprecated & being removed may 8, 2018
 export type UsersSetPhotoArguments = TokenOverridable & {
-  image: Buffer;
+  image: Buffer | Stream;
   crop_w?: number;
   crop_x?: number;
   crop_y?: number;

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -42,6 +42,30 @@ export interface LocaleAware {
 /*
  * Reusable shapes for argument values
  */
+export interface Dialog {
+  title: string;
+  callback_id: string;
+  elements: {
+    type: 'text' | 'textarea' | 'select';
+    name: string; // shown to user
+    label: string; // shown to user
+    optional?: boolean;
+    placeholder?: string;
+    value?: string; // sent to app
+    // types `text` & `textarea`:
+    max_length?: number;
+    min_length?: number;
+    hint?: string;
+    subtype?: 'email' | 'number' | 'tel' | 'url';
+    // type `select`:
+    options?: {
+      label: string; // shown to user
+      value: string; // sent to app
+    }[];
+  }[];
+  submit_label?: string;
+}
+
 export interface MessageAttachment {
   fallback?: string; // either this or text must be defined
   color?: 'good' | 'warning' | 'danger' | string;
@@ -226,105 +250,267 @@ export type ChatUpdateArguments = TokenOverridable & {
   parse?: 'full' | 'none';
 };
 
-// TODO: fill out the rest of these arugment types
-
   /*
    * `conversations.*`
    */
-export type ConversationsArchiveArguments = TokenOverridable & {};
-export type ConversationsCloseArguments = TokenOverridable & {};
-export type ConversationsCreateArguments = TokenOverridable & {};
-export type ConversationsHistoryArguments = TokenOverridable & {};
-export type ConversationsInfoArguments = TokenOverridable & {};
-export type ConversationsInviteArguments = TokenOverridable & {};
-export type ConversationsJoinArguments = TokenOverridable & {};
-export type ConversationsKickArguments = TokenOverridable & {};
-export type ConversationsLeaveArguments = TokenOverridable & {};
-export type ConversationsListArguments = TokenOverridable & {};
-export type ConversationsMembersArguments = TokenOverridable & {};
-export type ConversationsOpenArguments = TokenOverridable & {};
-export type ConversationsRenameArguments = TokenOverridable & {};
-export type ConversationsRepliesArguments = TokenOverridable & {};
-export type ConversationsSetPurposeArguments = TokenOverridable & {};
-export type ConversationsSetTopicArguments = TokenOverridable & {};
-export type ConversationsUnarchiveArguments = TokenOverridable & {};
+export type ConversationsArchiveArguments = TokenOverridable & {
+  channel: string;
+};
+export type ConversationsCloseArguments = TokenOverridable & {
+  channel: string;
+};
+export type ConversationsCreateArguments = TokenOverridable & {
+  name: string;
+  is_private?: boolean;
+};
+export type ConversationsHistoryArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
+  channel: string;
+};
+export type ConversationsInfoArguments = TokenOverridable & LocaleAware & {
+  channel: string;
+};
+export type ConversationsInviteArguments = TokenOverridable & {
+  channel: string;
+  users: string; // comma-separated list of users
+};
+export type ConversationsJoinArguments = TokenOverridable & {
+  channel: string;
+};
+export type ConversationsKickArguments = TokenOverridable & {
+  channel: string;
+  user: string;
+};
+export type ConversationsLeaveArguments = TokenOverridable & {
+  channel: string;
+};
+export type ConversationsListArguments = TokenOverridable & CursorPaginationEnabled & {
+  exclude_archived?: boolean;
+  types?: string; // comma-separated list of conversation types
+};
+export type ConversationsMembersArguments = TokenOverridable & CursorPaginationEnabled & {
+  channel: string;
+};
+export type ConversationsOpenArguments = TokenOverridable & {
+  channel?: string;
+  users?: string; // comma-separated list of users
+  return_im?: boolean;
+};
+export type ConversationsRenameArguments = TokenOverridable & {
+  channel: string;
+  name: string;
+};
+export type ConversationsRepliesArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
+  channel: string;
+  ts: string;
+};
+export type ConversationsSetPurposeArguments = TokenOverridable & {
+  channel: string;
+  purpose: string;
+};
+export type ConversationsSetTopicArguments = TokenOverridable & {
+  channel: string;
+  topic: string;
+};
+export type ConversationsUnarchiveArguments = TokenOverridable & {
+  channel: string;
+};
 
   /*
    * `dialog.*`
    */
-export type DialogOpenArguments = TokenOverridable & {};
+export type DialogOpenArguments = TokenOverridable & {
+  trigger_id: string;
+  dialog: Dialog;
+};
 
   /*
    * `dnd.*`
    */
-export type DndEndDndArguments = TokenOverridable & {};
-export type DndEndSnoozeArguments = TokenOverridable & {};
-export type DndInfoArguments = TokenOverridable & {};
-export type DndSetSnoozeArguments = TokenOverridable & {};
-export type DndTeamInfoArguments = TokenOverridable & {};
+export type DndEndDndArguments = TokenOverridable;
+export type DndEndSnoozeArguments = TokenOverridable;
+export type DndInfoArguments = TokenOverridable & {
+  user: string;
+};
+export type DndSetSnoozeArguments = TokenOverridable & {
+  num_minutes: number;
+};
+export type DndTeamInfoArguments = TokenOverridable & {
+  users?: string; // comma-separated list of users
+};
 
   /*
    * `emoji.*`
    */
-export type EmojiListArguments = TokenOverridable & {};
+export type EmojiListArguments = TokenOverridable;
 
   /*
    * `files.*`
    */
-export type FilesDeleteArguments = TokenOverridable & {};
-export type FilesInfoArguments = TokenOverridable & {};
-export type FilesListArguments = TokenOverridable & {};
-export type FilesRevokePublicURLArguments = TokenOverridable & {};
-export type FilesSharedPublicURLArguments = TokenOverridable & {};
-export type FilesUploadArguments = TokenOverridable & {};
-export type FilesCommentsAddArguments = TokenOverridable & {};
-export type FilesCommentsDeleteArguments = TokenOverridable & {};
-export type FilesCommentsEditArguments = TokenOverridable & {};
+export type FilesDeleteArguments = TokenOverridable & {
+  file: string; // file id
+};
+export type FilesInfoArguments = TokenOverridable & {
+  file: string; // file id
+  count?: number;
+  page?: number;
+};
+export type FilesListArguments = TokenOverridable & {
+  channel?: string;
+  user?: string;
+  count?: number;
+  page?: number;
+  ts_from?: string;
+  ts_to?: string;
+  types?: string; // comma-separated list of file types
+};
+export type FilesRevokePublicURLArguments = TokenOverridable & {
+  file: string; // file id
+};
+export type FilesSharedPublicURLArguments = TokenOverridable & {
+  file: string; // file id
+};
+export type FilesUploadArguments = TokenOverridable & {
+  channels?: string; // comma-separated list of channels
+  content?: string; // if absent, must provide `file`
+  file?: Buffer; // if absent, must provide `content`
+  filename?: string;
+  filetype?: string;
+  initial_comment?: string;
+  title?: string;
+};
+export type FilesCommentsAddArguments = TokenOverridable & {
+  comment: string;
+  file: string; // file id
+};
+export type FilesCommentsDeleteArguments = TokenOverridable & {
+  file: string; // file id
+  id: string; // comment id
+};
+export type FilesCommentsEditArguments = TokenOverridable & {
+  comment: string;
+  file: string; // file id
+  id: string; // comment id
+};
 
   /*
    * `groups.*`
    */
-export type GroupsArchiveArguments = TokenOverridable & {};
-export type GroupsCreateArguments = TokenOverridable & {};
-export type GroupsCreateChildArguments = TokenOverridable & {};
-export type GroupsHistoryArguments = TokenOverridable & {};
-export type GroupsInfoArguments = TokenOverridable & {};
-export type GroupsInviteArguments = TokenOverridable & {};
-export type GroupsKickArguments = TokenOverridable & {};
-export type GroupsLeaveArguments = TokenOverridable & {};
-export type GroupsListArguments = TokenOverridable & {};
-export type GroupsMarkArguments = TokenOverridable & {};
-export type GroupsOpenArguments = TokenOverridable & {};
-export type GroupsRenameArguments = TokenOverridable & {};
-export type GroupsRepliesArguments = TokenOverridable & {};
-export type GroupsSetPurposeArguments = TokenOverridable & {};
-export type GroupsSetTopicArguments = TokenOverridable & {};
-export type GroupsUnarchiveArguments = TokenOverridable & {};
+export type GroupsArchiveArguments = TokenOverridable & {
+  channel: string;
+};
+export type GroupsCreateArguments = TokenOverridable & {
+  name: string;
+  validate?: boolean;
+};
+export type GroupsCreateChildArguments = TokenOverridable & {
+  channel: string;
+};
+export type GroupsHistoryArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
+  channel: string;
+  unreads?: boolean;
+};
+export type GroupsInfoArguments = TokenOverridable & LocaleAware & {
+  channel: string;
+};
+export type GroupsInviteArguments = TokenOverridable & {
+  channel: string;
+  user: string;
+};
+export type GroupsKickArguments = TokenOverridable & {
+  channel: string;
+  user: string;
+};
+export type GroupsLeaveArguments = TokenOverridable & {
+  channel: string;
+};
+export type GroupsListArguments = TokenOverridable & {
+  exclude_archived?: boolean;
+  exclude_members?: boolean;
+};
+export type GroupsMarkArguments = TokenOverridable & {
+  channel: string;
+  ts: string;
+};
+export type GroupsOpenArguments = TokenOverridable & {
+  channel: string;
+};
+export type GroupsRenameArguments = TokenOverridable & {
+  channel: string;
+  name: string;
+  validate?: boolean;
+};
+export type GroupsRepliesArguments = TokenOverridable & {
+  channel: string;
+  thread_ts: boolean;
+};
+export type GroupsSetPurposeArguments = TokenOverridable & {
+  channel: string;
+  purpose: string;
+};
+export type GroupsSetTopicArguments = TokenOverridable & {
+  channel: string;
+  topic: string;
+};
+export type GroupsUnarchiveArguments = TokenOverridable & {
+  channel: string;
+};
 
   /*
    * `im.*`
    */
-export type IMCloseArguments = TokenOverridable & {};
-export type IMHistoryArguments = TokenOverridable & {};
-export type IMListArguments = TokenOverridable & {};
-export type IMMarkArguments = TokenOverridable & {};
-export type IMOpenArguments = TokenOverridable & {};
-export type IMRepliesArguments = TokenOverridable & {};
+export type IMCloseArguments = TokenOverridable & {
+  channel: string;
+};
+export type IMHistoryArguments = TokenOverridable & TimelinePaginationEnabled & {
+  channel: string;
+  count?: number;
+  unreads?: boolean;
+};
+export type IMListArguments = TokenOverridable & CursorPaginationEnabled;
+export type IMMarkArguments = TokenOverridable & {
+  channel: string;
+  ts: string;
+};
+export type IMOpenArguments = TokenOverridable & LocaleAware & {
+  user: string;
+  return_im?: boolean;
+};
+export type IMRepliesArguments = TokenOverridable & {
+  channel: string;
+  thread_ts?: string;
+};
 
   /*
    * `migration.*`
    */
-export type MigrationExchangeArguments = TokenOverridable & {};
+export type MigrationExchangeArguments = TokenOverridable & {
+  users: string; // comma-separated list of users
+  to_old?: boolean;
+};
 
   /*
    * `mpim.*`
    */
-export type MPIMCloseArguments = TokenOverridable & {};
-export type MPIMHistoryArguments = TokenOverridable & {};
-export type MPIMListArguments = TokenOverridable & {};
-export type MPIMMarkArguments = TokenOverridable & {};
-export type MPIMOpenArguments = TokenOverridable & {};
-export type MPIMRepliesArguments = TokenOverridable & {};
+export type MPIMCloseArguments = TokenOverridable & {
+  channel: string;
+};
+export type MPIMHistoryArguments = TokenOverridable & TimelinePaginationEnabled & {
+  channel: string;
+  count?: number;
+  unreads?: boolean;
+};
+export type MPIMListArguments = TokenOverridable;
+export type MPIMMarkArguments = TokenOverridable & {
+  channel: string;
+  ts: string;
+};
+export type MPIMOpenArguments = TokenOverridable & {
+  users: string; // comma-separated list of users
+};
+export type MPIMRepliesArguments = TokenOverridable & {
+  channel: string;
+  thread_ts: string;
+};
 
   /*
    * `oauth.*`
@@ -346,71 +532,203 @@ export type OAuthTokenArguments = {
   /*
    * `pins.*`
    */
-export type PinsAddArguments = TokenOverridable & {};
-export type PinsListArguments = TokenOverridable & {};
-export type PinsRemoveArguments = TokenOverridable & {};
+export type PinsAddArguments = TokenOverridable & {
+  channel: string;
+  // must supply one of:
+  file?: string; // file id
+  file_comment?: string;
+  timestamp?: string;
+};
+export type PinsListArguments = TokenOverridable & {
+  channel: string;
+};
+export type PinsRemoveArguments = TokenOverridable & {
+  channel: string;
+  // must supply one of:
+  file?: string; // file id
+  file_comment?: string;
+  timestamp?: string;
+};
 
   /*
    * `reactions.*`
    */
-export type ReactionsAddArguments = TokenOverridable & {};
-export type ReactionsGetArguments = TokenOverridable & {};
-export type ReactionsListArguments = TokenOverridable & {};
-export type ReactionsRemoveArguments = TokenOverridable & {};
+export type ReactionsAddArguments = TokenOverridable & {
+  name: string;
+  // must supply one of:
+  channel?: string; // paired with timestamp
+  timestamp?: string; // paired with channel
+  file?: string; // file id
+  file_comment?: string;
+};
+export type ReactionsGetArguments = TokenOverridable & {
+  full?: boolean;
+  // must supply one of:
+  channel?: string; // paired with timestamp
+  timestamp?: string; // paired with channel
+  file?: string; // file id
+  file_comment?: string;
+};
+export type ReactionsListArguments = TokenOverridable & {
+  user?: string;
+  count?: number;
+  page?: number;
+  full?: boolean;
+};
+export type ReactionsRemoveArguments = TokenOverridable & {
+  name: string;
+  // must supply one of:
+  channel?: string; // paired with timestamp
+  timestamp?: string; // paired with channel
+  file?: string; // file id
+  file_comment?: string;
+};
 
   /*
    * `reminders.*`
    */
-export type RemindersAddArguments = TokenOverridable & {};
-export type RemindersCompleteArguments = TokenOverridable & {};
-export type RemindersDeleteArguments = TokenOverridable & {};
-export type RemindersInfoArguments = TokenOverridable & {};
-export type RemindersListArguments = TokenOverridable & {};
+export type RemindersAddArguments = TokenOverridable & {
+  text: string;
+  time: string | number;
+  user?: string;
+};
+export type RemindersCompleteArguments = TokenOverridable & {
+  reminder: string;
+};
+export type RemindersDeleteArguments = TokenOverridable & {
+  reminder: string;
+};
+export type RemindersInfoArguments = TokenOverridable & {
+  reminder: string;
+};
+export type RemindersListArguments = TokenOverridable;
 
   /*
    * `rtm.*`
    */
-export type RTMConnectArguments = TokenOverridable & {};
-export type RTMStartArguments = TokenOverridable & {};
+export type RTMConnectArguments = TokenOverridable & {
+  batch_presence_aware?: boolean;
+  presence_sub?: boolean;
+};
+export type RTMStartArguments = TokenOverridable & LocaleAware & {
+  batch_presence_aware?: boolean;
+  mpim_aware?: boolean;
+  no_latest?: '0' | '1';
+  no_unreads?: string;
+  presence_sub?: boolean;
+  simple_latest?: boolean;
+};
 
   /*
    * `search.*`
    */
-export type SearchAllArguments = TokenOverridable & {};
-export type SearchFilesArguments = TokenOverridable & {};
-export type SearchMessagesArguments = TokenOverridable & {};
+export type SearchAllArguments = TokenOverridable & {
+  query: string;
+  count?: number;
+  page?: number;
+  highlight?: boolean;
+  sort: 'score' | 'timestamp';
+  sort_dir: 'asc' | 'desc';
+};
+export type SearchFilesArguments = SearchAllArguments;
+export type SearchMessagesArguments = SearchAllArguments;
 
   /*
    * `stars.*`
    */
-export type StarsAddArguments = TokenOverridable & {};
-export type StarsListArguments = TokenOverridable & {};
-export type StarsRemoveArguments = TokenOverridable & {};
+export type StarsAddArguments = TokenOverridable & {
+  // must supply one of:
+  channel?: string; // paired with `timestamp`
+  timestamp?: string; // paired with `channel`
+  file?: string; // file id
+  file_comment?: string;
+};
+export type StarsListArguments = TokenOverridable & {
+  count?: number;
+  page?: number;
+};
+export type StarsRemoveArguments = TokenOverridable & {
+  // must supply one of:
+  channel?: string; // paired with `timestamp`
+  timestamp?: string; // paired with `channel`
+  file?: string; // file id
+  file_comment?: string;
+};
 
   /*
    * `team.*`
    */
-export type TeamAccessLogsArguments = TokenOverridable & {};
-export type TeamBillableInfoArguments = TokenOverridable & {};
-export type TeamInfoArguments = TokenOverridable & {};
-export type TeamIntegrationLogsArguments = TokenOverridable & {};
-export type TeamProfileGetArguments = TokenOverridable & {};
+export type TeamAccessLogsArguments = TokenOverridable & {
+  before?: number;
+  count?: number;
+  page?: number;
+};
+export type TeamBillableInfoArguments = TokenOverridable & {
+  user?: string;
+};
+export type TeamInfoArguments = TokenOverridable;
+export type TeamIntegrationLogsArguments = TokenOverridable & {
+  app_id?: string;
+  change_type?: string; // TODO: list types: 'x' | 'y' | 'z'
+  count?: number;
+  page?: number;
+  service_id?: string;
+  user?: string;
+};
+export type TeamProfileGetArguments = TokenOverridable & {
+  visibility?: 'all' | 'visible' | 'hidden';
+};
 
   /*
    * `usergroups.*`
    */
-export type UsergroupsCreateArguments = TokenOverridable & {};
-export type UsergroupsDisableArguments = TokenOverridable & {};
-export type UsergroupsEnableArguments = TokenOverridable & {};
-export type UsergroupsListArguments = TokenOverridable & {};
-export type UsergroupsUpdateArguments = TokenOverridable & {};
-export type UsergroupsUsersListArguments = TokenOverridable & {};
-export type UsergroupsUsersUpdateArguments = TokenOverridable & {};
+export type UsergroupsCreateArguments = TokenOverridable & {
+  name: string;
+  channels?: string; // comma-separated list of channels
+  description?: string;
+  handle?: string;
+  include_count?: boolean;
+};
+export type UsergroupsDisableArguments = TokenOverridable & {
+  usergroup: string;
+  include_count?: boolean;
+};
+export type UsergroupsEnableArguments = TokenOverridable & {
+  usergroup: string;
+  include_count?: boolean;
+};
+export type UsergroupsListArguments = TokenOverridable & {
+  include_count?: boolean;
+  include_disabled?: boolean;
+  include_users?: boolean;
+};
+export type UsergroupsUpdateArguments = TokenOverridable & {
+  usergroup: string;
+  channels?: string; // comma-separated list of channels
+  description?: string;
+  handle?: string;
+  include_count?: boolean;
+  name?: string;
+};
+export type UsergroupsUsersListArguments = TokenOverridable & {
+  usergroup: string;
+  include_disabled?: boolean;
+};
+export type UsergroupsUsersUpdateArguments = TokenOverridable & {
+  usergroup: string;
+  users: string; // comma-separated list of users
+  include_count?: boolean;
+};
 
   /*
    * `users.*`
    */
-export type UsersInfoArguments = TokenOverridable & {
+export type UsersDeletePhotoArguments = TokenOverridable;
+export type UsersGetPresenceArguments = TokenOverridable & {
+  user: string;
+};
+export type UsersIdentityArguments = TokenOverridable;
+export type UsersInfoArguments = TokenOverridable & LocaleAware & {
   user: string;
 };
 export type UsersListArguments = TokenOverridable & CursorPaginationEnabled & LocaleAware & {
@@ -419,20 +737,23 @@ export type UsersListArguments = TokenOverridable & CursorPaginationEnabled & Lo
 export type UsersLookupByEmailArguments = TokenOverridable & {
   email: string;
 };
-export type UsersGetPresenceArguments = TokenOverridable & {
-  user: string;
-};
-export type UsersIdentityArguments = TokenOverridable & {};
-export type UsersSetActiveArguments = TokenOverridable & {};
+export type UsersSetActiveArguments = TokenOverridable; // deprecated & being removed may 8, 2018
 export type UsersSetPhotoArguments = TokenOverridable & {
-  image: string; // TODO: file contents what?
+  image: Buffer;
   crop_w?: number;
   crop_x?: number;
   crop_y?: number;
 };
-export type UsersDeletePhotoArguments = TokenOverridable & {};
 export type UsersSetPresenceArguments = TokenOverridable & {
   presence: 'auto' | 'away';
 };
-export type UsersProfileGetArguments = TokenOverridable & {};
-export type UsersProfileSetArguments = TokenOverridable & {};
+export type UsersProfileGetArguments = TokenOverridable & {
+  include_labels?: boolean;
+  user?: string;
+};
+export type UsersProfileSetArguments = TokenOverridable & {
+  profile?: string; // url-encoded json
+  user?: string;
+  name?: string; // usable if `profile` is not passed
+  value?: string; // usable if `profile` is not passed
+};


### PR DESCRIPTION
###  Summary

Fixes #505. Implements the remaining method arguments.

The only remaining incomplete type definitions for arguments is `actions` of `MessageAttachment`s.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).