### PR TITLE
Enable WebClient to send binary data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 
 export {
   WebClient,
+  WebClientBinaryData,
   WebClientOptions,
   WebAPICallOptions,
   WebAPICallResult,


### PR DESCRIPTION
###  Summary

Enables the WebClient to send Buffers and Streams as binary data via `multipart/form-data` requests.

```js
web.files.upload({
    file: new Buffer('Hi! I like crème-filled chocolate eggs!'),

    // or:
    file: fs.createReadStream('image/of/chocolate_egg.jpg'),

    // or:
    file: new ReadableEggFileStream({ type: 'chocolate' }),
});
```

This is mostly done using a simple `WebClientBinaryData` container which signals to `WebClient` that the request should be sent as `multipart/form-data`. All top-level arguments that are `Buffer`s or `Stream`s are automatically wrapped in `WebClientBinaryData` for convenience.

`WebClientBinaryData` is exposed for future cases where a user might specifically want the `multipart/form-data` file name to be something specific.

```js
web.some.method({
    binary_argument: new WebClientBinaryData(bufferOrStream, 'binary data name'),
});
```

If the name argument is omitted (as it is when wrapping `Buffer`s and most `Stream`s), then a random 24-character name is generated to ensure that the data will be sent.

Best of all, this solution is generic, so there's nothing in it specific to `files.upload`. The only cost of this generic solution is the `multipart/form-data` name of the file won't be the same as the `filename` argument, if provided, but this shouldn't matter as the Web API itself handles renaming the file to the provided value of `filename`.

#### Follow-up

If this and #512 are merged, any binary arguments (`file` of `files.upload` and `image` of `users.setPhoto`) should be modified to also accept `WebClientBinaryData`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).