### PR TITLE
Generalize handling of arguments with binary value types

### DIFF
--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -529,8 +529,7 @@ export class WebClient extends EventEmitter {
 
     // A body with binary content should be serialized as multipart/form-data
     if (containsBinaryData) {
-      // TODO: when there's a part called 'file' that does not have the 'filename' option, and there's no
-      //       part called 'filename': log a warning OR generate a random name
+      this.logger.debug('request arguments contain binary data');
       return flattened.reduce((form, [key, value]) => {
         if (Buffer.isBuffer(value) || isStream(value)) {
           const options: FormData.AppendOptions = {};
@@ -547,7 +546,7 @@ export class WebClient extends EventEmitter {
             if (typeof streamOrBuffer.path === 'string') {
               return basename(streamOrBuffer.path);
             }
-            return undefined;
+            return defaultFilename;
           })();
           form.append(key, value, options);
         } else {
@@ -651,6 +650,8 @@ export interface WebAPIHTTPError extends CodedError {
 /*
  * Helpers
  */
+
+const defaultFilename = 'Untitled';
 
 interface FormCanBeURLEncoded {
   [key: string]: string | number | boolean;


### PR DESCRIPTION
###  Summary

based on #513 - as this PR states, this should allow methods like `users.setPhoto` to also work properly.

fixes #452 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
