### PR TITLE
WebClient.apiCall() will detect some types of bad arguments

### DIFF
--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -100,6 +100,37 @@ describe('WebClient', function () {
       });
     });
 
+    describe('when called with bad options', function () {
+      it('should reject its Promise with TypeError', function (done) {
+        const results = [
+          this.client.apiCall('method', 4),
+          this.client.apiCall('method', 'a string'),
+          this.client.apiCall('method', false),
+        ];
+        const caughtErrors = results.map(r => {
+          assert(isPromise(r));
+          return r
+            .then(() => {
+              // if any of these promises resolve, this test fails
+              assert(false);
+            })
+            .catch((error) => {
+              // each promise should reject with the right kind of error
+              assert.instanceOf(error, TypeError);
+            });
+        });
+        Promise.all(caughtErrors)
+          .then(() => done());
+      });
+
+      it('should return a TypeError to its callback', function (done) {
+        this.client.apiCall('method', 4, (error) => {
+          assert.instanceOf(error, TypeError);
+          done();
+        });
+      });
+    });
+
     // TODO: simulate each of the error types
     describe('when the call fails', function () {
       beforeEach(function () {

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -121,7 +121,11 @@ export class WebClient extends EventEmitter {
 
     // The following thunk is the actual implementation for this method. It is wrapped so that it can be adapted for
     // different executions below.
-    const implementation = () => {
+    const implementation = async () => {
+
+      if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
+        throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
+      }
 
       const requestBody = this.serializeApiCallOptions(Object.assign({ token: this.token }, options));
 


### PR DESCRIPTION
###  Summary

fixes #521

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
