### PR TITLE
Fix and Add Logging for StateMachine websocket close

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -147,8 +147,16 @@ export class RTMClient extends EventEmitter {
           .state('handshaking') // a state in which to wait until the 'server hello' event
             .on('websocket close')
               .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
-              .transitionTo('disconnected').withAction((_from, _to, context) => {
-                this.logger.debug(`unexpected close ${context.eventPayload.reason} ${context.eventPayload.code}`);
+              .withAction((_from, _to, context) => {
+                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason} 
+                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} 
+                  and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
+              })
+              .transitionTo('disconnected')
+              .withAction((_from, _to, context) => {
+                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason} 
+                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} 
+                  and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
                 // this transition circumvents the 'disconnecting' state (since the websocket is already closed),
                 // so we need to execute its onExit behavior here.
                 this.teardownWebsocket();


### PR DESCRIPTION
###  Summary

Addresses #531 and #527. Adds flags to `KeepAlive` and logs in client on unexpected websocket close during `handshaking` state. Also addresses race condition that could cause this unexpected close.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
