### PR TITLE
Updated MessageAttachment inteface to contain better type for actions

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -87,12 +87,40 @@ export interface MessageAttachment {
   footer?: string;
   footer_icon?: string; // footer must be present
   ts?: string;
-  actions?: { // note: this is a very minimal definition of link buttons, interactive buttons, and message menus
-    type: string;
-    text?: string;
-  }[];
+  actions?: AttachmentAction[];
   callback_id?: string;
   mrkdwn_in?: ('pretext' | 'text' | 'fields')[];
+}
+
+export interface AttachmentAction {
+  id?: string;
+  confirm?: Confirmation;
+  data_source?: string;
+  min_query_length: number;
+  name: string;
+  options?: OptionField[];
+  option_groups?: {
+    text: string
+    options: OptionField[];
+  }[];
+  selected_options: OptionField[];
+  style?: string;
+  text: string;
+  type: string;
+  value?: string;
+}
+
+export interface OptionField {
+  description?: string;
+  text: string;
+  value: string;
+}
+
+export interface Confirmation {
+  dismiss_text?: string;
+  ok_text?: string;
+  text: string;
+  title?: string;
 }
 
 export interface LinkUnfurls {


### PR DESCRIPTION
###  Summary

MessageAttachment.actions is incomplete and incorrect based on the field guide (https://api.slack.com/docs/interactive-message-field-guide).


### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).