### PR TITLE
Add missing properties for a dialog select element

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -59,10 +59,14 @@ export interface Dialog {
     hint?: string;
     subtype?: 'email' | 'number' | 'tel' | 'url';
     // type `select`:
-    options?: {
-      label: string; // shown to user
-      value: string; // sent to app
+    data_source?: 'users' | 'channels' | 'conversations' | 'external'
+    selected_options?: string;
+    options?: SelectOption[];
+    option_groups?: {
+      label: string;
+      options: SelectOption[]
     }[];
+    min_query_length?: number;
   }[];
   submit_label?: string;
   notify_on_cancel?: boolean;
@@ -98,6 +102,11 @@ export interface MessageAttachment {
 
 export interface LinkUnfurls {
   [linkUrl: string]: MessageAttachment;
+}
+
+export interface SelectOption {
+  label: string; // shown to user
+  value: string; // sent to app
 }
 
 /*

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -59,12 +59,12 @@ export interface Dialog {
     hint?: string;
     subtype?: 'email' | 'number' | 'tel' | 'url';
     // type `select`:
-    data_source?: 'users' | 'channels' | 'conversations' | 'external'
+    data_source?: 'users' | 'channels' | 'conversations' | 'external';
     selected_options?: string;
     options?: SelectOption[];
     option_groups?: {
       label: string;
-      options: SelectOption[]
+      options: SelectOption[];
     }[];
     min_query_length?: number;
   }[];


### PR DESCRIPTION
###  Summary
Some properties (`data_source`, `selected_options`, `option_groups` and `min_query_length`) were missing in definitions for a dialog select element.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
