### PR TITLE
fixes typo in x-oauth-scopes response header name

### DIFF
--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -100,6 +100,23 @@ describe('WebClient', function () {
       });
     });
 
+    describe('with OAuth scopes in the response headers', function () {
+      it('should expose a scopes and acceptedScopes properties on the result', function () {
+        const scope = nock('https://slack.com')
+          .post(/api/)
+          .reply(200, { ok: true }, {
+            'X-OAuth-Scopes': 'files:read, chat:write:bot',
+            'X-Accepted-OAuth-Scopes': 'files:read'
+          });
+        return this.client.apiCall('method')
+          .then((result) => {
+            assert.deepNestedInclude(result, { 'scopes': ['files:read', 'chat:write:bot'] });
+            assert.deepNestedInclude(result, { 'acceptedScopes': ['files:read'] });
+            scope.done();
+          })
+      });
+    });
+
     describe('when called with bad options', function () {
       it('should reject its Promise with TypeError', function (done) {
         const results = [

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -579,7 +579,7 @@ export class WebClient extends EventEmitter {
     const data = JSON.parse(response.body);
 
     // add scopes metadata from headers
-    if (response.headers['x-oauth'] !== undefined) {
+    if (response.headers['x-oauth-scopes'] !== undefined) {
       data.scopes = (response.headers['x-oauth-scopes'] as string).trim().split(/\s*,\s*/);
     }
     if (response.headers['x-accepted-oauth-scopes'] !== undefined) {


### PR DESCRIPTION
###  Summary

relevant doc: https://api.slack.com/docs/oauth-scopes#working_with_scopes

fixes #553

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
