### PR TITLE
Adds websocket close handlers in connecting:authenticated

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -144,18 +144,25 @@ export class RTMClient extends EventEmitter {
               });
             })
             .on('websocket open').transitionTo('handshaking')
+            .on('websocket close')
+              .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
+              .transitionTo('disconnected').withAction(() => {
+                // this transition circumvents the 'disconnecting' state (since the websocket is already closed), so we
+                // need to execute its onExit behavior here.
+                this.teardownWebsocket();
+              })
           .state('handshaking') // a state in which to wait until the 'server hello' event
             .on('websocket close')
               .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
               .withAction((_from, _to, context) => {
-                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason} 
-                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} 
+                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason}
+                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring}
                   and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
               })
               .transitionTo('disconnected')
               .withAction((_from, _to, context) => {
-                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason} 
-                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} 
+                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason}
+                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring}
                   and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
                 // this transition circumvents the 'disconnecting' state (since the websocket is already closed),
                 // so we need to execute its onExit behavior here.
@@ -234,7 +241,10 @@ export class RTMClient extends EventEmitter {
       // reconnecting is just like disconnecting, except that the websocket should already be closed before we enter
       // this state, and that the next state should be connecting.
       .state('reconnecting')
-        .do(() => Promise.resolve(true))
+        .do(() => {
+          this.keepAlive.stop();
+          return Promise.resolve(true);
+        })
           .onSuccess().transitionTo('connecting')
         .onExit(() => this.teardownWebsocket())
       .global()

--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -155,15 +155,15 @@ export class RTMClient extends EventEmitter {
             .on('websocket close')
               .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
               .withAction((_from, _to, context) => {
-                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason}
-                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring}
-                  and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
+                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason} ` +
+                  `${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} ` +
+                  `and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
               })
               .transitionTo('disconnected')
               .withAction((_from, _to, context) => {
-                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason}
-                  ${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring}
-                  and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
+                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason} ` +
+                  `${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} ` +
+                  `and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
                 // this transition circumvents the 'disconnecting' state (since the websocket is already closed),
                 // so we need to execute its onExit behavior here.
                 this.teardownWebsocket();


### PR DESCRIPTION
###  Summary

The RTMClient's websocket is set up during the `connecting:authenticated` state. As soon as that happens, its possible for the webosocket to close. Previously, if that close happened before websocket open, that event would go unhandled and cause a crash. That seemed like it could never happen, until we discovered that certain websocket errors trigger the websocket close event, even before the websocket open event fires.

Also, if this occurs after transitioning from the `reconnecting` state (as opposed to a first time connection), then the `KeepAlive` object would still be monitoring. That means it could send a `ping` while the websocket is not ready (in closing). This is addressed by stopping its monitoring when transitioning into the `reconnecting` state.

Fixes #550 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
