### PR TITLE
handles transitions at parent machine instead of submachine

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -144,36 +144,20 @@ export class RTMClient extends EventEmitter {
               });
             })
             .on('websocket open').transitionTo('handshaking')
-            .on('websocket close')
-              .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
-              .transitionTo('disconnected').withAction(() => {
-                // this transition circumvents the 'disconnecting' state (since the websocket is already closed), so we
-                // need to execute its onExit behavior here.
-                this.teardownWebsocket();
-              })
           .state('handshaking') // a state in which to wait until the 'server hello' event
-            .on('websocket close')
-              .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
-              .withAction((_from, _to, context) => {
-                this.logger.debug(`reconnecting after unexpected close ${context.eventPayload.reason} ` +
-                  `${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} ` +
-                  `and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
-              })
-              .transitionTo('disconnected')
-              .withAction((_from, _to, context) => {
-                this.logger.debug(`disconnected after unexpected close ${context.eventPayload.reason} ` +
-                  `${context.eventPayload.code} with isMonitoring set to ${this.keepAlive.isMonitoring} ` +
-                  `and recommendReconnect set to ${this.keepAlive.recommendReconnect}`);
-                // this transition circumvents the 'disconnecting' state (since the websocket is already closed),
-                // so we need to execute its onExit behavior here.
-                this.teardownWebsocket();
-              })
           .global()
             .onStateEnter((state) => {
               this.logger.debug(`transitioning to state: connecting:${state}`);
             })
         .getConfig())
         .on('server hello').transitionTo('connected')
+        .on('websocket close')
+          .transitionTo('reconnecting').withCondition(() => this.autoReconnect)
+          .transitionTo('disconnected').withAction(() => {
+            // this transition circumvents the 'disconnecting' state (since the websocket is already closed), so we need
+            // to execute its onExit behavior here.
+            this.teardownWebsocket();
+          })
         .on('failure').transitionTo('disconnected')
       .state('connected')
         .onEnter(() => {


### PR DESCRIPTION
###  Summary

the destinations of the the transitions are parent machine states, so the handling inside the submachine does not work.

Fixes #550

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
