### PR TITLE
Add first pass at response typings

### DIFF
--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -12,9 +12,16 @@ import got = require('got'); // tslint:disable-line:no-require-imports
 import FormData = require('form-data'); // tslint:disable-line:no-require-imports import-name
 import { callbackify, getUserAgent, AgentOption, TLSOptions } from './util';
 import { CodedError, errorWithCode, ErrorCode } from './errors';
-import { LogLevel, Logger, LoggingFunc, getLogger, loggerFromLoggingFunc } from './logger';
+import {
+  LogLevel,
+  Logger,
+  LoggingFunc,
+  getLogger,
+  loggerFromLoggingFunc,
+} from './logger';
 import retryPolicies, { RetryOptions } from './retry-policies';
 import Method, * as methods from './methods'; // tslint:disable-line:import-name
+import * as responses from './responses';
 const pkg = require('../package.json'); // tslint:disable-line:no-require-imports no-var-requires
 
 /**
@@ -74,15 +81,18 @@ export class WebClient extends EventEmitter {
   /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`, or `xoxa`)
    */
-  constructor(token?: string, {
-    slackApiUrl = 'https://slack.com/api/',
-    logger = undefined,
-    logLevel = LogLevel.INFO,
-    maxRequestConcurrency = 3,
-    retryConfig = retryPolicies.retryForeverExponentialCappedRandom,
-    agent = undefined,
-    tls = undefined,
-  }: WebClientOptions = {}) {
+  constructor(
+    token?: string,
+    {
+      slackApiUrl = 'https://slack.com/api/',
+      logger = undefined,
+      logLevel = LogLevel.INFO,
+      maxRequestConcurrency = 3,
+      retryConfig = retryPolicies.retryForeverExponentialCappedRandom,
+      agent = undefined,
+      tls = undefined,
+    }: WebClientOptions = {},
+  ) {
     super();
     this.token = token;
     this.slackApiUrl = slackApiUrl;
@@ -112,38 +122,59 @@ export class WebClient extends EventEmitter {
    * @param options options
    * @param callback callback if you don't want a promise returned
    */
-  public apiCall(method: string, options?: WebAPICallOptions): Promise<WebAPICallResult>;
-  public apiCall(method: string, options: WebAPICallOptions, callback: WebAPIResultCallback): void;
-  public apiCall(method: string,
-                 options?: WebAPICallOptions,
-                 callback?: WebAPIResultCallback): void | Promise<WebAPICallResult> {
+  public apiCall(
+    method: string,
+    options?: WebAPICallOptions,
+  ): Promise<WebAPICallResult>;
+  public apiCall(
+    method: string,
+    options: WebAPICallOptions,
+    callback: WebAPIResultCallback,
+  ): void;
+  public apiCall(
+    method: string,
+    options?: WebAPICallOptions,
+    callback?: WebAPIResultCallback,
+  ): void | Promise<WebAPICallResult> {
     this.logger.debug('apiCall() start');
 
     // The following thunk is the actual implementation for this method. It is wrapped so that it can be adapted for
     // different executions below.
     const implementation = async () => {
-
-      if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
-        throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
+      if (
+        typeof options === 'string' ||
+        typeof options === 'number' ||
+        typeof options === 'boolean'
+      ) {
+        throw new TypeError(
+          `Expected an options argument but instead received a ${typeof options}`,
+        );
       }
 
-      const requestBody = this.serializeApiCallOptions(Object.assign({ token: this.token }, options));
+      const requestBody = this.serializeApiCallOptions(
+        Object.assign({ token: this.token }, options),
+      );
 
       // The following thunk encapsulates the task so that it can be coordinated for retries
       const task = () => {
         this.logger.debug('request attempt');
-        return got.post(urlJoin(this.slackApiUrl, method),
-          // @ts-ignore using older definitions for package `got`, can remove when type `@types/got` is updated for v8
-          Object.assign({
-            form: !canBodyBeFormMultipart(requestBody),
-            body: requestBody,
-            retries: 0,
-            headers: {
-              'user-agent': this.userAgent,
-            },
-            agent: this.agentConfig,
-          }, this.tlsConfig),
-        )
+        return got
+          .post(
+            urlJoin(this.slackApiUrl, method),
+            // @ts-ignore using older definitions for package `got`, can remove when type `@types/got` is updated for v8
+            Object.assign(
+              {
+                form: !canBodyBeFormMultipart(requestBody),
+                body: requestBody,
+                retries: 0,
+                headers: {
+                  'user-agent': this.userAgent,
+                },
+                agent: this.agentConfig,
+              },
+              this.tlsConfig,
+            ),
+          )
           .catch((error: got.GotError) => {
             // Wrap errors in this packages own error types (abstract the implementation details' types)
             if (error.name === 'RequestError') {
@@ -159,16 +190,26 @@ export class WebClient extends EventEmitter {
           .then((response: got.Response<string>) => {
             const result = this.buildResult(response);
             // log warnings in response metadata
-            if (result.response_metadata !== undefined && result.response_metadata.warnings !== undefined) {
+            if (
+              result.response_metadata !== undefined &&
+              result.response_metadata.warnings !== undefined
+            ) {
               result.response_metadata.warnings.forEach(this.logger.warn);
             }
 
             // handle rate-limiting
-            if (response.statusCode !== undefined && response.statusCode === 429) {
-              const retryAfterMs = result.retryAfter !== undefined ? result.retryAfter : (60 * 1000);
+            if (
+              response.statusCode !== undefined &&
+              response.statusCode === 429
+            ) {
+              const retryAfterMs =
+                result.retryAfter !== undefined ? result.retryAfter : 60 * 1000;
               // NOTE: the following event could have more information regarding the api call that is being delayed
               this.emit('rate_limited', retryAfterMs / 1000);
-              this.logger.info(`API Call failed due to rate limiting. Will retry in ${retryAfterMs / 1000} seconds.`);
+              this.logger.info(
+                `API Call failed due to rate limiting. Will retry in ${retryAfterMs /
+                  1000} seconds.`,
+              );
               // wait and return the result from calling `task` again after the specified number of seconds
               return delay(retryAfterMs).then(task);
             }
@@ -206,7 +247,10 @@ export class WebClient extends EventEmitter {
    * api method family
    */
   public readonly api = {
-    test: (this.apiCall.bind(this, 'api.test')) as Method<methods.APITestArguments>,
+    test: this.apiCall.bind(this, 'api.test') as Method<
+      methods.APITestArguments,
+      responses.APITestResponse
+    >,
   };
 
   /**
@@ -214,8 +258,14 @@ export class WebClient extends EventEmitter {
    */
   public readonly apps = {
     permissions: {
-      info: (this.apiCall.bind(this, 'apps.permissions.info')) as Method<methods.AppsPermissionsInfoArguments>,
-      request: (this.apiCall.bind(this, 'apps.permissions.request')) as Method<methods.AppsPermissionsRequestArguments>,
+      info: this.apiCall.bind(this, 'apps.permissions.info') as Method<
+        methods.AppsPermissionsInfoArguments,
+        responses.AppsPermissionsInfoResponse
+      >,
+      request: this.apiCall.bind(this, 'apps.permissions.request') as Method<
+        methods.AppsPermissionsRequestArguments,
+        responses.AppsPermissionsRequestResponse
+      >,
     },
   };
 
@@ -223,116 +273,287 @@ export class WebClient extends EventEmitter {
    * auth method family
    */
   public readonly auth = {
-    revoke: (this.apiCall.bind(this, 'auth.revoke')) as Method<methods.AuthRevokeArguments>,
-    test: (this.apiCall.bind(this, 'auth.test')) as Method<methods.AuthTestArguments>,
+    revoke: this.apiCall.bind(this, 'auth.revoke') as Method<
+      methods.AuthRevokeArguments,
+      responses.AuthRevokeResponse
+    >,
+    test: this.apiCall.bind(this, 'auth.test') as Method<
+      methods.AuthTestArguments,
+      responses.AuthTestResponse
+    >,
   };
 
   /**
    * bots method family
    */
   public readonly bots = {
-    info: (this.apiCall.bind(this, 'bots.info')) as Method<methods.BotsInfoArguments>,
+    info: this.apiCall.bind(this, 'bots.info') as Method<
+      methods.BotsInfoArguments,
+      responses.BotsInfoResponse
+    >,
   };
 
   /**
    * channels method family
    */
   public readonly channels = {
-    archive: (this.apiCall.bind(this, 'channels.archive')) as Method<methods.ChannelsArchiveArguments>,
-    create: (this.apiCall.bind(this, 'channels.create')) as Method<methods.ChannelsCreateArguments>,
-    history: (this.apiCall.bind(this, 'channels.history')) as Method<methods.ChannelsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'channels.info')) as Method<methods.ChannelsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'channels.invite')) as Method<methods.ChannelsInviteArguments>,
-    join: (this.apiCall.bind(this, 'channels.join')) as Method<methods.ChannelsJoinArguments>,
-    kick: (this.apiCall.bind(this, 'channels.kick')) as Method<methods.ChannelsKickArguments>,
-    leave: (this.apiCall.bind(this, 'channels.leave')) as Method<methods.ChannelsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'channels.list')) as Method<methods.ChannelsListArguments>,
-    mark: (this.apiCall.bind(this, 'channels.mark')) as Method<methods.ChannelsMarkArguments>,
-    rename: (this.apiCall.bind(this, 'channels.rename')) as Method<methods.ChannelsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'channels.replies')) as Method<methods.ChannelsRepliesArguments>,
-    setPurpose: (this.apiCall.bind(this, 'channels.setPurpose')) as Method<methods.ChannelsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'channels.setTopic')) as Method<methods.ChannelsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'channels.unarchive')) as Method<methods.ChannelsUnarchiveArguments>,
+    archive: this.apiCall.bind(this, 'channels.archive') as Method<
+      methods.ChannelsArchiveArguments,
+      responses.ChannelsArchiveResponse
+    >,
+    create: this.apiCall.bind(this, 'channels.create') as Method<
+      methods.ChannelsCreateArguments,
+      responses.ChannelsCreateResponse
+    >,
+    history: this.apiCall.bind(this, 'channels.history') as Method<
+      methods.ChannelsHistoryArguments,
+      responses.ChannelsHistoryResponse
+    >,
+    info: this.apiCall.bind(this, 'channels.info') as Method<
+      methods.ChannelsInfoArguments,
+      responses.ChannelsInfoResponse
+    >,
+    invite: this.apiCall.bind(this, 'channels.invite') as Method<
+      methods.ChannelsInviteArguments,
+      responses.ChannelsInviteResponse
+    >,
+    join: this.apiCall.bind(this, 'channels.join') as Method<
+      methods.ChannelsJoinArguments,
+      responses.ChannelsJoinResponse
+    >,
+    kick: this.apiCall.bind(this, 'channels.kick') as Method<
+      methods.ChannelsKickArguments,
+      responses.ChannelsKickResponse
+    >,
+    leave: this.apiCall.bind(this, 'channels.leave') as Method<
+      methods.ChannelsLeaveArguments,
+      responses.ChannelsLeaveResponse
+    >,
+    list: this.apiCall.bind(this, 'channels.list') as Method<
+      methods.ChannelsListArguments,
+      responses.ChannelsListResponse
+    >,
+    mark: this.apiCall.bind(this, 'channels.mark') as Method<
+      methods.ChannelsMarkArguments,
+      responses.ChannelsMarkResponse
+    >,
+    rename: this.apiCall.bind(this, 'channels.rename') as Method<
+      methods.ChannelsRenameArguments,
+      responses.ChannelsRenameResponse
+    >,
+    replies: this.apiCall.bind(this, 'channels.replies') as Method<
+      methods.ChannelsRepliesArguments,
+      responses.ChannelsRepliesResponse
+    >,
+    setPurpose: this.apiCall.bind(this, 'channels.setPurpose') as Method<
+      methods.ChannelsSetPurposeArguments,
+      responses.ChannelsSetPurposeResponse
+    >,
+    setTopic: this.apiCall.bind(this, 'channels.setTopic') as Method<
+      methods.ChannelsSetTopicArguments,
+      responses.ChannelsSetTopicResponse
+    >,
+    unarchive: this.apiCall.bind(this, 'channels.unarchive') as Method<
+      methods.ChannelsUnarchiveArguments,
+      responses.ChannelsUnarchiveResponse
+    >,
   };
 
   /**
    * chat method family
    */
   public readonly chat = {
-    delete: (this.apiCall.bind(this, 'chat.delete')) as Method<methods.ChatDeleteArguments>,
-    getPermalink: (this.apiCall.bind(this, 'chat.getPermalink')) as Method<methods.ChatGetPermalinkArguments>,
-    meMessage: (this.apiCall.bind(this, 'chat.meMessage')) as Method<methods.ChatMeMessageArguments>,
-    postEphemeral: (this.apiCall.bind(this, 'chat.postEphemeral')) as Method<methods.ChatPostEphemeralArguments>,
-    postMessage: (this.apiCall.bind(this, 'chat.postMessage')) as Method<methods.ChatPostMessageArguments>,
-    unfurl: (this.apiCall.bind(this, 'chat.unfurl')) as Method<methods.ChatUnfurlArguments>,
-    update: (this.apiCall.bind(this, 'chat.update')) as Method<methods.ChatUpdateArguments>,
+    delete: this.apiCall.bind(this, 'chat.delete') as Method<
+      methods.ChatDeleteArguments,
+      responses.ChatDeleteResponse
+    >,
+    getPermalink: this.apiCall.bind(this, 'chat.getPermalink') as Method<
+      methods.ChatGetPermalinkArguments,
+      responses.ChatGetPermalinkResponse
+    >,
+    meMessage: this.apiCall.bind(this, 'chat.meMessage') as Method<
+      methods.ChatMeMessageArguments,
+      responses.ChatMeMessageResponse
+    >,
+    postEphemeral: this.apiCall.bind(this, 'chat.postEphemeral') as Method<
+      methods.ChatPostEphemeralArguments,
+      responses.ChatPostEphemeralResponse
+    >,
+    postMessage: this.apiCall.bind(this, 'chat.postMessage') as Method<
+      methods.ChatPostMessageArguments,
+      responses.ChatPostMessageResponse
+    >,
+    unfurl: this.apiCall.bind(this, 'chat.unfurl') as Method<
+      methods.ChatUnfurlArguments,
+      responses.ChatUnfurlResponse
+    >,
+    update: this.apiCall.bind(this, 'chat.update') as Method<
+      methods.ChatUpdateArguments,
+      responses.ChatUpdateResponse
+    >,
   };
 
   /**
    * conversations method family
    */
   public readonly conversations = {
-    archive: (this.apiCall.bind(this, 'conversations.archive')) as Method<methods.ConversationsArchiveArguments>,
-    close: (this.apiCall.bind(this, 'conversations.close')) as Method<methods.ConversationsCloseArguments>,
-    create: (this.apiCall.bind(this, 'conversations.create')) as Method<methods.ConversationsCreateArguments>,
-    history: (this.apiCall.bind(this, 'conversations.history')) as Method<methods.ConversationsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'conversations.info')) as Method<methods.ConversationsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'conversations.invite')) as Method<methods.ConversationsInviteArguments>,
-    join: (this.apiCall.bind(this, 'conversations.join')) as Method<methods.ConversationsJoinArguments>,
-    kick: (this.apiCall.bind(this, 'conversations.kick')) as Method<methods.ConversationsKickArguments>,
-    leave: (this.apiCall.bind(this, 'conversations.leave')) as Method<methods.ConversationsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'conversations.list')) as Method<methods.ConversationsListArguments>,
-    members: (this.apiCall.bind(this, 'conversations.members')) as Method<methods.ConversationsMembersArguments>,
-    open: (this.apiCall.bind(this, 'conversations.open')) as Method<methods.ConversationsOpenArguments>,
-    rename: (this.apiCall.bind(this, 'conversations.rename')) as Method<methods.ConversationsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'conversations.replies')) as Method<methods.ConversationsRepliesArguments>,
-    setPurpose:
-      (this.apiCall.bind(this, 'conversations.setPurpose')) as Method<methods.ConversationsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'conversations.setTopic')) as Method<methods.ConversationsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'conversations.unarchive')) as Method<methods.ConversationsUnarchiveArguments>,
+    archive: this.apiCall.bind(this, 'conversations.archive') as Method<
+      methods.ConversationsArchiveArguments,
+      responses.ConversationsArchiveResponse
+    >,
+    close: this.apiCall.bind(this, 'conversations.close') as Method<
+      methods.ConversationsCloseArguments,
+      responses.ConversationsCloseResponse
+    >,
+    create: this.apiCall.bind(this, 'conversations.create') as Method<
+      methods.ConversationsCreateArguments,
+      responses.ConversationsCreateResponse
+    >,
+    history: this.apiCall.bind(this, 'conversations.history') as Method<
+      methods.ConversationsHistoryArguments,
+      responses.ConversationsHistoryResponse
+    >,
+    info: this.apiCall.bind(this, 'conversations.info') as Method<
+      methods.ConversationsInfoArguments,
+      responses.ConversationsInfoResponse
+    >,
+    invite: this.apiCall.bind(this, 'conversations.invite') as Method<
+      methods.ConversationsInviteArguments,
+      responses.ConversationsInviteResponse
+    >,
+    join: this.apiCall.bind(this, 'conversations.join') as Method<
+      methods.ConversationsJoinArguments,
+      responses.ConversationsJoinResponse
+    >,
+    kick: this.apiCall.bind(this, 'conversations.kick') as Method<
+      methods.ConversationsKickArguments,
+      responses.ConversationsKickResponse
+    >,
+    leave: this.apiCall.bind(this, 'conversations.leave') as Method<
+      methods.ConversationsLeaveArguments,
+      responses.ConversationsLeaveResponse
+    >,
+    list: this.apiCall.bind(this, 'conversations.list') as Method<
+      methods.ConversationsListArguments,
+      responses.ConversationsListResponse
+    >,
+    members: this.apiCall.bind(this, 'conversations.members') as Method<
+      methods.ConversationsMembersArguments,
+      responses.ConversationsMembersResponse
+    >,
+    open: this.apiCall.bind(this, 'conversations.open') as Method<
+      methods.ConversationsOpenArguments,
+      responses.ConversationsOpenResponse
+    >,
+    rename: this.apiCall.bind(this, 'conversations.rename') as Method<
+      methods.ConversationsRenameArguments,
+      responses.ConversationsRenameResponse
+    >,
+    replies: this.apiCall.bind(this, 'conversations.replies') as Method<
+      methods.ConversationsRepliesArguments,
+      responses.ConversationsRepliesResponse
+    >,
+    setPurpose: this.apiCall.bind(this, 'conversations.setPurpose') as Method<
+      methods.ConversationsSetPurposeArguments,
+      responses.ConversationsSetPurposeResponse
+    >,
+    setTopic: this.apiCall.bind(this, 'conversations.setTopic') as Method<
+      methods.ConversationsSetTopicArguments,
+      responses.ConversationsSetTopicResponse
+    >,
+    unarchive: this.apiCall.bind(this, 'conversations.unarchive') as Method<
+      methods.ConversationsUnarchiveArguments,
+      responses.ConversationsUnarchiveResponse
+    >,
   };
 
   /**
    * dialog method family
    */
   public readonly dialog = {
-    open: (this.apiCall.bind(this, 'dialog.open')) as Method<methods.DialogOpenArguments>,
+    open: this.apiCall.bind(this, 'dialog.open') as Method<
+      methods.DialogOpenArguments,
+      responses.DialogOpenResponse
+    >,
   };
 
   /**
    * dnd method family
    */
   public readonly dnd = {
-    endDnd: (this.apiCall.bind(this, 'dnd.endDnd')) as Method<methods.DndEndDndArguments>,
-    endSnooze: (this.apiCall.bind(this, 'dnd.endSnooze')) as Method<methods.DndEndSnoozeArguments>,
-    info: (this.apiCall.bind(this, 'dnd.info')) as Method<methods.DndInfoArguments>,
-    setSnooze: (this.apiCall.bind(this, 'dnd.setSnooze')) as Method<methods.DndSetSnoozeArguments>,
-    teamInfo: (this.apiCall.bind(this, 'dnd.teamInfo')) as Method<methods.DndTeamInfoArguments>,
+    endDnd: this.apiCall.bind(this, 'dnd.endDnd') as Method<
+      methods.DndEndDndArguments,
+      responses.DndEndDndResponse
+    >,
+    endSnooze: this.apiCall.bind(this, 'dnd.endSnooze') as Method<
+      methods.DndEndSnoozeArguments,
+      responses.DndEndSnoozeResponse
+    >,
+    info: this.apiCall.bind(this, 'dnd.info') as Method<
+      methods.DndInfoArguments,
+      responses.DndInfoResponse
+    >,
+    setSnooze: this.apiCall.bind(this, 'dnd.setSnooze') as Method<
+      methods.DndSetSnoozeArguments,
+      responses.DndSetSnoozeResponse
+    >,
+    teamInfo: this.apiCall.bind(this, 'dnd.teamInfo') as Method<
+      methods.DndTeamInfoArguments,
+      responses.DndTeamInfoResponse
+    >,
   };
 
   /**
    * emoji method family
    */
   public readonly emoji = {
-    list: (this.apiCall.bind(this, 'emoji.list')) as Method<methods.EmojiListArguments>,
+    list: this.apiCall.bind(this, 'emoji.list') as Method<
+      methods.EmojiListArguments,
+      responses.EmojiListResponse
+    >,
   };
 
   /**
    * files method family
    */
   public readonly files = {
-    delete: (this.apiCall.bind(this, 'files.delete')) as Method<methods.FilesDeleteArguments>,
-    info: (this.apiCall.bind(this, 'files.info')) as Method<methods.FilesInfoArguments>,
-    list: (this.apiCall.bind(this, 'files.list')) as Method<methods.FilesListArguments>,
-    revokePublicURL:
-      (this.apiCall.bind(this, 'files.revokePublicURL')) as Method<methods.FilesRevokePublicURLArguments>,
-    sharedPublicURL:
-      (this.apiCall.bind(this, 'files.sharedPublicURL')) as Method<methods.FilesSharedPublicURLArguments>,
-    upload: (this.apiCall.bind(this, 'files.upload')) as Method<methods.FilesUploadArguments>,
+    delete: this.apiCall.bind(this, 'files.delete') as Method<
+      methods.FilesDeleteArguments,
+      responses.FilesDeleteResponse
+    >,
+    info: this.apiCall.bind(this, 'files.info') as Method<
+      methods.FilesInfoArguments,
+      responses.FilesInfoResponse
+    >,
+    list: this.apiCall.bind(this, 'files.list') as Method<
+      methods.FilesListArguments,
+      responses.FilesListResponse
+    >,
+    revokePublicURL: this.apiCall.bind(this, 'files.revokePublicURL') as Method<
+      methods.FilesRevokePublicURLArguments,
+      responses.FilesRevokePublicURLResponse
+    >,
+    sharedPublicURL: this.apiCall.bind(this, 'files.sharedPublicURL') as Method<
+      methods.FilesSharedPublicURLArguments,
+      responses.FilesSharedPublicURLResponse
+    >,
+    upload: this.apiCall.bind(this, 'files.upload') as Method<
+      methods.FilesUploadArguments,
+      responses.FilesUploadResponse
+    >,
     comments: {
-      add: (this.apiCall.bind(this, 'files.comments.add')) as Method<methods.FilesCommentsAddArguments>,
-      delete: (this.apiCall.bind(this, 'files.comments.delete')) as Method<methods.FilesCommentsDeleteArguments>,
-      edit: (this.apiCall.bind(this, 'files.comments.edit')) as Method<methods.FilesCommentsEditArguments>,
+      add: this.apiCall.bind(this, 'files.comments.add') as Method<
+        methods.FilesCommentsAddArguments,
+        responses.FilesCommentsAddResponse
+      >,
+      delete: this.apiCall.bind(this, 'files.comments.delete') as Method<
+        methods.FilesCommentsDeleteArguments,
+        responses.FilesCommentsDeleteResponse
+      >,
+      edit: this.apiCall.bind(this, 'files.comments.edit') as Method<
+        methods.FilesCommentsEditArguments,
+        responses.FilesCommentsEditResponse
+      >,
     },
   };
 
@@ -340,129 +561,297 @@ export class WebClient extends EventEmitter {
    * groups method family
    */
   public readonly groups = {
-    archive: (this.apiCall.bind(this, 'groups.archive')) as Method<methods.GroupsArchiveArguments>,
-    create: (this.apiCall.bind(this, 'groups.create')) as Method<methods.GroupsCreateArguments>,
-    createChild: (this.apiCall.bind(this, 'groups.createChild')) as Method<methods.GroupsCreateChildArguments>,
-    history: (this.apiCall.bind(this, 'groups.history')) as Method<methods.GroupsHistoryArguments>,
-    info: (this.apiCall.bind(this, 'groups.info')) as Method<methods.GroupsInfoArguments>,
-    invite: (this.apiCall.bind(this, 'groups.invite')) as Method<methods.GroupsInviteArguments>,
-    kick: (this.apiCall.bind(this, 'groups.kick')) as Method<methods.GroupsKickArguments>,
-    leave: (this.apiCall.bind(this, 'groups.leave')) as Method<methods.GroupsLeaveArguments>,
-    list: (this.apiCall.bind(this, 'groups.list')) as Method<methods.GroupsListArguments>,
-    mark: (this.apiCall.bind(this, 'groups.mark')) as Method<methods.GroupsMarkArguments>,
-    open: (this.apiCall.bind(this, 'groups.open')) as Method<methods.GroupsOpenArguments>,
-    rename: (this.apiCall.bind(this, 'groups.rename')) as Method<methods.GroupsRenameArguments>,
-    replies: (this.apiCall.bind(this, 'groups.replies')) as Method<methods.GroupsRepliesArguments>,
-    setPurpose: (this.apiCall.bind(this, 'groups.setPurpose')) as Method<methods.GroupsSetPurposeArguments>,
-    setTopic: (this.apiCall.bind(this, 'groups.setTopic')) as Method<methods.GroupsSetTopicArguments>,
-    unarchive: (this.apiCall.bind(this, 'groups.unarchive')) as Method<methods.GroupsUnarchiveArguments>,
+    archive: this.apiCall.bind(this, 'groups.archive') as Method<
+      methods.GroupsArchiveArguments,
+      responses.GroupsArchiveResponse
+    >,
+    create: this.apiCall.bind(this, 'groups.create') as Method<
+      methods.GroupsCreateArguments,
+      responses.GroupsCreateResponse
+    >,
+    createChild: this.apiCall.bind(this, 'groups.createChild') as Method<
+      methods.GroupsCreateChildArguments,
+      responses.GroupsCreateChildResponse
+    >,
+    history: this.apiCall.bind(this, 'groups.history') as Method<
+      methods.GroupsHistoryArguments,
+      responses.GroupsHistoryResponse
+    >,
+    info: this.apiCall.bind(this, 'groups.info') as Method<
+      methods.GroupsInfoArguments,
+      responses.GroupsInfoResponse
+    >,
+    invite: this.apiCall.bind(this, 'groups.invite') as Method<
+      methods.GroupsInviteArguments,
+      responses.GroupsInviteResponse
+    >,
+    kick: this.apiCall.bind(this, 'groups.kick') as Method<
+      methods.GroupsKickArguments,
+      responses.GroupsKickResponse
+    >,
+    leave: this.apiCall.bind(this, 'groups.leave') as Method<
+      methods.GroupsLeaveArguments,
+      responses.GroupsLeaveResponse
+    >,
+    list: this.apiCall.bind(this, 'groups.list') as Method<
+      methods.GroupsListArguments,
+      responses.GroupsListResponse
+    >,
+    mark: this.apiCall.bind(this, 'groups.mark') as Method<
+      methods.GroupsMarkArguments,
+      responses.GroupsMarkResponse
+    >,
+    open: this.apiCall.bind(this, 'groups.open') as Method<
+      methods.GroupsOpenArguments,
+      responses.GroupsOpenResponse
+    >,
+    rename: this.apiCall.bind(this, 'groups.rename') as Method<
+      methods.GroupsRenameArguments,
+      responses.GroupsRenameResponse
+    >,
+    replies: this.apiCall.bind(this, 'groups.replies') as Method<
+      methods.GroupsRepliesArguments,
+      responses.GroupsRepliesResponse
+    >,
+    setPurpose: this.apiCall.bind(this, 'groups.setPurpose') as Method<
+      methods.GroupsSetPurposeArguments,
+      responses.GroupsSetPurposeResponse
+    >,
+    setTopic: this.apiCall.bind(this, 'groups.setTopic') as Method<
+      methods.GroupsSetTopicArguments,
+      responses.GroupsSetTopicResponse
+    >,
+    unarchive: this.apiCall.bind(this, 'groups.unarchive') as Method<
+      methods.GroupsUnarchiveArguments,
+      responses.GroupsUnarchiveResponse
+    >,
   };
 
   /**
    * im method family
    */
   public readonly im = {
-    close: (this.apiCall.bind(this, 'im.close')) as Method<methods.IMCloseArguments>,
-    history: (this.apiCall.bind(this, 'im.history')) as Method<methods.IMHistoryArguments>,
-    list: (this.apiCall.bind(this, 'im.list')) as Method<methods.IMListArguments>,
-    mark: (this.apiCall.bind(this, 'im.mark')) as Method<methods.IMMarkArguments>,
-    open: (this.apiCall.bind(this, 'im.open')) as Method<methods.IMOpenArguments>,
-    replies: (this.apiCall.bind(this, 'im.replies')) as Method<methods.IMRepliesArguments>,
+    close: this.apiCall.bind(this, 'im.close') as Method<
+      methods.IMCloseArguments,
+      responses.IMCloseResponse
+    >,
+    history: this.apiCall.bind(this, 'im.history') as Method<
+      methods.IMHistoryArguments,
+      responses.IMHistoryResponse
+    >,
+    list: this.apiCall.bind(this, 'im.list') as Method<
+      methods.IMListArguments,
+      responses.IMListResponse
+    >,
+    mark: this.apiCall.bind(this, 'im.mark') as Method<
+      methods.IMMarkArguments,
+      responses.IMMarkResponse
+    >,
+    open: this.apiCall.bind(this, 'im.open') as Method<
+      methods.IMOpenArguments,
+      responses.IMOpenResponse
+    >,
+    replies: this.apiCall.bind(this, 'im.replies') as Method<
+      methods.IMRepliesArguments,
+      responses.IMRepliesResponse
+    >,
   };
 
   /**
    * migration method family
    */
   public readonly migration = {
-    exchange: (this.apiCall.bind(this, 'migration.exchange')) as Method<methods.MigrationExchangeArguments>,
+    exchange: this.apiCall.bind(this, 'migration.exchange') as Method<
+      methods.MigrationExchangeArguments,
+      responses.MigrationExchangeResponse
+    >,
   };
 
   /**
    * mpim method family
    */
   public readonly mpim = {
-    close: (this.apiCall.bind(this, 'mpim.close')) as Method<methods.MPIMCloseArguments>,
-    history: (this.apiCall.bind(this, 'mpim.history')) as Method<methods.MPIMHistoryArguments>,
-    list: (this.apiCall.bind(this, 'mpim.list')) as Method<methods.MPIMListArguments>,
-    mark: (this.apiCall.bind(this, 'mpim.mark')) as Method<methods.MPIMMarkArguments>,
-    open: (this.apiCall.bind(this, 'mpim.open')) as Method<methods.MPIMOpenArguments>,
-    replies: (this.apiCall.bind(this, 'mpim.replies')) as Method<methods.MPIMRepliesArguments>,
+    close: this.apiCall.bind(this, 'mpim.close') as Method<
+      methods.MPIMCloseArguments,
+      responses.MPIMCloseResponse
+    >,
+    history: this.apiCall.bind(this, 'mpim.history') as Method<
+      methods.MPIMHistoryArguments,
+      responses.MPIMHistoryResponse
+    >,
+    list: this.apiCall.bind(this, 'mpim.list') as Method<
+      methods.MPIMListArguments,
+      responses.MPIMListResponse
+    >,
+    mark: this.apiCall.bind(this, 'mpim.mark') as Method<
+      methods.MPIMMarkArguments,
+      responses.MPIMMarkResponse
+    >,
+    open: this.apiCall.bind(this, 'mpim.open') as Method<
+      methods.MPIMOpenArguments,
+      responses.MPIMOpenResponse
+    >,
+    replies: this.apiCall.bind(this, 'mpim.replies') as Method<
+      methods.MPIMRepliesArguments,
+      responses.MPIMRepliesResponse
+    >,
   };
 
   /**
    * oauth method family
    */
   public readonly oauth = {
-    access: (this.apiCall.bind(this, 'oauth.access')) as Method<methods.OAuthAccessArguments>,
-    token: (this.apiCall.bind(this, 'oauth.token')) as Method<methods.OAuthTokenArguments>,
+    access: this.apiCall.bind(this, 'oauth.access') as Method<
+      methods.OAuthAccessArguments,
+      responses.OAuthAccessResponse
+    >,
+    token: this.apiCall.bind(this, 'oauth.token') as Method<
+      methods.OAuthTokenArguments,
+      responses.OAuthTokenResponse
+    >,
   };
 
   /**
    * pins method family
    */
   public readonly pins = {
-    add: (this.apiCall.bind(this, 'pins.add')) as Method<methods.PinsAddArguments>,
-    list: (this.apiCall.bind(this, 'pins.list')) as Method<methods.PinsListArguments>,
-    remove: (this.apiCall.bind(this, 'pins.remove')) as Method<methods.PinsRemoveArguments>,
+    add: this.apiCall.bind(this, 'pins.add') as Method<
+      methods.PinsAddArguments,
+      responses.PinsAddResponse
+    >,
+    list: this.apiCall.bind(this, 'pins.list') as Method<
+      methods.PinsListArguments,
+      responses.PinsListResponse
+    >,
+    remove: this.apiCall.bind(this, 'pins.remove') as Method<
+      methods.PinsRemoveArguments,
+      responses.PinsRemoveResponse
+    >,
   };
 
   /**
    * reactions method family
    */
   public readonly reactions = {
-    add: (this.apiCall.bind(this, 'reactions.add')) as Method<methods.ReactionsAddArguments>,
-    get: (this.apiCall.bind(this, 'reactions.get')) as Method<methods.ReactionsGetArguments>,
-    list: (this.apiCall.bind(this, 'reactions.list')) as Method<methods.ReactionsListArguments>,
-    remove: (this.apiCall.bind(this, 'reactions.remove')) as Method<methods.ReactionsRemoveArguments>,
+    add: this.apiCall.bind(this, 'reactions.add') as Method<
+      methods.ReactionsAddArguments,
+      responses.ReactionsAddResponse
+    >,
+    get: this.apiCall.bind(this, 'reactions.get') as Method<
+      methods.ReactionsGetArguments,
+      responses.ReactionsGetResponse
+    >,
+    list: this.apiCall.bind(this, 'reactions.list') as Method<
+      methods.ReactionsListArguments,
+      responses.ReactionsListResponse
+    >,
+    remove: this.apiCall.bind(this, 'reactions.remove') as Method<
+      methods.ReactionsRemoveArguments,
+      responses.ReactionsRemoveResponse
+    >,
   };
 
   /**
    * reminders method family
    */
   public readonly reminders = {
-    add: (this.apiCall.bind(this, 'reminders.add')) as Method<methods.RemindersAddArguments>,
-    complete: (this.apiCall.bind(this, 'reminders.complete')) as Method<methods.RemindersCompleteArguments>,
-    delete: (this.apiCall.bind(this, 'reminders.delete')) as Method<methods.RemindersDeleteArguments>,
-    info: (this.apiCall.bind(this, 'reminders.info')) as Method<methods.RemindersInfoArguments>,
-    list: (this.apiCall.bind(this, 'reminders.list')) as Method<methods.RemindersListArguments>,
+    add: this.apiCall.bind(this, 'reminders.add') as Method<
+      methods.RemindersAddArguments,
+      responses.RemindersAddResponse
+    >,
+    complete: this.apiCall.bind(this, 'reminders.complete') as Method<
+      methods.RemindersCompleteArguments,
+      responses.RemindersCompleteResponse
+    >,
+    delete: this.apiCall.bind(this, 'reminders.delete') as Method<
+      methods.RemindersDeleteArguments,
+      responses.RemindersDeleteResponse
+    >,
+    info: this.apiCall.bind(this, 'reminders.info') as Method<
+      methods.RemindersInfoArguments,
+      responses.RemindersInfoResponse
+    >,
+    list: this.apiCall.bind(this, 'reminders.list') as Method<
+      methods.RemindersListArguments,
+      responses.RemindersListResponse
+    >,
   };
 
   /**
    * rtm method family
    */
   public readonly rtm = {
-    connect: (this.apiCall.bind(this, 'rtm.connect')) as Method<methods.RTMConnectArguments>,
-    start: (this.apiCall.bind(this, 'rtm.start')) as Method<methods.RTMStartArguments>,
+    connect: this.apiCall.bind(this, 'rtm.connect') as Method<
+      methods.RTMConnectArguments,
+      responses.RTMConnectResponse
+    >,
+    start: this.apiCall.bind(this, 'rtm.start') as Method<
+      methods.RTMStartArguments,
+      responses.RTMStartResponse
+    >,
   };
 
   /**
    * search method family
    */
   public readonly search = {
-    all: (this.apiCall.bind(this, 'search.all')) as Method<methods.SearchAllArguments>,
-    files: (this.apiCall.bind(this, 'search.files')) as Method<methods.SearchFilesArguments>,
-    messages: (this.apiCall.bind(this, 'search.messages')) as Method<methods.SearchMessagesArguments>,
+    all: this.apiCall.bind(this, 'search.all') as Method<
+      methods.SearchAllArguments,
+      responses.SearchAllResponse
+    >,
+    files: this.apiCall.bind(this, 'search.files') as Method<
+      methods.SearchFilesArguments,
+      responses.SearchFilesResponse
+    >,
+    messages: this.apiCall.bind(this, 'search.messages') as Method<
+      methods.SearchMessagesArguments,
+      responses.SearchMessagesResponse
+    >,
   };
 
   /**
    * stars method family
    */
   public readonly stars = {
-    add: (this.apiCall.bind(this, 'stars.add')) as Method<methods.StarsAddArguments>,
-    list: (this.apiCall.bind(this, 'stars.list')) as Method<methods.StarsListArguments>,
-    remove: (this.apiCall.bind(this, 'stars.remove')) as Method<methods.StarsRemoveArguments>,
+    add: this.apiCall.bind(this, 'stars.add') as Method<
+      methods.StarsAddArguments,
+      responses.StarsAddResponse
+    >,
+    list: this.apiCall.bind(this, 'stars.list') as Method<
+      methods.StarsListArguments,
+      responses.StarsListResponse
+    >,
+    remove: this.apiCall.bind(this, 'stars.remove') as Method<
+      methods.StarsRemoveArguments,
+      responses.StarsRemoveResponse
+    >,
   };
 
   /**
    * team method family
    */
   public readonly team = {
-    accessLogs: (this.apiCall.bind(this, 'team.accessLogs')) as Method<methods.TeamAccessLogsArguments>,
-    billableInfo: (this.apiCall.bind(this, 'team.billableInfo')) as Method<methods.TeamBillableInfoArguments>,
-    info: (this.apiCall.bind(this, 'team.info')) as Method<methods.TeamInfoArguments>,
-    integrationLogs: (this.apiCall.bind(this, 'team.integrationLogs')) as Method<methods.TeamIntegrationLogsArguments>,
+    accessLogs: this.apiCall.bind(this, 'team.accessLogs') as Method<
+      methods.TeamAccessLogsArguments,
+      responses.TeamAccessLogsResponse
+    >,
+    billableInfo: this.apiCall.bind(this, 'team.billableInfo') as Method<
+      methods.TeamBillableInfoArguments,
+      responses.TeamBillableInfoResponse
+    >,
+    info: this.apiCall.bind(this, 'team.info') as Method<
+      methods.TeamInfoArguments,
+      responses.TeamInfoResponse
+    >,
+    integrationLogs: this.apiCall.bind(this, 'team.integrationLogs') as Method<
+      methods.TeamIntegrationLogsArguments,
+      responses.TeamIntegrationLogsResponse
+    >,
     profile: {
-      get: (this.apiCall.bind(this, 'team.profile.get')) as Method<methods.TeamProfileGetArguments>,
+      get: this.apiCall.bind(this, 'team.profile.get') as Method<
+        methods.TeamProfileGetArguments,
+        responses.TeamProfileGetResponse
+      >,
     },
   };
 
@@ -470,14 +859,35 @@ export class WebClient extends EventEmitter {
    * usergroups method family
    */
   public readonly usergroups = {
-    create: (this.apiCall.bind(this, 'usergroups.create')) as Method<methods.UsergroupsCreateArguments>,
-    disable: (this.apiCall.bind(this, 'usergroups.disable')) as Method<methods.UsergroupsDisableArguments>,
-    enable: (this.apiCall.bind(this, 'usergroups.enable')) as Method<methods.UsergroupsEnableArguments>,
-    list: (this.apiCall.bind(this, 'usergroups.list')) as Method<methods.UsergroupsListArguments>,
-    update: (this.apiCall.bind(this, 'usergroups.update')) as Method<methods.UsergroupsUpdateArguments>,
+    create: this.apiCall.bind(this, 'usergroups.create') as Method<
+      methods.UsergroupsCreateArguments,
+      responses.UsergroupsCreateResponse
+    >,
+    disable: this.apiCall.bind(this, 'usergroups.disable') as Method<
+      methods.UsergroupsDisableArguments,
+      responses.UsergroupsDisableResponse
+    >,
+    enable: this.apiCall.bind(this, 'usergroups.enable') as Method<
+      methods.UsergroupsEnableArguments,
+      responses.UsergroupsEnableResponse
+    >,
+    list: this.apiCall.bind(this, 'usergroups.list') as Method<
+      methods.UsergroupsListArguments,
+      responses.UsergroupsListResponse
+    >,
+    update: this.apiCall.bind(this, 'usergroups.update') as Method<
+      methods.UsergroupsUpdateArguments,
+      responses.UsergroupsUpdateResponse
+    >,
     users: {
-      list: (this.apiCall.bind(this, 'usergroups.users.list')) as Method<methods.UsergroupsUsersListArguments>,
-      update: (this.apiCall.bind(this, 'usergroups.users.update')) as Method<methods.UsergroupsUsersUpdateArguments>,
+      list: this.apiCall.bind(this, 'usergroups.users.list') as Method<
+        methods.UsergroupsUsersListArguments,
+        responses.UsergroupsUsersListResponse
+      >,
+      update: this.apiCall.bind(this, 'usergroups.users.update') as Method<
+        methods.UsergroupsUsersUpdateArguments,
+        responses.UsergroupsUsersUpdateResponse
+      >,
     },
   };
 
@@ -485,19 +895,55 @@ export class WebClient extends EventEmitter {
    * users method family
    */
   public readonly users = {
-    conversations: (this.apiCall.bind(this, 'users.conversations')) as Method<methods.UsersConversationsArguments>,
-    deletePhoto: (this.apiCall.bind(this, 'users.deletePhoto')) as Method<methods.UsersDeletePhotoArguments>,
-    getPresence: (this.apiCall.bind(this, 'users.getPresence')) as Method<methods.UsersGetPresenceArguments>,
-    identity: (this.apiCall.bind(this, 'users.identity')) as Method<methods.UsersIdentityArguments>,
-    info: (this.apiCall.bind(this, 'users.info')) as Method<methods.UsersInfoArguments>,
-    list: (this.apiCall.bind(this, 'users.list')) as Method<methods.UsersListArguments>,
-    lookupByEmail: (this.apiCall.bind(this, 'users.lookupByEmail')) as Method<methods.UsersLookupByEmailArguments>,
-    setActive: (this.apiCall.bind(this, 'users.setActive')) as Method<methods.UsersSetActiveArguments>,
-    setPhoto: (this.apiCall.bind(this, 'users.setPhoto')) as Method<methods.UsersSetPhotoArguments>,
-    setPresence: (this.apiCall.bind(this, 'users.setPresence')) as Method<methods.UsersSetPresenceArguments>,
+    conversations: this.apiCall.bind(this, 'users.conversations') as Method<
+      methods.UsersConversationsArguments,
+      responses.UsersConversationsResponse
+    >,
+    deletePhoto: this.apiCall.bind(this, 'users.deletePhoto') as Method<
+      methods.UsersDeletePhotoArguments,
+      responses.UsersDeletePhotoResponse
+    >,
+    getPresence: this.apiCall.bind(this, 'users.getPresence') as Method<
+      methods.UsersGetPresenceArguments,
+      responses.UsersGetPresenceResponse
+    >,
+    identity: this.apiCall.bind(this, 'users.identity') as Method<
+      methods.UsersIdentityArguments,
+      responses.UsersIdentityResponse
+    >,
+    info: this.apiCall.bind(this, 'users.info') as Method<
+      methods.UsersInfoArguments,
+      responses.UsersInfoResponse
+    >,
+    list: this.apiCall.bind(this, 'users.list') as Method<
+      methods.UsersListArguments,
+      responses.UsersListResponse
+    >,
+    lookupByEmail: this.apiCall.bind(this, 'users.lookupByEmail') as Method<
+      methods.UsersLookupByEmailArguments,
+      responses.UsersLookupByEmailResponse
+    >,
+    setActive: this.apiCall.bind(this, 'users.setActive') as Method<
+      methods.UsersSetActiveArguments,
+      responses.UsersSetActiveResponse
+    >,
+    setPhoto: this.apiCall.bind(this, 'users.setPhoto') as Method<
+      methods.UsersSetPhotoArguments,
+      responses.UsersSetPhotoResponse
+    >,
+    setPresence: this.apiCall.bind(this, 'users.setPresence') as Method<
+      methods.UsersSetPresenceArguments,
+      responses.UsersSetPresenceResponse
+    >,
     profile: {
-      get: (this.apiCall.bind(this, 'users.profile.get')) as Method<methods.UsersProfileGetArguments>,
-      set: (this.apiCall.bind(this, 'users.profile.set')) as Method<methods.UsersProfileSetArguments>,
+      get: this.apiCall.bind(this, 'users.profile.get') as Method<
+        methods.UsersProfileGetArguments,
+        responses.UsersProfileGetResponse
+      >,
+      set: this.apiCall.bind(this, 'users.profile.set') as Method<
+        methods.UsersProfileSetArguments,
+        responses.UsersProfileSetResponse
+      >,
     },
   };
 
@@ -509,28 +955,33 @@ export class WebClient extends EventEmitter {
    *
    * @param options arguments for the Web API method
    */
-  private serializeApiCallOptions(options: WebAPICallOptions): FormCanBeURLEncoded | BodyCanBeFormMultipart {
+  private serializeApiCallOptions(
+    options: WebAPICallOptions,
+  ): FormCanBeURLEncoded | BodyCanBeFormMultipart {
     // The following operation both flattens complex objects into a JSON-encoded strings and searches the values for
     // binary content
     let containsBinaryData = false;
-    const flattened = objectEntries(options)
-      .map(([key, value]) => {
-        if (value === undefined || value === null) {
-          return [];
-        }
+    const flattened = objectEntries(options).map(([key, value]) => {
+      if (value === undefined || value === null) {
+        return [];
+      }
 
-        let serializedValue = value;
+      let serializedValue = value;
 
-        if (Buffer.isBuffer(value) || isStream(value)) {
-          containsBinaryData = true;
-        } else if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
-          // if value is anything other than string, number, boolean, binary data, a Stream, or a Buffer, then encode it
-          // as a JSON string.
-          serializedValue = JSON.stringify(value);
-        }
+      if (Buffer.isBuffer(value) || isStream(value)) {
+        containsBinaryData = true;
+      } else if (
+        typeof value !== 'string' &&
+        typeof value !== 'number' &&
+        typeof value !== 'boolean'
+      ) {
+        // if value is anything other than string, number, boolean, binary data, a Stream, or a Buffer, then encode it
+        // as a JSON string.
+        serializedValue = JSON.stringify(value);
+      }
 
-        return [key, serializedValue];
-      });
+      return [key, serializedValue];
+    });
 
     // A body with binary content should be serialized as multipart/form-data
     if (containsBinaryData) {
@@ -544,7 +995,7 @@ export class WebClient extends EventEmitter {
             // https://github.com/form-data/form-data/blob/028c21e0f93c5fefa46a7bbf1ba753e4f627ab7a/lib/form_data.js#L227-L230
             // formidable and the browser add a name property
             // fs- and request- streams have path property
-            const streamOrBuffer: any = (value as any);
+            const streamOrBuffer: any = value as any;
             if (typeof streamOrBuffer.name === 'string') {
               return basename(streamOrBuffer.name);
             }
@@ -573,22 +1024,28 @@ export class WebClient extends EventEmitter {
   /**
    * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
    * HTTP headers into the object.
-   * @param response
    */
   private buildResult(response: got.Response<string>): WebAPICallResult {
     const data = JSON.parse(response.body);
 
     // add scopes metadata from headers
     if (response.headers['x-oauth-scopes'] !== undefined) {
-      data.scopes = (response.headers['x-oauth-scopes'] as string).trim().split(/\s*,\s*/);
+      data.scopes = (response.headers['x-oauth-scopes'] as string)
+        .trim()
+        .split(/\s*,\s*/);
     }
     if (response.headers['x-accepted-oauth-scopes'] !== undefined) {
-      data.acceptedScopes = (response.headers['x-accepted-oauth-scopes'] as string).trim().split(/\s*,\s*/);
+      data.acceptedScopes = (response.headers[
+        'x-accepted-oauth-scopes'
+      ] as string)
+        .trim()
+        .split(/\s*,\s*/);
     }
 
     // add retry metadata from headers
     if (response.headers['retry-after'] !== undefined) {
-      data.retryAfter = parseInt((response.headers['retry-after'] as string), 10) * 1000;
+      data.retryAfter =
+        parseInt(response.headers['retry-after'] as string, 10) * 1000;
     }
 
     return data;
@@ -612,8 +1069,7 @@ export interface WebClientOptions {
 }
 
 // NOTE: could potentially add GotOptions to this interface (using &, or maybe as an embedded key)
-export interface WebAPICallOptions {
-}
+export interface WebAPICallOptions {}
 
 export interface WebAPICallResult {
   ok: boolean;
@@ -628,7 +1084,11 @@ export interface WebAPIResultCallback {
   (error: WebAPICallError, result: WebAPICallResult): void;
 }
 
-export type WebAPICallError = WebAPIPlatformError | WebAPIRequestError | WebAPIReadError | WebAPIHTTPError;
+export type WebAPICallError =
+  | WebAPIPlatformError
+  | WebAPIRequestError
+  | WebAPIReadError
+  | WebAPIHTTPError;
 
 export interface WebAPIPlatformError extends CodedError {
   code: ErrorCode.PlatformError;
@@ -662,22 +1122,22 @@ interface FormCanBeURLEncoded {
   [key: string]: string | number | boolean;
 }
 
-interface BodyCanBeFormMultipart extends Readable { }
+interface BodyCanBeFormMultipart extends Readable {}
 
 /**
  * Determines whether a request body object should be treated as FormData-encodable (Content-Type=multipart/form-data).
  * @param body a request body
  */
-function canBodyBeFormMultipart(body: FormCanBeURLEncoded | BodyCanBeFormMultipart): body is BodyCanBeFormMultipart {
+function canBodyBeFormMultipart(
+  body: FormCanBeURLEncoded | BodyCanBeFormMultipart,
+): body is BodyCanBeFormMultipart {
   // tried using `isStream.readable(body)` but that failes because the object doesn't have a `_read()` method or a
   // `_readableState` property
   return isStream(body);
 }
 
-
 /**
  * A factory to create WebAPIRequestError objects
- * @param original
  */
 function requestErrorWithOriginal(original: Error): WebAPIRequestError {
   const error = errorWithCode(
@@ -686,12 +1146,11 @@ function requestErrorWithOriginal(original: Error): WebAPIRequestError {
     ErrorCode.RequestError,
   ) as Partial<WebAPIRequestError>;
   error.original = original;
-  return (error as WebAPIRequestError);
+  return error as WebAPIRequestError;
 }
 
 /**
  * A factory to create WebAPIReadError objects
- * @param original
  */
 function readErrorWithOriginal(original: Error): WebAPIReadError {
   const error = errorWithCode(
@@ -700,19 +1159,22 @@ function readErrorWithOriginal(original: Error): WebAPIReadError {
     ErrorCode.ReadError,
   ) as Partial<WebAPIReadError>;
   error.original = original;
-  return (error as WebAPIReadError);
+  return error as WebAPIReadError;
 }
 
 /**
  * A factory to create WebAPIHTTPError objects
- * @param original
  */
 function httpErrorWithOriginal(original: Error): WebAPIHTTPError {
   const error = errorWithCode(
     // any cast is used because the got definition file doesn't export the got.HTTPError type
-    new Error(`An HTTP protocol error occurred: statusCode = ${(original as any).statusCode}`),
+    new Error(
+      `An HTTP protocol error occurred: statusCode = ${
+        (original as any).statusCode
+      }`,
+    ),
     ErrorCode.HTTPError,
   ) as Partial<WebAPIHTTPError>;
   error.original = original;
-  return (error as WebAPIHTTPError);
+  return error as WebAPIHTTPError;
 }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,5 +1,9 @@
 import { Stream } from 'stream';
-import { WebAPICallOptions, WebAPIResultCallback, WebAPICallResult } from './WebClient';
+import {
+  WebAPICallOptions,
+  WebAPIResultCallback,
+  WebAPICallResult,
+} from './WebClient';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
 // NOTE: not clear if these interfaces should be exported at the top-level
@@ -7,10 +11,16 @@ import { WebAPICallOptions, WebAPIResultCallback, WebAPICallResult } from './Web
 /**
  * Generic method definition
  */
-export default interface Method<MethodArguments extends WebAPICallOptions> {
+export default interface Method<
+  MethodArguments extends WebAPICallOptions,
+  ResponseType extends WebAPICallResult
+> {
   // TODO: can we create a relationship between MethodArguments and a MethodResult type?
-  (options?: MethodArguments & AuxiliaryArguments): Promise<WebAPICallResult>;
-  (options: MethodArguments & AuxiliaryArguments, callback: WebAPIResultCallback): void;
+  (options?: MethodArguments & AuxiliaryArguments): Promise<ResponseType>;
+  (
+    options: MethodArguments & AuxiliaryArguments,
+    callback: WebAPIResultCallback,
+  ): void;
 }
 
 /*
@@ -105,7 +115,7 @@ export interface AttachmentAction {
   name?: string;
   options?: OptionField[];
   option_groups?: {
-    text: string
+    text: string;
     options: OptionField[];
   }[];
   selected_options?: OptionField[];
@@ -142,12 +152,12 @@ export interface SelectOption {
  * MethodArguments types (no formal relationship other than the generic constraint in Method<>)
  */
 
-  /*
+/*
    * `api.*`
    */
 export type APITestArguments = {};
 
-  /*
+/*
    * `apps.*`
    */
 export type AppsPermissionsInfoArguments = TokenOverridable & {};
@@ -156,7 +166,7 @@ export type AppsPermissionsRequestArguments = TokenOverridable & {
   trigger_id: string;
 };
 
-  /*
+/*
    * `auth.*`
    */
 export type AuthRevokeArguments = TokenOverridable & {
@@ -164,14 +174,14 @@ export type AuthRevokeArguments = TokenOverridable & {
 };
 export type AuthTestArguments = TokenOverridable & {};
 
-  /*
+/*
    * `bots.*`
    */
 export type BotsInfoArguments = TokenOverridable & {
   bot?: string;
 };
 
-  /*
+/*
    * `channels.*`
    */
 export type ChannelsArchiveArguments = TokenOverridable & {
@@ -181,14 +191,16 @@ export type ChannelsCreateArguments = TokenOverridable & {
   name: string;
   validate?: boolean;
 };
-export type ChannelsHistoryArguments = TokenOverridable & TimelinePaginationEnabled & {
-  channel: string;
-  count?: number;
-  unreads?: boolean;
-};
-export type ChannelsInfoArguments = TokenOverridable & LocaleAware & {
-  channel: string;
-};
+export type ChannelsHistoryArguments = TokenOverridable &
+  TimelinePaginationEnabled & {
+    channel: string;
+    count?: number;
+    unreads?: boolean;
+  };
+export type ChannelsInfoArguments = TokenOverridable &
+  LocaleAware & {
+    channel: string;
+  };
 export type ChannelsInviteArguments = TokenOverridable & {
   channel: string;
   user: string;
@@ -204,10 +216,11 @@ export type ChannelsKickArguments = TokenOverridable & {
 export type ChannelsLeaveArguments = TokenOverridable & {
   channel: string;
 };
-export type ChannelsListArguments = TokenOverridable & CursorPaginationEnabled & {
-  exclude_archived: boolean;
-  exclude_members: boolean;
-};
+export type ChannelsListArguments = TokenOverridable &
+  CursorPaginationEnabled & {
+    exclude_archived: boolean;
+    exclude_members: boolean;
+  };
 export type ChannelsMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
@@ -233,13 +246,13 @@ export type ChannelsUnarchiveArguments = TokenOverridable & {
   channel: string;
 };
 
-  /*
+/*
    * `chat.*`
    */
 export type ChatDeleteArguments = TokenOverridable & {
   channel: string;
   ts: string;
-  as_user?: boolean
+  as_user?: boolean;
 };
 export type ChatGetPermalinkArguments = TokenOverridable & {
   channel: string;
@@ -292,7 +305,7 @@ export type ChatUpdateArguments = TokenOverridable & {
   parse?: 'full' | 'none';
 };
 
-  /*
+/*
    * `conversations.*`
    */
 export type ConversationsArchiveArguments = TokenOverridable & {
@@ -305,12 +318,15 @@ export type ConversationsCreateArguments = TokenOverridable & {
   name: string;
   is_private?: boolean;
 };
-export type ConversationsHistoryArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
-  channel: string;
-};
-export type ConversationsInfoArguments = TokenOverridable & LocaleAware & {
-  channel: string;
-};
+export type ConversationsHistoryArguments = TokenOverridable &
+  CursorPaginationEnabled &
+  TimelinePaginationEnabled & {
+    channel: string;
+  };
+export type ConversationsInfoArguments = TokenOverridable &
+  LocaleAware & {
+    channel: string;
+  };
 export type ConversationsInviteArguments = TokenOverridable & {
   channel: string;
   users: string; // comma-separated list of users
@@ -325,13 +341,15 @@ export type ConversationsKickArguments = TokenOverridable & {
 export type ConversationsLeaveArguments = TokenOverridable & {
   channel: string;
 };
-export type ConversationsListArguments = TokenOverridable & CursorPaginationEnabled & {
-  exclude_archived?: boolean;
-  types?: string; // comma-separated list of conversation types
-};
-export type ConversationsMembersArguments = TokenOverridable & CursorPaginationEnabled & {
-  channel: string;
-};
+export type ConversationsListArguments = TokenOverridable &
+  CursorPaginationEnabled & {
+    exclude_archived?: boolean;
+    types?: string; // comma-separated list of conversation types
+  };
+export type ConversationsMembersArguments = TokenOverridable &
+  CursorPaginationEnabled & {
+    channel: string;
+  };
 export type ConversationsOpenArguments = TokenOverridable & {
   channel?: string;
   users?: string; // comma-separated list of users
@@ -341,10 +359,12 @@ export type ConversationsRenameArguments = TokenOverridable & {
   channel: string;
   name: string;
 };
-export type ConversationsRepliesArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
-  channel: string;
-  ts: string;
-};
+export type ConversationsRepliesArguments = TokenOverridable &
+  CursorPaginationEnabled &
+  TimelinePaginationEnabled & {
+    channel: string;
+    ts: string;
+  };
 export type ConversationsSetPurposeArguments = TokenOverridable & {
   channel: string;
   purpose: string;
@@ -357,7 +377,7 @@ export type ConversationsUnarchiveArguments = TokenOverridable & {
   channel: string;
 };
 
-  /*
+/*
    * `dialog.*`
    */
 export type DialogOpenArguments = TokenOverridable & {
@@ -365,7 +385,7 @@ export type DialogOpenArguments = TokenOverridable & {
   dialog: Dialog;
 };
 
-  /*
+/*
    * `dnd.*`
    */
 export type DndEndDndArguments = TokenOverridable;
@@ -380,12 +400,12 @@ export type DndTeamInfoArguments = TokenOverridable & {
   users?: string; // comma-separated list of users
 };
 
-  /*
+/*
    * `emoji.*`
    */
 export type EmojiListArguments = TokenOverridable;
 
-  /*
+/*
    * `files.*`
    */
 export type FilesDeleteArguments = TokenOverridable & {
@@ -434,7 +454,7 @@ export type FilesCommentsEditArguments = TokenOverridable & {
   id: string; // comment id
 };
 
-  /*
+/*
    * `groups.*`
    */
 export type GroupsArchiveArguments = TokenOverridable & {
@@ -447,13 +467,16 @@ export type GroupsCreateArguments = TokenOverridable & {
 export type GroupsCreateChildArguments = TokenOverridable & {
   channel: string;
 };
-export type GroupsHistoryArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
-  channel: string;
-  unreads?: boolean;
-};
-export type GroupsInfoArguments = TokenOverridable & LocaleAware & {
-  channel: string;
-};
+export type GroupsHistoryArguments = TokenOverridable &
+  CursorPaginationEnabled &
+  TimelinePaginationEnabled & {
+    channel: string;
+    unreads?: boolean;
+  };
+export type GroupsInfoArguments = TokenOverridable &
+  LocaleAware & {
+    channel: string;
+  };
 export type GroupsInviteArguments = TokenOverridable & {
   channel: string;
   user: string;
@@ -497,32 +520,34 @@ export type GroupsUnarchiveArguments = TokenOverridable & {
   channel: string;
 };
 
-  /*
+/*
    * `im.*`
    */
 export type IMCloseArguments = TokenOverridable & {
   channel: string;
 };
-export type IMHistoryArguments = TokenOverridable & TimelinePaginationEnabled & {
-  channel: string;
-  count?: number;
-  unreads?: boolean;
-};
+export type IMHistoryArguments = TokenOverridable &
+  TimelinePaginationEnabled & {
+    channel: string;
+    count?: number;
+    unreads?: boolean;
+  };
 export type IMListArguments = TokenOverridable & CursorPaginationEnabled;
 export type IMMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
 };
-export type IMOpenArguments = TokenOverridable & LocaleAware & {
-  user: string;
-  return_im?: boolean;
-};
+export type IMOpenArguments = TokenOverridable &
+  LocaleAware & {
+    user: string;
+    return_im?: boolean;
+  };
 export type IMRepliesArguments = TokenOverridable & {
   channel: string;
   thread_ts?: string;
 };
 
-  /*
+/*
    * `migration.*`
    */
 export type MigrationExchangeArguments = TokenOverridable & {
@@ -530,17 +555,18 @@ export type MigrationExchangeArguments = TokenOverridable & {
   to_old?: boolean;
 };
 
-  /*
+/*
    * `mpim.*`
    */
 export type MPIMCloseArguments = TokenOverridable & {
   channel: string;
 };
-export type MPIMHistoryArguments = TokenOverridable & TimelinePaginationEnabled & {
-  channel: string;
-  count?: number;
-  unreads?: boolean;
-};
+export type MPIMHistoryArguments = TokenOverridable &
+  TimelinePaginationEnabled & {
+    channel: string;
+    count?: number;
+    unreads?: boolean;
+  };
 export type MPIMListArguments = TokenOverridable;
 export type MPIMMarkArguments = TokenOverridable & {
   channel: string;
@@ -554,7 +580,7 @@ export type MPIMRepliesArguments = TokenOverridable & {
   thread_ts: string;
 };
 
-  /*
+/*
    * `oauth.*`
    */
 export type OAuthAccessArguments = {
@@ -571,7 +597,7 @@ export type OAuthTokenArguments = {
   single_channel?: '0' | '1';
 };
 
-  /*
+/*
    * `pins.*`
    */
 export type PinsAddArguments = TokenOverridable & {
@@ -592,7 +618,7 @@ export type PinsRemoveArguments = TokenOverridable & {
   timestamp?: string;
 };
 
-  /*
+/*
    * `reactions.*`
    */
 export type ReactionsAddArguments = TokenOverridable & {
@@ -626,7 +652,7 @@ export type ReactionsRemoveArguments = TokenOverridable & {
   file_comment?: string;
 };
 
-  /*
+/*
    * `reminders.*`
    */
 export type RemindersAddArguments = TokenOverridable & {
@@ -645,23 +671,24 @@ export type RemindersInfoArguments = TokenOverridable & {
 };
 export type RemindersListArguments = TokenOverridable;
 
-  /*
+/*
    * `rtm.*`
    */
 export type RTMConnectArguments = TokenOverridable & {
   batch_presence_aware?: boolean;
   presence_sub?: boolean;
 };
-export type RTMStartArguments = TokenOverridable & LocaleAware & {
-  batch_presence_aware?: boolean;
-  mpim_aware?: boolean;
-  no_latest?: '0' | '1';
-  no_unreads?: string;
-  presence_sub?: boolean;
-  simple_latest?: boolean;
-};
+export type RTMStartArguments = TokenOverridable &
+  LocaleAware & {
+    batch_presence_aware?: boolean;
+    mpim_aware?: boolean;
+    no_latest?: '0' | '1';
+    no_unreads?: string;
+    presence_sub?: boolean;
+    simple_latest?: boolean;
+  };
 
-  /*
+/*
    * `search.*`
    */
 export type SearchAllArguments = TokenOverridable & {
@@ -675,7 +702,7 @@ export type SearchAllArguments = TokenOverridable & {
 export type SearchFilesArguments = SearchAllArguments;
 export type SearchMessagesArguments = SearchAllArguments;
 
-  /*
+/*
    * `stars.*`
    */
 export type StarsAddArguments = TokenOverridable & {
@@ -697,7 +724,7 @@ export type StarsRemoveArguments = TokenOverridable & {
   file_comment?: string;
 };
 
-  /*
+/*
    * `team.*`
    */
 export type TeamAccessLogsArguments = TokenOverridable & {
@@ -721,7 +748,7 @@ export type TeamProfileGetArguments = TokenOverridable & {
   visibility?: 'all' | 'visible' | 'hidden';
 };
 
-  /*
+/*
    * `usergroups.*`
    */
 export type UsergroupsCreateArguments = TokenOverridable & {
@@ -762,25 +789,29 @@ export type UsergroupsUsersUpdateArguments = TokenOverridable & {
   include_count?: boolean;
 };
 
-  /*
+/*
    * `users.*`
    */
-export type UsersConversationsArguments = TokenOverridable & CursorPaginationEnabled & {
-  exclude_archived?: boolean;
-  types?: string; // comma-separated list of conversation types
-  user?: string;
-};
+export type UsersConversationsArguments = TokenOverridable &
+  CursorPaginationEnabled & {
+    exclude_archived?: boolean;
+    types?: string; // comma-separated list of conversation types
+    user?: string;
+  };
 export type UsersDeletePhotoArguments = TokenOverridable;
 export type UsersGetPresenceArguments = TokenOverridable & {
   user: string;
 };
 export type UsersIdentityArguments = TokenOverridable;
-export type UsersInfoArguments = TokenOverridable & LocaleAware & {
-  user: string;
-};
-export type UsersListArguments = TokenOverridable & CursorPaginationEnabled & LocaleAware & {
-  presence?: boolean; // deprecated, defaults to false
-};
+export type UsersInfoArguments = TokenOverridable &
+  LocaleAware & {
+    user: string;
+  };
+export type UsersListArguments = TokenOverridable &
+  CursorPaginationEnabled &
+  LocaleAware & {
+    presence?: boolean; // deprecated, defaults to false
+  };
 export type UsersLookupByEmailArguments = TokenOverridable & {
   email: string;
 };

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,0 +1,2430 @@
+export interface Im {
+  is_org_shared: boolean;
+  created: number;
+  is_user_deleted: boolean;
+  priority?: number;
+  user: user_id;
+  is_im: boolean;
+  id: dm_id;
+}
+
+export interface User {
+  profile: UserProfile;
+  updated: number;
+  tz: string;
+  name: string;
+  deleted: boolean;
+  is_app_user: boolean;
+  is_bot: boolean;
+  tz_label: string;
+  real_name: string;
+  locale?: string;
+  team_id: team;
+  is_admin: boolean;
+  is_ultra_restricted: boolean;
+  is_owner: boolean;
+  is_restricted: boolean;
+  tz_offset: number;
+  has_2fa?: boolean;
+  id: user_id;
+  color: string;
+  is_primary_owner: boolean;
+}
+
+export type comment_id = string;
+export type bot_id = string;
+export interface Paging {
+  count: number;
+  total: number;
+  page: number;
+  pages?: number;
+}
+
+export type team = string;
+export interface FileObjectWithIdOnly {
+  [key: string]: any;
+}
+
+export type ts = string;
+export interface File {
+  thumb_480_w?: number;
+  reactions?: Reaction[];
+  image_exif_rotation?: number;
+  filetype?: string;
+  thumb_800_h?: number;
+  thumb_480?: string;
+  display_as_bot?: boolean;
+  thumb_800_w?: number;
+  thumb_64?: string;
+  size?: number;
+  original_h?: number;
+  thumb_360_w?: number;
+  title?: string;
+  url_private?: string;
+  thumb_720_h?: number;
+  thumb_360?: string;
+  id?: file_id;
+  ims?: any[];
+  thumb_720_w?: number;
+  thumb_80?: string;
+  comments_count?: number;
+  thumb_360_h?: number;
+  thumb_480_h?: number;
+  original_w?: number;
+  username?: string;
+  thumb_800?: string;
+  timestamp?: number;
+  public_url_shared?: boolean;
+  editable?: boolean;
+  thumb_160?: string;
+  external_type?: string;
+  url_private_download?: string;
+  thumb_1024?: string;
+  user?: string;
+  groups?: any[];
+  thumb_960?: string;
+  is_public?: boolean;
+  pretty_type?: string;
+  name?: string;
+  mimetype?: string;
+  permalink_public?: string;
+  permalink?: string;
+  is_external?: boolean;
+  created?: number;
+  thumb_1024_h?: number;
+  thumb_960_h?: number;
+  pinned_to?: channel[];
+  thumb_960_w?: number;
+  thumb_1024_w?: number;
+  mode?: string;
+  thumb_720?: string;
+  channels?: channel_id[];
+}
+
+export interface UserProfile {
+  last_name?: string;
+  status_emoji?: string;
+  display_name_normalized: string;
+  email?: string;
+  image_32: string;
+  skype?: string;
+  image_72: string;
+  status_expiration?: number;
+  image_192: string;
+  first_name?: string;
+  display_name: string;
+  title?: string;
+  real_name_normalized: string;
+  always_active?: boolean;
+  status_text_canonical?: string;
+  image_24: string;
+  phone?: string;
+  image_48: string;
+  guest_channels?: string;
+  image_original?: string;
+  fields?: any;
+  real_name: string;
+  image_512?: string;
+  team?: team;
+  avatar_hash: string;
+  status_text?: string;
+}
+
+export type room_id = string;
+export type channel_id = string;
+export type channel_name = string;
+export interface TeamProfileField {
+  hint: string;
+  ordering: number;
+  type: 'text' | 'date' | 'link' | 'mailto' | 'options_list' | 'user';
+  possible_values?: string[];
+  label: string;
+  id: string;
+  is_hidden?: boolean;
+  field_name?: string;
+  options: string[];
+}
+
+export type dm_id = string;
+export type channel = string;
+export interface Comment {
+  comment?: string;
+  reactions?: Reaction[];
+  created?: number;
+  timestamp?: number;
+  pinned_to?: channel[];
+  is_intro?: boolean;
+  user?: string;
+  id?: comment_id;
+}
+
+export interface Channel {
+  is_general?: boolean;
+  name_normalized: string;
+  last_read?: ts;
+  creator: user_id;
+  is_member?: boolean;
+  is_archived?: boolean;
+  topic: {
+    last_set: number;
+    value: string;
+    creator: topic_purpose_creator;
+  };
+  unread_count_display?: number;
+  id: channel_id;
+  is_org_shared: boolean;
+  is_channel: boolean;
+  name: string;
+  priority?: number;
+  is_moved?: number;
+  accepted_user?: user_id;
+  is_pending_ext_shared?: boolean;
+  is_mpim: boolean;
+  is_read_only?: boolean;
+  purpose: {
+    last_set: number;
+    value: string;
+    creator: topic_purpose_creator;
+  };
+  members: user_id[];
+  is_private: boolean;
+  previous_names?: channel_name[];
+  num_members?: number;
+  is_shared: boolean;
+  created: number;
+  pending_shared?: team[];
+  unread_count?: number;
+  unlinked?: number;
+  latest?: null | Message;
+}
+
+export type topic_purpose_creator = string;
+export type invite_id = number;
+export type file_id = string;
+export type group_id = string;
+export type user_id = string;
+export interface Group {
+  is_pending_ext_shared?: boolean;
+  name_normalized: string;
+  name: string;
+  last_read?: ts;
+  creator: user_id;
+  is_moved?: number;
+  is_mpim?: boolean;
+  is_archived?: boolean;
+  created: number;
+  is_group: boolean;
+  topic: {
+    last_set: number;
+    value: string;
+    creator: topic_purpose_creator;
+  };
+  unread_count?: number;
+  is_open?: boolean;
+  purpose: {
+    last_set: number;
+    value: string;
+    creator: topic_purpose_creator;
+  };
+  members: user_id[];
+  priority?: number;
+  latest?: null | Message;
+  id: group_id;
+  unread_count_display?: number;
+}
+
+export interface Reaction {
+  count: number;
+  name: string;
+  users: user_id[];
+}
+
+export type ok_false = false;
+export interface InvitingUser {
+  profile: UserProfileShortest;
+  updated: number;
+  name: string;
+  is_app_user: boolean;
+  real_name?: string;
+  team_id: team;
+  is_ultra_restricted: boolean;
+  is_restricted: boolean;
+  id: user_id;
+}
+
+export interface UserProfileShort {
+  first_name: string;
+  display_name: string;
+  name: string;
+  team: team;
+  real_name: string;
+  avatar_hash: string;
+  is_ultra_restricted: boolean;
+  is_restricted: boolean;
+  image_72: string;
+}
+
+export interface Comments {
+  [key: string]: any;
+}
+
+export type ok_true = true;
+export interface Conversation {
+  [key: string]: any;
+}
+
+export interface Team {
+  domain: string;
+  name: string;
+  enterprise_name?: string;
+  id: team;
+  email_domain: string;
+  has_compliance_export?: boolean;
+  enterprise_id?: string;
+  icon: {
+    image_230?: string;
+    image_132?: string;
+    image_68?: string;
+    image_34?: string;
+    image_102?: string;
+    image_default?: boolean;
+    image_44?: string;
+    image_88?: string;
+  };
+}
+
+export interface UserProfileShortest {
+  first_name: string;
+  display_name: string;
+  team: team;
+  real_name: string;
+  avatar_hash: string;
+  image_72: string;
+}
+
+export interface Message {
+  comment?: Comment;
+  reactions?: Reaction[];
+  attachments?: {
+    image_bytes?: number;
+    image_width?: number;
+    image_height?: number;
+    image_url?: string;
+    fallback?: string;
+    id: number;
+  }[];
+  last_read?: ts;
+  text: string;
+  topic?: string;
+  display_as_bot?: boolean;
+  reply_count?: number;
+  file?: File;
+  replies?: {
+    ts: ts;
+    user: user_id;
+  }[];
+  user_team?: team;
+  subscribed?: boolean;
+  icons?: {
+    emoji?: string;
+  };
+  purpose?: string;
+  ts: ts;
+  subtype?: string;
+  type: string;
+  username?: string;
+  source_team?: team;
+  user_profile?: UserProfileShort;
+  user?: user_id;
+  old_name?: string;
+  thread_ts?: ts;
+  permalink?: string;
+  name?: string;
+  upload?: boolean;
+  pinned_to?: channel[];
+  unread_count?: number;
+  is_intro?: boolean;
+  team?: team;
+  inviter?: user_id;
+  bot_id?: null | bot_id;
+}
+
+// POST: /chat.delete
+export type ChatDeleteResponse = {
+  ok: ok_true;
+  ts: ts;
+  channel: channel;
+} & {
+  [key: string]: any;
+};
+// POST: /files.comments.edit
+export type FilesCommentsEditResponse = {
+  ok: ok_false;
+  error:
+  | 'cant_edit'
+  | 'comment_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  comment: Comment;
+  ok: ok_true;
+};
+// POST: /mpim.open
+export type MPIMOpenResponse = {
+  ok: ok_false;
+  error:
+  | 'users_list_not_supplied'
+  | 'not_enough_users'
+  | 'too_many_users'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+  group: Group;
+};
+// GET: /groups.replies
+export type GroupsRepliesResponse = {
+  ok: ok_true;
+};
+// GET: /bots.info
+export type BotsInfoResponse = {
+  ok: ok_true;
+};
+// POST: /reminders.add
+export type RemindersAddResponse = {
+  ok: ok_true;
+};
+// POST: /groups.rename
+export type GroupsRenameResponse = {
+  ok: ok_true;
+};
+// POST: /users.profile.set
+export type UsersProfileSetResponse = {
+  ok: ok_true;
+};
+// POST: /users.setPresence
+export type UsersSetPresenceResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.close
+export type ConversationsCloseResponse = {
+  no_op?: boolean;
+  ok: ok_true;
+  already_closed?: boolean;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'channel_not_found'
+    | 'user_does_not_own_channel'
+    | 'missing_scope'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// POST: /im.open
+export type IMOpenResponse = {
+  ok: ok_false;
+  error:
+  | 'user_not_found'
+  | 'user_not_visible'
+  | 'user_disabled'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} &
+  {
+    no_op?: boolean;
+    already_open?: boolean;
+    ok: ok_true;
+    channel: {
+      last_read?: ts;
+      created?: string;
+      unread_count?: number;
+      is_open?: boolean;
+      user?: user_id;
+      unread_count_display?: number;
+      is_im?: boolean;
+      id: dm_id;
+      latest?: Message;
+    }
+  };
+// GET: /groups.list
+export type GroupsListResponse = {
+  ok: ok_false;
+  error:
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+  groups: Group[];
+};
+// GET: /team.integrationLogs
+export type TeamIntegrationLogsResponse = {
+  ok: ok_true;
+};
+// POST: /groups.kick
+export type GroupsKickResponse = {
+  ok: ok_true;
+};
+// GET: /dnd.info
+export type DndInfoResponse = {
+  ok: ok_true;
+};
+// POST: /channels.archive
+export type ChannelsArchiveResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'already_archived'
+  | 'cant_archive_general'
+  | 'restricted_action'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'user_is_bot'
+  | 'user_is_restricted'
+  | 'user_is_ultra_restricted'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'team_added_to_org'
+  | 'missing_charset'
+  | 'superfluous_charset';
+} & {
+  ok: ok_true;
+};
+// GET: /reminders.info
+export type RemindersInfoResponse = {
+  ok: ok_true;
+};
+// GET: /channels.info
+export type ChannelsInfoResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'team_added_to_org'
+  | 'missing_charset'
+  | 'superfluous_charset';
+} & {
+  ok: ok_true;
+  channel: Channel;
+};
+// POST: /channels.kick
+export type ChannelsKickResponse = {
+  ok: ok_true;
+};
+// POST: /groups.mark
+export type GroupsMarkResponse = {
+  ok: ok_true;
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'invalid_timestamp'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// POST: /mpim.close
+export type MPIMCloseResponse = {
+  ok: ok_true;
+};
+// GET: /users.profile.get
+export type UsersProfileGetResponse = {
+  ok: ok_true;
+};
+// GET: /channels.history
+export type ChannelsHistoryResponse = {
+  has_more: boolean;
+  ok: ok_true;
+  messages: Message[];
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'invalid_ts_latest'
+    | 'invalid_ts_oldest'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// POST: /im.mark
+export type IMMarkResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'invalid_timestamp'
+  | 'not_in_channel'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// GET: /oauth.token
+export type OAuthTokenResponse = {
+  ok: ok_true;
+};
+// POST: /files.upload
+export type FilesUploadResponse = {
+  ok: ok_false;
+  error:
+  | 'posting_to_general_channel_denied'
+  | 'invalid_channel'
+  | 'file_uploads_disabled'
+  | 'file_uploads_except_images_disabled'
+  | 'storage_limit_reached'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+  file: File;
+};
+// GET: /usergroups.users.list
+export type UsergroupsUsersListResponse = {
+  ok: ok_true;
+};
+// GET: /users.info
+export type UsersInfoResponse = {
+  ok: ok_true;
+  user: User;
+} & {
+  ok: ok_false;
+  error:
+    | 'user_not_found'
+    | 'user_not_visible'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// GET: /users.lookupByEmail
+export type UsersLookupByEmailResponse = {
+  ok: ok_false;
+  error:
+  | 'users_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'fatal_error';
+} & {
+  ok: ok_true;
+  user: User;
+};
+// GET: /reactions.list
+export type ReactionsListResponse = {
+  items: {
+    comment: Comment;
+    type: 'file_comment';
+    file: File;
+  }[]
+  | {
+    message: Message;
+    type: 'message';
+    channel: channel;
+  }[]
+  | {
+    type: 'file';
+    file: File;
+  }[];
+
+  paging?: Paging;
+  ok: ok_true;
+} & {
+  ok: ok_false;
+  error:
+    | 'user_not_found'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactiv'
+    | 'no_permission'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'fatal_error';
+};
+// POST: /conversations.create
+export type ConversationsCreateResponse = {
+  provided?: string;
+  error:
+  | 'method_not_supported_for_channel_type'
+  | 'missing_scope'
+  | 'name_taken'
+  | 'restricted_action'
+  | 'no_channel'
+  | 'invalid_name_required'
+  | 'invalid_name_punctuation'
+  | 'invalid_name_maxlength'
+  | 'invalid_name_specials'
+  | 'invalid_name'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'user_is_bot'
+  | 'user_is_restricted'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+  ok: ok_false;
+  detail?: string;
+  needed?: string;
+} & {
+  ok: ok_true;
+  channel: Conversation;
+};
+// GET: /team.billableInfo
+export type TeamBillableInfoResponse = {
+  ok: ok_true;
+};
+// POST: /dnd.endDnd
+export type DndEndDndResponse = {
+  ok: ok_true;
+};
+// GET: /search.all
+export type SearchAllResponse = {
+  ok: ok_true;
+};
+// POST: /files.comments.delete
+export type FilesCommentsDeleteResponse = {
+  ok: ok_false;
+  error:
+  | 'cant_delete'
+  | 'comment_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// GET: /auth.revoke
+export type AuthRevokeResponse = {
+  ok: ok_true;
+};
+// POST: /reactions.add
+export type ReactionsAddResponse = {
+  ok: ok_false;
+  error:
+  | 'bad_timestamp'
+  | 'file_not_found'
+  | 'file_comment_not_found'
+  | 'message_not_found'
+  | 'no_item_specified'
+  | 'invalid_name'
+  | 'already_reacted'
+  | 'too_many_emoji'
+  | 'too_many_reactions'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// POST: /stars.add
+export type StarsAddResponse = {
+  ok: ok_true;
+};
+// POST: /reminders.complete
+export type RemindersCompleteResponse = {
+  ok: ok_true;
+};
+// POST: /chat.unfurl
+export type ChatUnfurlResponse = {
+  [key: string]: any;
+} & {
+  ok: ok_true;
+};
+// POST: /conversations.unarchive
+export type ConversationsUnarchiveResponse = {
+  ok: ok_true;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'not_archived'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'team_added_to_org'
+    | 'missing_charset'
+    | 'superfluous_charset';
+  ok: ok_false;
+  provided?: string;
+};
+// GET: /groups.info
+export type GroupsInfoResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+  group: Group;
+};
+// POST: /files.revokePublicURL
+export type FilesRevokePublicURLResponse = {
+  ok: ok_true;
+};
+// GET: /conversations.list
+export type ConversationsListResponse = {
+  needed?: string;
+  error:
+  | 'missing_scope'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+} &
+  {
+    channels: Conversation[];
+    ok: ok_true;
+    response_metadata?: {
+      next_cursor: string;
+    };
+  };
+// GET: /stars.list
+export type StarsListResponse = {
+  ok: ok_true;
+};
+// GET: /reactions.get
+export type ReactionsGetResponse = {
+  ok: ok_false;
+  error:
+  | 'bad_timestamp'
+  | 'file_not_found'
+  | 'file_comment_not_found'
+  | 'message_not_found'
+  | 'no_item_specified'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  [key: string]: any;
+};
+// GET: /im.history
+export type IMHistoryResponse = {
+  needed?: string;
+  error:
+  | 'channel_not_found'
+  | 'invalid_ts_latest'
+  | 'invalid_ts_oldest'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+} & {
+  has_more: boolean;
+  ok: ok_true;
+  messages: Message[];
+};
+// POST: /pins.add
+export type PinsAddResponse = {
+  ok: ok_false;
+  error:
+  | 'bad_timestamp'
+  | 'file_not_found'
+  | 'file_comment_not_found'
+  | 'message_not_found'
+  | 'channel_not_found'
+  | 'no_item_specified'
+  | 'already_pinned'
+  | 'permission_denied'
+  | 'file_not_shared'
+  | 'not_pinnable'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// POST: /channels.leave
+export type ChannelsLeaveResponse = {
+  ok: ok_true;
+};
+// GET: /chat.getPermalink
+export type ChatGetPermalinkResponse = {
+  permalink: string;
+  ok: ok_true;
+  channel: channel;
+} & {
+  [key: string]: any;
+};
+// POST: /channels.rename
+export type ChannelsRenameResponse = {
+  ok: ok_true;
+};
+// GET: /files.list
+export type FilesListResponse = {
+  files: File[];
+  paging: Paging;
+  ok: ok_true;
+} & {
+  ok: ok_false;
+  error:
+    | 'user_not_found'
+    | 'unknown_type'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'no_permission'
+    | 'user_is_bot'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// POST: /mpim.mark
+export type MPIMMarkResponse = {
+  ok: ok_true;
+};
+// POST: /usergroups.users.update
+export type UsergroupsUsersUpdateResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.setTopic
+export type ConversationsSetTopicResponse = {
+  ok: ok_true;
+  channel: Conversation;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'not_in_channel'
+    | 'is_archived'
+    | 'too_long'
+    | 'user_is_restricted'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// GET: /conversations.members
+export type ConversationsMembersResponse = {
+  ok: ok_true;
+  members: user_id[];
+  response_metadata: {
+    next_cursor: string;
+  };
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'invalid_limit'
+    | 'invalid_cursor'
+    | 'fetch_members_failed'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// POST: /conversations.open
+export type ConversationsOpenResponse = {
+  no_op?: boolean;
+  already_open?: boolean;
+  ok: ok_true;
+  channel: Conversation;
+} & {
+  ok: ok_false;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'user_not_found'
+    | 'user_not_visible'
+    | 'user_disabled'
+    | 'users_list_not_supplied'
+    | 'not_enough_users'
+    | 'too_many_users'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'channel_not_found';
+};
+// POST: /pins.remove
+export type PinsRemoveResponse = {
+  ok: ok_true;
+} & {
+  ok: ok_false;
+  error:
+    | 'bad_timestamp'
+    | 'file_not_found'
+    | 'file_comment_not_found'
+    | 'message_not_found'
+    | 'no_item_specified'
+    | 'not_pinned'
+    | 'permission_denied'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'no_permission'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_typ'
+    | 'missing_post_typ'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeou'
+    | 'upgrade_required';
+};
+// POST: /files.delete
+export type FilesDeleteResponse = {
+  ok: ok_false;
+  error:
+  | 'file_not_found'
+  | 'file_deleted'
+  | 'cant_delete_file'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// GET: /pins.list
+export type PinsListResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  [key: string]: any;
+};
+// GET: /api.test
+export type APITestResponse = {
+  ok: ok_false;
+  error: string;
+} & {
+  ok: ok_true;
+};
+// GET: /reminders.list
+export type RemindersListResponse = {
+  ok: ok_true;
+};
+// GET: /users.getPresence
+export type UsersGetPresenceResponse = {
+  ok: ok_false;
+  error: string;
+} & {
+  manual_away?: boolean;
+  presence: string;
+  last_activity?: number;
+  online?: boolean;
+  ok: ok_true;
+  connection_count?: number;
+  auto_away?: boolean;
+};
+// POST: /usergroups.update
+export type UsergroupsUpdateResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.leave
+export type ConversationsLeaveResponse = {
+  needed?: string;
+  error:
+  | 'method_not_supported_for_channel_type'
+  | 'last_member'
+  | 'missing_scope'
+  | 'channel_not_found'
+  | 'is_archived'
+  | 'cant_leave_general'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'user_is_bot'
+  | 'user_is_restricted'
+  | 'user_is_ultra_restricted'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'team_added_to_org'
+  | 'missing_charset'
+  | 'superfluous_charset';
+  ok: ok_false;
+  provided?: string;
+} & {
+  ok: ok_true;
+  not_in_channel?: true;
+};
+// GET: /files.info
+export type FilesInfoResponse = {
+  ok: ok_false;
+  error:
+  | 'file_not_found'
+  | 'file_deleted'
+  | 'timezone_count_failed'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  paging: Paging;
+  ok: ok_true;
+  file: File;
+  comments: Comments;
+};
+// POST: /groups.leave
+export type GroupsLeaveResponse = {
+  ok: ok_true;
+};
+// GET: /apps.permissions.info
+export type AppsPermissionsInfoResponse = {
+  ok: ok_true;
+};
+// POST: /usergroups.create
+export type UsergroupsCreateResponse = {
+  ok: ok_true;
+};
+// POST: /groups.createChild
+export type GroupsCreateChildResponse = {
+  ok: ok_true;
+};
+// POST: /channels.mark
+export type ChannelsMarkResponse = {
+  ok: ok_false;
+  error:
+  | 'channel_not_found'
+  | 'invalid_timestamp'
+  | 'not_in_channel'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+};
+// POST: /users.deletePhoto
+export type UsersDeletePhotoResponse = {
+  ok: ok_true;
+};
+// POST: /users.setPhoto
+export type UsersSetPhotoResponse = {
+  ok: ok_true;
+};
+// POST: /files.sharedPublicURL
+export type FilesSharedPublicURLResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.kick
+export type ConversationsKickResponse = {
+  ok: ok_true;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'user_not_found'
+    | 'cant_kick_self'
+    | 'not_in_channel'
+    | 'cant_kick_from_general'
+    | 'restricted_action'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// POST: /chat.postEphemeral
+export type ChatPostEphemeralResponse = {
+  ok: ok_true;
+  message_ts: ts;
+} & {
+  [key: string]: any;
+};
+// POST: /conversations.rename
+export type ConversationsRenameResponse = {
+  needed?: string;
+  error:
+  | 'user_is_restricted'
+  | 'method_not_supported_for_channel_type'
+  | 'missing_scope'
+  | 'channel_not_found'
+  | 'not_in_channel'
+  | 'not_authorized'
+  | 'invalid_name'
+  | 'name_taken'
+  | 'invalid_name_required'
+  | 'invalid_name_punctuation'
+  | 'invalid_name_maxlength'
+  | 'invalid_name_specials'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+} & {
+  ok: ok_true;
+  channel: Conversation;
+};
+// GET: /migration.exchange
+export type MigrationExchangeResponse = {
+  [key: string]: any;
+}
+  & {
+    team_id: string;
+    ok: ok_true;
+    enterprise_id: string;
+    invalid_user_ids?: string[];
+    user_id_map?: {
+      [k: string]: any;
+    };
+  };
+// POST: /usergroups.enable
+export type UsergroupsEnableResponse = {
+  ok: ok_true;
+};
+// POST: /dnd.setSnooze
+export type DndSetSnoozeResponse = {
+  ok: ok_true;
+};
+// POST: /chat.update
+export type ChatUpdateResponse = {
+  text: string;
+  ok: ok_true;
+  ts: ts;
+  channel: channel;
+} & {
+  ok: ok_false;
+  error:
+    | 'message_not_found'
+    | 'cant_update_message'
+    | 'channel_not_found'
+    | 'edit_window_closed'
+    | 'msg_too_long'
+    | 'too_many_attachments'
+    | 'rate_limited'
+    | 'no_text'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'token_revoked'
+    | 'no_permission'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'request_timeout'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'upgrade_required'
+    | 'fatal_error';
+};
+// GET: /mpim.history
+export type MPIMHistoryResponse = {
+  ok: ok_true;
+};
+// GET: /apps.permissions.request
+export type AppsPermissionsRequestResponse = {
+  ok: ok_true;
+};
+// POST: /channels.setPurpose
+export type ChannelsSetPurposeResponse = {
+  ok: ok_true;
+};
+// GET: /users.identity
+export type UsersIdentityResponse = {
+  ok: ok_true;
+};
+// GET: /team.accessLogs
+export type TeamAccessLogsResponse = {
+  ok: ok_true;
+};
+// POST: /groups.invite
+export type GroupsInviteResponse = {
+  ok: ok_true;
+  group: Group;
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'user_not_found'
+    | 'cant_invite_self'
+    | 'is_archived'
+    | 'cant_invite'
+    | 'ura_max_channels'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// POST: /channels.unarchive
+export type ChannelsUnarchiveResponse = {
+  ok: ok_true;
+};
+// GET: /rtm.connect
+export type RTMConnectResponse = {
+  ok: ok_true;
+};
+// GET: /team.info
+export type TeamInfoResponse = {
+  ok: ok_false;
+  error:
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'token_revokedno_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'fatal_error';
+} & {
+  ok: ok_true;
+  team: Team;
+};
+// GET: /conversations.history
+export type ConversationsHistoryResponse = {
+  has_more: boolean;
+  ok: ok_true;
+  messages: Message[];
+  pin_count: number;
+} & {
+  needed?: string;
+  error:
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'invalid_ts_latest'
+    | 'invalid_ts_oldest'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// POST: /channels.create
+export type ChannelsCreateResponse = {
+  ok: ok_true;
+  channel: Channel;
+} & {
+  ok: ok_false;
+  error:
+    | 'name_taken'
+    | 'restricted_action'
+    | 'no_channel'
+    | 'invalid_name_required'
+    | 'invalid_name_punctuation'
+    | 'invalid_name_maxlength'
+    | 'invalid_name_specials'
+    | 'invalid_name'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'team_added_to_org'
+    | 'missing_charset'
+    | 'superfluous_charset';
+};
+// GET: /im.replies
+export type IMRepliesResponse = {
+  ok: ok_true;
+};
+// POST: /groups.create
+export type GroupsCreateResponse = {
+  ok: ok_true;
+  group: Group;
+} & {
+  ok: ok_false;
+  error:
+    | 'no_channel'
+    | 'restricted_action'
+    | 'name_taken'
+    | 'invalid_name_required'
+    | 'invalid_name_punctuation'
+    | 'invalid_name_maxlength'
+    | 'invalid_name_specials'
+    | 'invalid_name'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// GET: /users.conversations
+export type UsersConversationsResponse = {
+  channels: Conversation[];
+  ok: ok_true;
+} & {
+  [key: string]: any;
+};
+// POST: /conversations.setPurpose
+export type ConversationsSetPurposeResponse = {
+  ok: ok_true;
+  channel: Conversation;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'not_in_channel'
+    | 'is_archived'
+    | 'too_long'
+    | 'user_is_restricted'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// POST: /channels.join
+export type ChannelsJoinResponse = {
+  ok: ok_true;
+};
+// GET: /usergroups.list
+export type UsergroupsListResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.join
+export type ConversationsJoinResponse = {
+  needed?: string;
+  error:
+  | 'method_not_supported_for_channel_type'
+  | 'missing_scope'
+  | 'channel_not_found'
+  | 'is_archived'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'user_is_bot'
+  | 'user_is_restricted'
+  | 'user_is_ultra_restricted'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'team_added_to_org'
+  | 'missing_charset'
+  | 'superfluous_charset';
+  ok: ok_false;
+  provided?: string;
+}
+  & {
+    warning?: string;
+    ok: ok_true;
+    channel: Conversation;
+    response_metadata?: {
+      warnings?: string[];
+    };
+  };
+// POST: /groups.open
+export type GroupsOpenResponse = {
+  ok: ok_true;
+};
+// GET: /emoji.list
+export type EmojiListResponse = {
+  ok: ok_true;
+};
+// GET: /conversations.info
+export type ConversationsInfoResponse = {
+  ok: ok_true;
+  channel: Conversation;
+} & {
+  needed?: string;
+  error:
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'team_added_to_org'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// POST: /chat.meMessage
+export type ChatMeMessageResponse = {
+  ok: ok_true;
+};
+// POST: /dnd.endSnooze
+export type DndEndSnoozeResponse = {
+  ok: ok_true;
+};
+// GET: /groups.history
+export type GroupsHistoryResponse = {
+  has_more: boolean;
+  ok: ok_true;
+  messages: Message[];
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'invalid_ts_latest'
+    | 'invalid_ts_oldest'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// GET: /search.messages
+export type SearchMessagesResponse = {
+  ok: ok_true;
+};
+// GET: /RTM.start
+export type RTMStartResponse = {
+  ok: ok_true;
+};
+// POST: /channels.setTopic
+export type ChannelsSetTopicResponse = {
+  ok: ok_true;
+};
+// POST: /groups.setTopic
+export type GroupsSetTopicResponse = {
+  ok: ok_true;
+};
+// POST: /im.close
+export type IMCloseResponse = {
+  ok: ok_true;
+};
+// POST: /reactions.remove
+export type ReactionsRemoveResponse = {
+  ok: ok_false;
+  error:
+  | 'bad_timestamp'
+  | 'file_not_found'
+  | 'file_comment_not_found'
+  | 'message_not_found'
+  | 'no_item_specified'
+  | 'invalid_name'
+  | 'no_reaction'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'fatal_error';
+} & {
+  ok: ok_true;
+};
+// POST: /reminders.delete
+export type RemindersDeleteResponse = {
+  ok: ok_true;
+};
+// POST: /usergroups.disable
+export type UsergroupsDisableResponse = {
+  ok: ok_true;
+};
+// POST: /files.comments.add
+export type FilesCommentsAddResponse = {
+  ok: ok_false;
+  error:
+  | 'file_not_found'
+  | 'file_deleted'
+  | 'no_comment'
+  | 'cant_add'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  comment: Comment;
+  ok: ok_true;
+};
+// GET: /im.list
+export type IMListResponse = {
+  ims: Im[];
+  ok: ok_true;
+} & {
+  ok: ok_false;
+  error:
+    | 'invalid_cursor'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'no_permission'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+};
+// GET: /search.files
+export type SearchFilesResponse = {
+  ok: ok_true;
+};
+// GET: /mpim.replies
+export type MPIMRepliesResponse = {
+  ok: ok_true;
+};
+// GET: /dialog.open
+export type DialogOpenResponse = {
+  ok: ok_true;
+};
+// GET: /dnd.teamInfo
+export type DndTeamInfoResponse = {
+  cached?: boolean;
+  ok: ok_true;
+  users: {
+    [k: string]: any;
+  };
+} & {
+  needed?: string;
+  error:
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// GET: /users.list
+export type UsersListResponse = {
+  cache_ts: number;
+  ok: ok_true;
+  members: User[];
+} & {
+  ok: ok_false;
+  error:
+    | 'invalid_cursor'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'no_permission'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'fatal_error';
+};
+// POST: /conversations.invite
+export type ConversationsInviteResponse = {
+  provided?: string;
+  errors?: {
+    ok: ok_false;
+    user?: user_id;
+    error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'user_not_found'
+    | 'cant_invite_self'
+    | 'not_in_channel'
+    | 'already_in_channel'
+    | 'is_archived'
+    | 'cant_invite'
+    | 'too_many_users'
+    | 'ura_max_channels'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'team_added_to_org'
+    | 'missing_charset'
+    | 'superfluous_charset';
+  }[]
+  ok: ok_false;
+  error?:
+  | 'method_not_supported_for_channel_type'
+  | 'missing_scope'
+  | 'channel_not_found'
+  | 'user_not_found'
+  | 'cant_invite_self'
+  | 'not_in_channel'
+  | 'already_in_channel'
+  | 'is_archived'
+  | 'cant_invite'
+  | 'too_many_users'
+  | 'ura_max_channels'
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'user_is_bot'
+  | 'user_is_restricted'
+  | 'user_is_ultra_restricted'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required'
+  | 'team_added_to_org'
+  | 'missing_charset'
+  | 'superfluous_charset';
+  needed?: string;
+} & {
+  ok: ok_true;
+  channel: Conversation;
+};
+// GET: /auth.test
+export type AuthTestResponse = {
+  ok: ok_false;
+  error:
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'token_revoked'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  ok: ok_true;
+  url: string;
+  team_id: team;
+  user: string;
+  team: string;
+  user_id: user_id;
+};
+// GET: /channels.list
+export type ChannelsListResponse = {
+  ok: ok_false;
+  error:
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_type'
+  | 'missing_post_type'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeout'
+  | 'upgrade_required';
+} & {
+  channels: Channel[];
+  ok: ok_true;
+};
+// POST: /groups.setPurpose
+export type GroupsSetPurposeResponse = {
+  ok: ok_true;
+};
+// POST: /channels.invite
+export type ChannelsInviteResponse = {
+  ok: ok_true;
+  channel: Channel;
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'user_not_found'
+    | 'cant_invite_self'
+    | 'not_in_channel'
+    | 'already_in_channel'
+    | 'is_archived'
+    | 'cant_invite'
+    | 'too_many_users'
+    | 'ura_max_channels'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'team_added_to_org'
+    | 'missing_charset'
+    | 'superfluous_charset';
+};
+// GET: /oauth.access
+export type OAuthAccessResponse = {
+  ok: ok_true;
+};
+// GET: /mpim.list
+export type MPIMListResponse = {
+  ok: ok_true;
+};
+// GET: /conversations.replies
+export type ConversationsRepliesResponse = {
+  has_more?: boolean;
+  ok: ok_true;
+  messages: {
+    thread_ts: ts;
+    subscribed: boolean;
+    source_team?: team;
+    last_read?: ts;
+    user_profile?: UserProfileShort;
+    text: string;
+    team?: team;
+    ts: ts;
+    unread_count?: number;
+    reply_count: number;
+    user: user_id;
+    replies: {
+      ts: ts;
+      user: user_id;
+    }[]
+    type: string;
+    user_team?: team;
+  }[]
+  | {
+    thread_ts: ts;
+    source_team?: team;
+    user_profile?: UserProfileShort;
+    text: string;
+    ts: ts;
+    user: user_id;
+    team?: team;
+    parent_user_id: user_id;
+    is_starred?: boolean;
+    type: string;
+    user_team?: team;
+  }[]
+} & {
+  needed?: string;
+  error:
+    | 'missing_scope'
+    | 'channel_not_found'
+    | 'thread_not_found'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'team_added_to_org'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required';
+  ok: ok_false;
+  provided?: string;
+};
+// GET: /channels.replies
+export type ChannelsRepliesResponse = {
+  ok: ok_true;
+};
+// POST: /chat.postMessage
+export type ChatPostMessageResponse = {
+  message: Message;
+  ok: ok_true;
+  ts: ts;
+  channel: channel;
+} & {
+  ok: ok_false;
+  error:
+    | 'channel_not_found'
+    | 'not_in_channel'
+    | 'is_archived'
+    | 'msg_too_long'
+    | 'no_text'
+    | 'too_many_attachments'
+    | 'rate_limited'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type';
+};
+// POST: /users.setActive
+export type UsersSetActiveResponse = {
+  ok: ok_true;
+};
+// POST: /conversations.archive
+export type ConversationsArchiveResponse = {
+  ok: ok_true;
+} & {
+  needed?: string;
+  error:
+    | 'method_not_supported_for_channel_type'
+    | 'missing_scope'
+    | 'not_supported'
+    | 'channel_not_found'
+    | 'already_archived'
+    | 'cant_archive_general'
+    | 'restricted_action'
+    | 'not_authed'
+    | 'invalid_auth'
+    | 'account_inactive'
+    | 'user_is_bot'
+    | 'user_is_restricted'
+    | 'user_is_ultra_restricted'
+    | 'invalid_arg_name'
+    | 'invalid_array_arg'
+    | 'invalid_charset'
+    | 'invalid_form_data'
+    | 'invalid_post_type'
+    | 'missing_post_type'
+    | 'invalid_json'
+    | 'json_not_object'
+    | 'request_timeout'
+    | 'upgrade_required'
+    | 'team_added_to_org'
+    | 'missing_charset'
+    | 'superfluous_charset';
+  ok: ok_false;
+  provided?: string;
+};
+// GET: /team.profile.get
+export type TeamProfileGetResponse = {
+  ok: ok_false;
+  error:
+  | 'not_authed'
+  | 'invalid_auth'
+  | 'account_inactive'
+  | 'no_permission'
+  | 'user_is_bot'
+  | 'invalid_arg_name'
+  | 'invalid_array_arg'
+  | 'invalid_charset'
+  | 'invalid_form_data'
+  | 'invalid_post_typ'
+  | 'missing_post_type'
+  | 'team_added_to_org'
+  | 'invalid_json'
+  | 'json_not_object'
+  | 'request_timeou'
+  | 'upgrade_required';
+}
+  & {
+    profile: {
+      fields: TeamProfileField[];
+    };
+    ok: ok_true;
+  };
+// POST: /groups.archive
+export type GroupsArchiveResponse = {
+  ok: ok_true;
+};
+// POST: /groups.unarchive
+export type GroupsUnarchiveResponse = {
+  ok: ok_true;
+};
+// POST: /stars.remove
+export type StarsRemoveResponse = {
+  ok: ok_true;
+};


### PR DESCRIPTION
###  Summary

Adds auto-generated response types for all API methods. Typings are generated based on the public JSON schema, so it is only as complete as that schema is. Addresses #509. Does not make any adjustments to runtime code.

Not entirely sure how strict you want to be on the cases where there is incomplete data. Master currently shows a typescript error any time you try and access an API response property directly, which I took as a hint and erred on the side of strictness. I cannot find any cases where Typescript throws an error or warning on my branch that doesn't also get a warning or error in master.

It wouldn't let me commit without resolving a few unrelated tslint errors. I went through your .tslint.json and you guys have `no-redundant-jsdoc` turned on - so I think I was fixing a lint error and not creating one - but it's entirely possible there's something mismatched in my local environment to yours that is triggering it for me.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
