### PR TITLE
WIP: Clean up got types in WebClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 node_modules
+package-lock.json
 npm-debug.log
 coverage
 dist
-examples/package-lock.json
 
 # nyc test coverage
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@types/delay": "^2.0.1",
     "@types/form-data": "^2.2.1",
-    "@types/got": "^7.1.7",
+    "@types/got": "^8.3.1",
     "@types/is-stream": "^1.1.0",
     "@types/loglevel": "^1.5.3",
     "@types/node": "^9.4.7",
@@ -78,7 +78,7 @@
     "busboy": "^0.2.14",
     "capture-stdout": "^1.0.0",
     "chai": "^4.1.2",
-    "codecov": "^3.0.0",
+    "codecov": "^3.0.2",
     "husky": "^0.14.3",
     "jsdoc-to-markdown": "^4.0.1",
     "lint-staged": "^6.1.0",


### PR DESCRIPTION
###  Summary

the goal of this commit is to remove the @ts-ignore found in `WebClient#apiCall()`. it turns out that accomplishing this is best done by making upstream changes to the `@types/got` package. the comment is revised to leave a trail to the relevant info.

while working towards this goal it became evident that `FormCanBeURLEncoded` is a confusing name, and `URLEncodableForm` is a better name, so its renamed to that. also, the `BodyCanBeFormMultipart` interface has a confusing name, and doesn't provide any value over `Readable`, since `got`'s options are typed in terms of `Readable`, so its been removed. if in the future there's a need to further specify the type that represents a form multipart body, we can add that in the future.

fixes #536

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
