### PR TITLE
RTMClient.start options is optional

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -352,7 +352,7 @@ export class RTMClient extends EventEmitter {
    * be sent or received.
    * @param options
    */
-  public start(options: methods.RTMStartArguments | methods.RTMConnectArguments): void {
+  public start(options?: methods.RTMStartArguments | methods.RTMConnectArguments): void {
     // TODO: should this return a Promise<WebAPICallResult>?
     // TODO: make a named interface for the type of `options`. it should end in -Options instead of Arguments.
 


### PR DESCRIPTION
###  Summary

Update typescript `RTMClient.start` options to be optional

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
