### PR TITLE
catch errors on platform

### DIFF
--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -191,15 +191,16 @@ describe('WebClient', function () {
       });
     });
 
-    it('should return platform error if 200 request is not ok', function () {
+    it.only('should fail with platform errors when the API response is an error', function () {
       const scope = nock('https://slack.com')
         .post(/api/)
-        .reply(200, { ok: false });
+        .reply(200, { ok: false, error: 'bad error' });
       const client = new WebClient(token);
       return client.apiCall('method')
         .catch((error) => {
           assert.propertyVal(error, 'code', 'slackclient_platform_error');
-          assert.propertyVal(error.data, 'ok', false);
+          assert.nestedPropertyVal(error, 'data.ok', false);
+          assert.nestedPropertyVal(error, 'data.error', 'bad error');
           scope.done();
         });
     });

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -191,7 +191,7 @@ describe('WebClient', function () {
       });
     });
 
-    it.only('should fail with platform errors when the API response is an error', function () {
+    it('should fail with platform errors when the API response is an error', function () {
       const scope = nock('https://slack.com')
         .post(/api/)
         .reply(200, { ok: false, error: 'bad error' });

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -191,6 +191,19 @@ describe('WebClient', function () {
       });
     });
 
+    it('should return platform error if 200 request is not ok', function () {
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(200, { ok: false });
+      const client = new WebClient(token);
+      return client.apiCall('method')
+        .catch((error) => {
+          assert.propertyVal(error, 'code', 'slackclient_platform_error');
+          assert.propertyVal(error.data, 'ok', false);
+          scope.done();
+        });
+    });
+
     it('should properly serialize simple API arguments', function () {
       const scope = nock('https://slack.com')
         // NOTE: this could create false negatives if the serialization order changes (it shouldn't matter)

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -150,6 +150,16 @@ export class WebClient extends EventEmitter {
             if (result.response_metadata !== undefined && result.response_metadata.warnings !== undefined) {
               result.response_metadata.warnings.forEach(this.logger.warn);
             }
+
+            if (!result.ok) {
+              const error = errorWithCode(
+                new Error(`An API error occurred: ${result.error}`),
+                ErrorCode.PlatformError,
+              );
+              error.data = result;
+              throw new pRetry.AbortError(error);
+            }
+
             return result;
           })
           .catch((error: got.GotError) => {
@@ -168,6 +178,7 @@ export class WebClient extends EventEmitter {
                 // wait and return the result from calling `task` again after the specified number of seconds
                 return delay(retryAfterMs).then(task);
               }
+
               throw httpErrorWithOriginal(error);
             } else {
               throw error;


### PR DESCRIPTION
###  Summary

This commit is solely to catch platform errors upon receiving a 200 request that is actually not ok. Test is also included.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
