### PR TITLE
Link to documentation source

### DIFF
--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -129,7 +129,7 @@ const web = new WebClient(token);
 // This file is located in the current directory (`process.pwd()`)
 const filename = 'test_file.csv';
 
-// See: https://api.slack.com/methods/chat.postMessage
+// See: https://api.slack.com/methods/files.upload
 web.files.upload({
   filename,
   // You can use a ReadableStream or a Buffer for the file option


### PR DESCRIPTION
Fix what looks like a copy/paste from `chat.postMessage` example

###  Summary

Link SDK users to the best source of documentation.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
