### PR TITLE
Fix Dialog.selected_options type

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -60,7 +60,7 @@ export interface Dialog {
     subtype?: 'email' | 'number' | 'tel' | 'url';
     // type `select`:
     data_source?: 'users' | 'channels' | 'conversations' | 'external';
-    selected_options?: string;
+    selected_options?: OptionField[];
     options?: SelectOption[];
     option_groups?: {
       label: string;

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -60,7 +60,7 @@ export interface Dialog {
     subtype?: 'email' | 'number' | 'tel' | 'url';
     // type `select`:
     data_source?: 'users' | 'channels' | 'conversations' | 'external';
-    selected_options?: OptionField[];
+    selected_options?: SelectOption[];
     options?: SelectOption[];
     option_groups?: {
       label: string;


### PR DESCRIPTION
###  Summary

Fixes the type of `Dialog.selected_options`. It now matches `AttachmentAction.selected_options` and what's described in [these docs](https://api.slack.com/dialogs#select_default_values).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
