### PR TITLE
drop support for node <v4 and update request dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/client",
-  "version": "3.16.0",
+  "version": "3.16.1-sec",
   "description": "A library for creating a Slack client",
   "main": "./index",
   "scripts": {
@@ -29,7 +29,7 @@
     "inherits": "^2.0.1",
     "lodash": "^4.13.1",
     "pkginfo": "^0.4.0",
-    "request": ">=2.0.0 <2.77.0",
+    "request": "^2.85.0",
     "retry": "^0.9.0",
     "url-join": "0.0.1",
     "winston": "^2.1.1",


### PR DESCRIPTION
###  Summary

In order to fix #547, we need to publish a prerelease version that drops support for node v4 and updates request.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
