### PR TITLE
Auto pagination

### DIFF
--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -13,6 +13,7 @@ headings:
     - title: Changing the retry configuration
     - title: Changing the request concurrency
     - title: Rate limit handling
+    - title: Pagination
     - title: Customizing the logger
     - title: Custom agent for proxy support
     - title: OAuth token exchange
@@ -241,6 +242,69 @@ const token = process.env.SLACK_TOKEN;
 const web = new WebClient(token);
 web.on('rate_limited', retryAfter => console.log(`Delay future requests by at least ${retryAfter} seconds`));
 ```
+
+---
+
+### Pagination
+
+Some methods are meant to return large lists of things; whether it be users, channels, messages, or something else. In
+order to efficiently get you the data you need, Slack will return parts of that entire list, or **pages**. Cursor-based
+pagination describes using a couple options: `cursor` and `limit` to get exactly the page of data you desire. For
+example, this is how your app would get the last 500 messages in a conversation.
+
+```javascript
+const { WebClient } = require('@slack/client');
+const token = process.env.SLACK_TOKEN;
+const web = new WebClient(token);
+const conversationId = 'C123456'; // some conversation ID
+
+web.conversations.history({ channel: conversationId, limit: 500 })
+  .then((res) => {
+    console.log(`Requested 500 messages, recieved ${res.messages.length} in the response`);
+  })
+  .catch(console.error);
+```
+
+In the code above, the `res.messages` array will contain, at maximum, 500 messages. But what about all the previous
+messages? That's what the `cursor` argument is used for 😎.
+
+Inside `res` is a property called `response_metadata`, which might (or might not) have a `next_cursor` property. When
+that `next_cursor` property exists, and is not an empty string, you know there's still more data in the list. If you
+want to read more messages in that channel's history, you would call the method again, but use that value as the
+`cursor` argument. **NOTE**: It should be rare that your app needs to read the entire history of a channel, avoid that!
+With other methods, such as `users.list`, it would be more common to request the entire list, so that's what we're
+illustrating below.
+
+```javascript
+// A function that recursively iterates through each page while a next_cursor exists
+function getAllUsers() {
+  let users = [];
+  function pageLoaded(res) {
+    users = users.concat(res.users);
+    if (res.response_metadata && res.response_metadata.next_cursor && res.response_metadata.cursor !== '') {
+      return web.users.list({ limit: 100, cursor: res.response_metadata.next_cursor }).then(pageLoaded);
+    }
+    return users;
+  }
+  return web.users.list({ limit: 100 }).then(pageLoaded);
+}
+
+getAllUsers()
+  .then(console.log) // prints out the list of users
+  .catch(console.error);
+```
+
+Cursor-based pagination, if available for a method, is always preferred. In fact, when you call a cursor-paginated
+method without a `cursor` or `limit`, the `WebClient` will **automatically paginate** the requests for you until the
+end of the list. Then, each page of results are concatenated, and that list takes the place of the last page in the last
+response. In other words, if you don't specify any pagination options then you get the whole list in the result as well
+as the non-list properties of the last API call. It's always preferred to perform your own pagination by specifying the
+`limit` and/or `cursor` since you can optimize to your own application's needs.
+
+A few methods that returns lists do not support cursor-based pagination, but do support
+[other pagination types](https://api.slack.com/docs/pagination#classic_pagination). These methods will not be
+automatically paginated for you, so you should give extra care and use appropriate options to only request a page at a
+time. If you don't, you risk failing with `Error`s which have a `code` property set to `errorCode.HTTPError`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "object.values": "^1.0.4",
     "p-cancelable": "^0.3.0",
     "p-queue": "^2.3.0",
-    "p-retry": "^1.0.0",
-    "retry": "^0.10.1",
+    "p-retry": "^2.0.0",
+    "retry": "^0.12.0",
     "url-join": "^4.0.0",
     "ws": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
     "ws": "^5.2.0"
   },
   "devDependencies": {
+    "@aoberoi/capture-console": "^1.0.0",
     "@types/chai": "^4.1.2",
     "@types/mocha": "^2.2.48",
     "busboy": "^0.2.14",
-    "capture-stdout": "^1.0.0",
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "docs:jsdoc": "ts2jsdoc"
   },
   "dependencies": {
-    "@types/delay": "^2.0.1",
     "@types/form-data": "^2.2.1",
     "@types/got": "^7.1.7",
     "@types/is-stream": "^1.1.0",
@@ -55,7 +54,6 @@
     "@types/retry": "^0.10.2",
     "@types/url-join": "^0.8.2",
     "@types/ws": "^4.0.1",
-    "delay": "^2.0.0",
     "eventemitter3": "^3.0.0",
     "finity": "^0.5.4",
     "form-data": "^2.3.1",

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -29,7 +29,6 @@ export class IncomingWebhook {
   /**
    * Send a notification to a conversation
    * @param message the message (a simple string, or an object describing the message)
-   * @param callback
    */
   public send(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult>;
   public send(message: string | IncomingWebhookSendArguments, callback: IncomingWebhookResultCallback): void;
@@ -75,7 +74,6 @@ export class IncomingWebhook {
 
   /**
    * Processes an HTTP response into an IncomingWebhookResult.
-   * @param response
    */
   private buildResult(response: got.Response<string>): IncomingWebhookResult {
     return {
@@ -147,7 +145,6 @@ function requestErrorWithOriginal(original: Error): IncomingWebhookRequestError 
   return (error as IncomingWebhookRequestError);
 }
 
-
 /**
  * A factory to create IncomingWebhookReadError objects
  * @param original The original error
@@ -160,7 +157,6 @@ function readErrorWithOriginal(original: Error): IncomingWebhookReadError {
   error.original = original;
   return (error as IncomingWebhookReadError);
 }
-
 
 /**
  * A factory to create IncomingWebhookHTTPError objects

--- a/src/KeepAlive.ts
+++ b/src/KeepAlive.ts
@@ -96,7 +96,6 @@ export class KeepAlive extends EventEmitter {
 
   /**
    * Start monitoring the RTMClient. This method should only be called after the client's websocket is already open.
-   * @param client
    */
   public start(client: RTMClient): void {
     if (!client.connected) {

--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -284,7 +284,6 @@ export class RTMClient extends EventEmitter {
    */
   private static loggerName = `${pkg.name}:RTMClient`;
 
-
   /**
    * This object's logger instance
    */
@@ -350,7 +349,6 @@ export class RTMClient extends EventEmitter {
   /**
    * Begin an RTM session using the provided options. This method must be called before any messages can
    * be sent or received.
-   * @param options
    */
   public start(options?: methods.RTMStartArguments | methods.RTMConnectArguments): void {
     // TODO: should this return a Promise<WebAPICallResult>?
@@ -537,7 +535,6 @@ export class RTMClient extends EventEmitter {
 
   /**
    * Set up method for the client's websocket instance. This method will attach event listeners.
-   * @param url
    */
   private setupWebsocket(url: string): void {
     // initialize the websocket
@@ -575,7 +572,6 @@ export class RTMClient extends EventEmitter {
   /**
    * `onmessage` handler for the client's websocket. This will parse the payload and dispatch the relevant events for
    * each incoming message.
-   * @param websocketMessage
    */
   private onWebsocketMessage({ data }: { data: string }): void {
     // v3 legacy
@@ -673,7 +669,6 @@ export interface RTMWebsocketError extends CodedError {
 
  /**
   * A factory to create RTMWebsocketError objects.
-  * @param original
   */
 function websocketErrorWithOriginal(original: Error): RTMWebsocketError {
   const error = errorWithCode(

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -556,6 +556,26 @@ describe('WebClient', function () {
     });
   });
 
+  describe('has support for automatic pagination', function () {
+    describe('when using a method that supports cursor-based pagination', function () {
+      it('should automatically paginate and return a single merged result when no pagination options are supplied', function () {
+
+      });
+
+      it('should not automatically paginate when pagination options are supplied', function () {
+
+      });
+
+      it('should warn when pagination options for timeline or traditional pagination are supplied', function () {
+
+      });
+    });
+
+    describe('when using a method that supports other pagination techniques', function () {
+      it('should not automatically paginate')
+    });
+  });
+
   afterEach(function () {
     nock.cleanAll();
   });

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -1,9 +1,11 @@
 require('mocha');
 const fs = require('fs');
 const path = require('path');
-const { Agent } = require('http');
+const { Agent } = require('https');
+const { Readable } = require('stream');
 const { assert } = require('chai');
 const { WebClient } = require('./WebClient');
+const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
 const { addAppMetadata } = require('./util');
 const rapidRetryPolicy = require('./retry-policies').rapidRetryPolicy;
@@ -166,8 +168,7 @@ describe('WebClient', function () {
       });
     });
 
-    // TODO: simulate each of the error types
-    describe('when the call fails', function () {
+    describe('when an API call fails', function () {
       beforeEach(function () {
         this.scope = nock('https://slack.com')
           .post(/api/)
@@ -177,8 +178,9 @@ describe('WebClient', function () {
       it('should return a Promise which rejects on error', function (done) {
         const r = this.client.apiCall('method')
         assert(isPromise(r));
-        r.catch(error => {
-          assert.ok(true);
+        r.catch((error) => {
+          assert.instanceOf(error, Error);
+          this.scope.done();
           done();
         });
       });
@@ -186,22 +188,78 @@ describe('WebClient', function () {
       it('should deliver error in a callback', function (done) {
         this.client.apiCall('method', {}, (error) => {
           assert.instanceOf(error, Error);
+          this.scope.done();
           done();
         });
       });
     });
 
-    it('should fail with platform errors when the API response is an error', function () {
+    it('should fail with WebAPIPlatformError when the API response has an error', function (done) {
       const scope = nock('https://slack.com')
         .post(/api/)
         .reply(200, { ok: false, error: 'bad error' });
-      const client = new WebClient(token);
-      return client.apiCall('method')
+      this.client.apiCall('method')
         .catch((error) => {
-          assert.propertyVal(error, 'code', 'slackclient_platform_error');
+          assert.instanceOf(error, Error);
+          assert.equal(error.code, ErrorCode.PlatformError);
           assert.nestedPropertyVal(error, 'data.ok', false);
           assert.nestedPropertyVal(error, 'data.error', 'bad error');
           scope.done();
+          done();
+        });
+    });
+
+    it('should fail with WebAPIHTTPError when the API response has an unexpected status', function (done) {
+      const body = { foo: 'bar' };
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(500, body);
+      const client = new WebClient(token, { retryConfig: { retries: 0 } });
+      client.apiCall('method')
+        .catch((error) => {
+          assert.instanceOf(error, Error);
+          assert.equal(error.code, ErrorCode.HTTPError);
+          assert.instanceOf(error.original, Error); // TODO: deprecate
+          assert.equal(error.statusCode, 500);
+          assert.exists(error.headers);
+          assert.deepEqual(error.body, body);
+          scope.done();
+          done();
+        });
+    });
+
+    it('should fail with WebAPIRequestError when the API request fails', function (done) {
+      // One known request error is when the node encounters an ECONNREFUSED. In order to simulate this, rather than
+      // using nock, we send the request to a host:port that is not listening.
+      const client = new WebClient(token, { slackApiUrl: 'https://localhost:8999/api/', retryConfig: { retries: 0 } });
+      client.apiCall('method')
+        .catch((error) => {
+          assert.instanceOf(error, Error);
+          assert.equal(error.code, ErrorCode.RequestError);
+          assert.instanceOf(error.original, Error);
+          done();
+        });
+    });
+
+    // Despite trying, could not figure out a good way to simulate a response that emits an error in a reliable way
+    it.skip('should fail with WebAPIReadError when an API response fails', function (done) {
+      class FailingReadable extends Readable {
+        constructor(options) { super(options); }
+        _read(size) {
+          this.emit('error', new Error('test error'));
+        }
+      }
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(200, () => new FailingReadable());
+      const client = new WebClient(token, { retryConfig: { retries: 0 } });
+      client.apiCall('method')
+        .catch((error) => {
+          assert.instanceOf(error, Error);
+          assert.equal(error.code, ErrorCode.ReadError);
+          assert.instanceOf(error.original, Error);
+          scope.done();
+          done();
         });
     });
 
@@ -252,8 +310,6 @@ describe('WebClient', function () {
         scope.done();
       });
     });
-
-    it('should remove undefined or null values from complex API arguments');
 
     describe('when API arguments contain binary to upload', function () {
       beforeEach(function () {
@@ -394,17 +450,19 @@ describe('WebClient', function () {
   });
 
   describe('apiCall() - without a token', function () {
-    const client = new WebClient(undefined, { retryConfig: rapidRetryPolicy });
+    it('should make successful api calls', function () {
+      const client = new WebClient(undefined, { retryConfig: rapidRetryPolicy });
 
-    const scope = nock('https://slack.com')
-      // NOTE: this could create false negatives if the serialization order changes (it shouldn't matter)
-      .post(/api/, 'foo=stringval')
-      .reply(200, { ok: true });
+      const scope = nock('https://slack.com')
+        // NOTE: this could create false negatives if the serialization order changes (it shouldn't matter)
+        .post(/api/, 'foo=stringval')
+        .reply(200, { ok: true });
 
-    const r = client.apiCall('method', { foo: 'stringval' });
-    assert(isPromise(r));
-    return r.then(result => {
-      scope.done();
+      const r = client.apiCall('method', { foo: 'stringval' });
+      assert(isPromise(r));
+      return r.then((result) => {
+        scope.done();
+      });
     });
   });
 
@@ -440,11 +498,23 @@ describe('WebClient', function () {
   });
 
   describe('has an option to set a custom HTTP agent', function () {
-    // not confident how to test this. one idea is to use sinon to intercept method calls on the agent.
-    it.skip('should send a request using the custom agent', function () {
-      const agent = new Agent();
+    it('should send a request using the custom agent', function () {
+      const agent = new Agent({ keepAlive: true });
+      const spy = sinon.spy(agent, 'addRequest');
       const client = new WebClient(token, { agent });
-      return client.apiCall('method');
+      return client.apiCall('method')
+        .catch(() => {
+          assert(spy.called);
+        })
+        .then(() => {
+          agent.addRequest.restore();
+          agent.destroy();
+        })
+        .catch((error) => {
+          agent.addRequest.restore();
+          agent.destroy();
+          throw error;
+        });
     });
   });
 
@@ -519,7 +589,7 @@ describe('WebClient', function () {
     it('retries a request which fails to get a response', function () {
       const scope = nock('https://slack.com')
         .post(/api/)
-        .replyWithError('could be a ECONNREFUESD, ENOTFOUND, ETIMEDOUT, ECONNRESET')
+        .replyWithError('could be a ECONNREFUSED, ENOTFOUND, ETIMEDOUT, ECONNRESET')
         .post(/api/)
         .reply(200, { ok: true });
       const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
@@ -646,8 +716,29 @@ describe('WebClient', function () {
       });
     });
 
+    // TODO: other types of warnings
+
+    // TODO: when pagination type is traditional
+
+    // TODO: when pagination type is mixed (differnt kinds of combos)
+
+    // TODO: when parsing he retry header fails
+
+    // TODO: a result that has retry headers in it (when automatic rate-limit handling is disabled)
+
     describe('when using a method that supports other pagination techniques', function () {
-      it('should not automatically paginate')
+      it('should not automatically paginate', function () {
+        const scope = nock('https://slack.com')
+          .post(/api/)
+          .reply(200, { ok: true, messages: [{}, {}], has_more: false });
+
+        const client = new WebClient(token);
+        return client.mpim.history({ channel: 'MPIM_ID' })
+          .then((result) => {
+            assert.isTrue(result.ok);
+            scope.done();
+          });
+      });
     });
   });
 

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -682,6 +682,22 @@ describe('WebClient', function () {
           });
       });
 
+      it('should allow the automatic page size to be configured', function () {
+        const pageSize = 400;
+        const scope = nock('https://slack.com')
+          .post(/api/, (body) => {
+            // NOTE: limit value is compared as a string because nock doesn't properly serialize the param into a number
+            return body.limit && body.limit === ('' + pageSize);
+          })
+          .reply(200, { ok: true, channels: [], response_metadata: {} })
+
+        const client = new WebClient(token, { pageSize });
+        return client.channels.list()
+          .then((result) => {
+            scope.done();
+          });
+      });
+
       it('should not automatically paginate when pagination options are supplied', function () {
         const scope = nock('https://slack.com')
           .post(/api/)

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -523,19 +523,20 @@ describe('WebClient', function () {
 
     describe('when a request fails due to rate-limiting', function () {
       // NOTE: is this retrying configurable with the retry policy? is it subject to the request concurrency?
-      it('should automatically retry the request after the specified timeout', function() {
+      it('should automatically retry the request after the specified timeout', function () {
         const scope = nock('https://slack.com')
           .post(/api/)
           .reply(429, {}, { 'retry-after': 1 })
           .post(/api/)
           .reply(200, { ok: true });
-        const client = new WebClient(token, { retryConfig: { retries: 1 } });
+        const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
         const startTime = new Date().getTime();
         return client.apiCall('method')
           .then((resp) => {
             const time = new Date().getTime() - startTime;
             assert.isAtLeast(time, 1000, 'elapsed time is at least a second');
             assert.propertyVal(resp, 'ok', true);
+            scope.done();
           });
       });
 

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -200,7 +200,7 @@ export class WebClient extends EventEmitter {
                 ),
               ) as got.Response<string>;
 
-              // TODO: config option for automatic retry handling here
+              // TODO: config option for automatic rate limit handling here
               if (response.statusCode === 429) {
                 const retrySec = parseRetryHeaders(response);
                 if (retrySec !== undefined) {
@@ -805,7 +805,7 @@ enum PaginationType {
 }
 
 /**
- * Determines which pagination type, if any, the supplied options (a.k.a. method arguments) is using. This method is
+ * Determines which pagination type, if any, the supplied options (a.k.a. method arguments) are using. This method is
  * also able to determine if the options have mixed different pagination types.
  */
 function getOptionsPaginationType(options?: WebAPICallOptions): PaginationType {

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -174,7 +174,6 @@ export class WebClient extends EventEmitter {
 
         if (shouldAutoPaginate) {
           // these are the default pagination options
-          // TODO: store the default page size in a constant, or possibly an instance-specific option
           paginationOptions = { limit: this.pageSize };
         }
 
@@ -886,12 +885,14 @@ function createResultMerger(method: string):
       return accumulator;
     };
   }
+  // For all methods who don't use cursor-pagination, return the identity reduction function
   return (_, result) => result;
 }
 
 /**
  * Determines an appropriate set of cursor pagination options for the next request to a paginated API method.
  * @param previousResult - the result of the last request, where the next cursor might be found.
+ * @param pageSize - the maximum number of additional items to fetch in the next request.
  */
 function paginationOptionsForNextPage(
   previousResult: WebAPICallResult, pageSize: number,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -40,9 +40,6 @@ export enum ErrorCode {
 
 /**
  * Factory for producing a {@link CodedError} from a generic error
- *
- * @param error
- * @param code
  */
 export function errorWithCode(error: Error, code: ErrorCode): CodedError {
   const codedError = error as Partial<CodedError>;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -106,8 +106,6 @@ function isMoreSevere(level: LogLevel, threshold: number): boolean {
 
 /**
  * INTERNAL function for transforming an external LoggerFunc type into the internal Logger interface
- * @param name
- * @param loggingFunc
  */
 export function loggerFromLoggingFunc(name: string, loggingFunc: LoggingFunc): Logger {
   const logger = log.getLogger(name);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -80,10 +80,8 @@ log.methodFactory = function (
 /**
  * INTERNAL interface for getting or creating a named Logger
  */
-// TODO: implement logger name prefixing (example plugins available on the loglevel package's site)
-// export const getLogger = log.getLogger as (name: string) => Logger;
-
 export function getLogger(name: string): Logger {
+  // TODO: implement logger name prefixing (example plugins available on the loglevel package's site)
   const instanceNumber = instanceCount;
   instanceCount += 1;
   return log.getLogger(name + instanceNumber);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,8 @@
 import * as log from 'loglevel';
 import { noop } from './util';
 
+let instanceCount = 0;
+
 /**
  * Severity levels for log entries
  */
@@ -79,7 +81,13 @@ log.methodFactory = function (
  * INTERNAL interface for getting or creating a named Logger
  */
 // TODO: implement logger name prefixing (example plugins available on the loglevel package's site)
-export const getLogger = log.getLogger as (name: string) => Logger;
+// export const getLogger = log.getLogger as (name: string) => Logger;
+
+export function getLogger(name: string): Logger {
+  const instanceNumber = instanceCount;
+  instanceCount += 1;
+  return log.getLogger(name + instanceNumber);
+}
 
 /**
  * Decides whether `level` is more severe than the `threshold` for logging. When this returns true, logs should be
@@ -108,7 +116,9 @@ function isMoreSevere(level: LogLevel, threshold: number): boolean {
  * INTERNAL function for transforming an external LoggerFunc type into the internal Logger interface
  */
 export function loggerFromLoggingFunc(name: string, loggingFunc: LoggingFunc): Logger {
-  const logger = log.getLogger(name);
+  const instanceNumber = instanceCount;
+  instanceCount += 1;
+  const logger = log.getLogger(name + instanceNumber);
   logger.methodFactory = function (methodName: LogLevel, logLevel, loggerName: string): (...msg: any[]) => void {
     if (isMoreSevere(methodName, logLevel)) {
       return function (...msg: any[]): void {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -8,7 +8,7 @@ import { WebAPICallOptions, WebAPIResultCallback, WebAPICallResult } from './Web
  * Generic method definition
  */
 export default interface Method<MethodArguments extends WebAPICallOptions> {
-  // TODO: can we create a relationship between MethodArguments and a MethodResult type?
+  // TODO: can we create a relationship between MethodArguments and a MethodResult type? hint: conditional types
   (options?: MethodArguments & AuxiliaryArguments): Promise<WebAPICallResult>;
   (options: MethodArguments & AuxiliaryArguments, callback: WebAPIResultCallback): void;
 }
@@ -51,7 +51,7 @@ export interface CursorPaginationEnabled {
   cursor?: string; // find this in a response's `response_metadata.next_cursor`
 }
 export const cursorPaginationOptionKeys = new Set(['limit', 'cursor']);
-export const cursorPaginationEnabledMethods = new Set();
+export const cursorPaginationEnabledMethods: Map<string, string> = new Map(); // method : paginatedResponseProperty
 
 export interface TimelinePaginationEnabled {
   oldest?: string;
@@ -184,7 +184,7 @@ export type AppsPermissionsRequestArguments = TokenOverridable & {
   trigger_id: string;
 };
 export type AppsPermissionsResourcesListArguments = TokenOverridable & CursorPaginationEnabled;
-cursorPaginationEnabledMethods.add('apps.permissions.resources.list');
+cursorPaginationEnabledMethods.set('apps.permissions.resources.list', 'resources');
 export type AppsPermissionsScopesListArguments = TokenOverridable & {};
 
   /*
@@ -240,7 +240,7 @@ export type ChannelsListArguments = TokenOverridable & CursorPaginationEnabled &
   exclude_archived: boolean;
   exclude_members: boolean;
 };
-cursorPaginationEnabledMethods.add('channels.list');
+cursorPaginationEnabledMethods.set('channels.list', 'channels');
 export type ChannelsMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
@@ -341,7 +341,7 @@ export type ConversationsCreateArguments = TokenOverridable & {
 export type ConversationsHistoryArguments = TokenOverridable & CursorPaginationEnabled & TimelinePaginationEnabled & {
   channel: string;
 };
-cursorPaginationEnabledMethods.add('conversations.history');
+cursorPaginationEnabledMethods.set('conversations.history', 'messages');
 timelinePaginationEnabledMethods.add('conversations.history');
 export type ConversationsInfoArguments = TokenOverridable & LocaleAware & {
   channel: string;
@@ -364,11 +364,11 @@ export type ConversationsListArguments = TokenOverridable & CursorPaginationEnab
   exclude_archived?: boolean;
   types?: string; // comma-separated list of conversation types
 };
-cursorPaginationEnabledMethods.add('conversations.list');
+cursorPaginationEnabledMethods.set('conversations.list', 'channels');
 export type ConversationsMembersArguments = TokenOverridable & CursorPaginationEnabled & {
   channel: string;
 };
-cursorPaginationEnabledMethods.add('conversations.members');
+cursorPaginationEnabledMethods.set('conversations.members', 'members');
 export type ConversationsOpenArguments = TokenOverridable & {
   channel?: string;
   users?: string; // comma-separated list of users
@@ -382,7 +382,7 @@ export type ConversationsRepliesArguments = TokenOverridable & CursorPaginationE
   channel: string;
   ts: string;
 };
-cursorPaginationEnabledMethods.add('conversations.replies');
+cursorPaginationEnabledMethods.set('conversations.replies', 'messages');
 timelinePaginationEnabledMethods.add('conversations.replies');
 export type ConversationsSetPurposeArguments = TokenOverridable & {
   channel: string;
@@ -489,7 +489,7 @@ export type GroupsHistoryArguments = TokenOverridable & CursorPaginationEnabled 
   channel: string;
   unreads?: boolean;
 };
-cursorPaginationEnabledMethods.add('groups.history');
+cursorPaginationEnabledMethods.set('groups.history', 'messages');
 timelinePaginationEnabledMethods.add('groups.history');
 export type GroupsInfoArguments = TokenOverridable & LocaleAware & {
   channel: string;
@@ -550,7 +550,7 @@ export type IMHistoryArguments = TokenOverridable & TimelinePaginationEnabled & 
 };
 timelinePaginationEnabledMethods.add('im.history');
 export type IMListArguments = TokenOverridable & CursorPaginationEnabled;
-cursorPaginationEnabledMethods.add('im.list');
+cursorPaginationEnabledMethods.set('im.list', 'ims');
 export type IMMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
@@ -806,7 +806,7 @@ export type UsersConversationsArguments = TokenOverridable & CursorPaginationEna
   types?: string; // comma-separated list of conversation types
   user?: string;
 };
-cursorPaginationEnabledMethods.add('users.conversations');
+cursorPaginationEnabledMethods.set('users.conversations', 'channels');
 export type UsersDeletePhotoArguments = TokenOverridable;
 export type UsersGetPresenceArguments = TokenOverridable & {
   user: string;
@@ -818,7 +818,7 @@ export type UsersInfoArguments = TokenOverridable & LocaleAware & {
 export type UsersListArguments = TokenOverridable & CursorPaginationEnabled & LocaleAware & {
   presence?: boolean; // deprecated, defaults to false
 };
-cursorPaginationEnabledMethods.add('users.list');
+cursorPaginationEnabledMethods.set('users.list', 'members');
 export type UsersLookupByEmailArguments = TokenOverridable & {
   email: string;
 };

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -430,11 +430,12 @@ export type EmojiListArguments = TokenOverridable;
 export type FilesDeleteArguments = TokenOverridable & {
   file: string; // file id
 };
-export type FilesInfoArguments = TokenOverridable & {
+export type FilesInfoArguments = TokenOverridable & CursorPaginationEnabled & {
   file: string; // file id
   count?: number;
   page?: number;
 };
+cursorPaginationEnabledMethods.set('files.info', 'comments');
 export type FilesListArguments = TokenOverridable & TraditionalPagingEnabled & {
   channel?: string;
   user?: string;
@@ -505,10 +506,11 @@ export type GroupsKickArguments = TokenOverridable & {
 export type GroupsLeaveArguments = TokenOverridable & {
   channel: string;
 };
-export type GroupsListArguments = TokenOverridable & {
+export type GroupsListArguments = TokenOverridable & CursorPaginationEnabled & {
   exclude_archived?: boolean;
   exclude_members?: boolean;
 };
+cursorPaginationEnabledMethods.set('groups.list', 'groups');
 export type GroupsMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
@@ -584,7 +586,8 @@ export type MPIMHistoryArguments = TokenOverridable & TimelinePaginationEnabled 
   unreads?: boolean;
 };
 timelinePaginationEnabledMethods.add('mpim.history');
-export type MPIMListArguments = TokenOverridable;
+export type MPIMListArguments = TokenOverridable & CursorPaginationEnabled;
+cursorPaginationEnabledMethods.set('mpim.list', 'groups');
 export type MPIMMarkArguments = TokenOverridable & {
   channel: string;
   ts: string;
@@ -654,10 +657,11 @@ export type ReactionsGetArguments = TokenOverridable & {
   file?: string; // file id
   file_comment?: string;
 };
-export type ReactionsListArguments = TokenOverridable & TraditionalPagingEnabled & {
+export type ReactionsListArguments = TokenOverridable & TraditionalPagingEnabled & CursorPaginationEnabled & {
   user?: string;
   full?: boolean;
 };
+cursorPaginationEnabledMethods.set('reactions.list', 'items');
 traditionalPagingEnabledMethods.add('reactions.list');
 export type ReactionsRemoveArguments = TokenOverridable & {
   name: string;
@@ -723,7 +727,8 @@ export type StarsAddArguments = TokenOverridable & {
   file?: string; // file id
   file_comment?: string;
 };
-export type StarsListArguments = TokenOverridable & TraditionalPagingEnabled;
+export type StarsListArguments = TokenOverridable & TraditionalPagingEnabled & CursorPaginationEnabled;
+cursorPaginationEnabledMethods.set('stars.list', 'items');
 traditionalPagingEnabledMethods.add('stars.list');
 export type StarsRemoveArguments = TokenOverridable & {
   // must supply one of:

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -44,10 +44,13 @@ export interface Searchable {
 // As maintainers, we must be careful to add each of the API methods into these sets, so that is handled local (in line
 // numbers close) to the application of each interface.
 
+// TODO: express the interfaces as keyof the sets?
+
 export interface CursorPaginationEnabled {
   limit?: number; // natural integer, max of 1000
   cursor?: string; // find this in a response's `response_metadata.next_cursor`
 }
+export const cursorPaginationOptionKeys = new Set(['limit', 'cursor']);
 export const cursorPaginationEnabledMethods = new Set();
 
 export interface TimelinePaginationEnabled {
@@ -55,12 +58,14 @@ export interface TimelinePaginationEnabled {
   latest?: string;
   inclusive?: boolean;
 }
+export const timelinePaginationOptionKeys = new Set(['oldest', 'latest', 'inclusive']);
 export const timelinePaginationEnabledMethods = new Set();
 
 export interface TraditionalPagingEnabled {
   page?: number; // default: 1
   count?: number; // default: 100
 }
+export const traditionalPagingOptionKeys = new Set(['page', 'count']);
 export const traditionalPagingEnabledMethods = new Set();
 
 /*
@@ -837,8 +842,3 @@ export type UsersProfileSetArguments = TokenOverridable & {
   name?: string; // usable if `profile` is not passed
   value?: string; // usable if `profile` is not passed
 };
-
-/**
- * Logical groups of methods which can be used for behavior
- */
-export

--- a/src/retry-policies.ts
+++ b/src/retry-policies.ts
@@ -15,7 +15,6 @@ export const retryForeverExponential: RetryOptions = {
   forever: true,
 };
 
-
 /**
  * Same as {@link retryForeverExponential}, but capped at 30 minutes.
  * TODO: should this name really have "forever" in it? if not, remove from all the derived names below
@@ -23,7 +22,6 @@ export const retryForeverExponential: RetryOptions = {
 export const retryForeverExponentialCapped: RetryOptions = Object.assign({}, retryForeverExponential, {
   maxTimeout: 30 * 60 * 1000,
 });
-
 
 /**
  * Same as {@link retryForeverExponentialCapped}, but with randomization to
@@ -33,7 +31,6 @@ export const retryForeverExponentialCappedRandom: RetryOptions = Object.assign({
   randomize: true,
 });
 
-
 /**
  * Short & sweet, five retries in five minutes and then bail.
  */
@@ -41,7 +38,6 @@ export const fiveRetriesInFiveMinutes: RetryOptions = {
   retries: 5,
   factor: 3.86,
 };
-
 
 /**
  * This policy is just to keep the tests running fast.

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,6 @@ export function noop(): void { } // tslint:disable-line:no-empty
 
 /**
  * Replaces occurences of '/' with ':' in a string, since '/' is meaningful inside User-Agent strings as a separator.
- * @param s
  */
 function replaceSlashes(s: string): string {
   return s.replace('/', ':');
@@ -43,11 +42,11 @@ export function getUserAgent(): string {
 
 // TODO: make initialValue optional (overloads or conditional types?)
 export async function awaitAndReduce<T, U>(iterable: AsyncIterable<T>,
-                                           callbackfn: (previousValue: U, currentValue: T) => Promise<U>,
+                                           callbackfn: (previousValue: U, currentValue: T) => U,
                                            initialValue: U): Promise<U> {
   let accumulator = initialValue;
   for await (const value of iterable) {
-    accumulator = await callbackfn(accumulator, value);
+    accumulator = callbackfn(accumulator, value);
   }
   return accumulator;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,17 @@ export function getUserAgent(): string {
   return ((appIdentifier.length > 0) ? `${appIdentifier} ` : '') + baseUserAgent;
 }
 
+// TODO: make initialValue optional (overloads or conditional types?)
+export async function awaitAndReduce<T, U>(iterable: AsyncIterable<T>,
+                                           callbackfn: (previousValue: U, currentValue: T) => Promise<U>,
+                                           initialValue: U): Promise<U> {
+  let accumulator = initialValue;
+  for await (const value of iterable) {
+  accumulator = await callbackfn(accumulator, value);
+}
+  return accumulator;
+}
+
 /**
  * The following is a polyfill of Node >= 8.2.0's util.callbackify method. The source is copied (with some
  * modification) from:

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,6 @@ const appMetadata: { [key: string]: string } = {};
 
 /**
  * Appends the app metadata into the User-Agent value
- * @param appMetadata
  * @param appMetadata.name name of tool to be counted in instrumentation
  * @param appMetadata.version version of tool to be counted in instrumentation
  */
@@ -48,8 +47,8 @@ export async function awaitAndReduce<T, U>(iterable: AsyncIterable<T>,
                                            initialValue: U): Promise<U> {
   let accumulator = initialValue;
   for await (const value of iterable) {
-  accumulator = await callbackfn(accumulator, value);
-}
+    accumulator = await callbackfn(accumulator, value);
+  }
   return accumulator;
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,10 +40,27 @@ export function getUserAgent(): string {
   return ((appIdentifier.length > 0) ? `${appIdentifier} ` : '') + baseUserAgent;
 }
 
-// TODO: make initialValue optional (overloads or conditional types?)
+/**
+ * Build a Promise that will resolve after the specified number of milliseconds.
+ * @param ms milliseconds to wait
+ * @param value value for eventual resolution
+ */
+export function delay<T>(ms: number, value?: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
+}
+
+/**
+ * Reduce an asynchronous iterable into a single value.
+ * @param iterable the async iterable to be reduced
+ * @param callbackfn a function that implements one step of the reduction
+ * @param initialValue the initial value for the accumulator
+ */
 export async function awaitAndReduce<T, U>(iterable: AsyncIterable<T>,
                                            callbackfn: (previousValue: U, currentValue: T) => U,
                                            initialValue: U): Promise<U> {
+  // TODO: make initialValue optional (overloads or conditional types?)
   let accumulator = initialValue;
   for await (const value of iterable) {
     accumulator = callbackfn(accumulator, value);

--- a/support/jsdoc/@slack-client-dist-KeepAlive.js
+++ b/support/jsdoc/@slack-client-dist-KeepAlive.js
@@ -8,8 +8,8 @@
  * `recommend_reconnect` event. That event should be handled by tearing down the websocket connection and
  * opening a new one.
  * @extends EventEmitter
- * @property {Boolean} [isMonitoring] Flag that indicates whether this object is still monitoring.
- * @property {Boolean} [recommendReconnect] Flag that indicates whether recommend_reconnect event has been emitted and stop() has not been called.
+ * @property {boolean} isMonitoring Flag that indicates whether this object is still monitoring.
+ * @property {boolean} recommendReconnect Flag that indicates whether recommend_reconnect event has been emitted and stop() has not been called.
  */
 export class KeepAlive {
   /**

--- a/support/jsdoc/@slack-client-dist-logger.js
+++ b/support/jsdoc/@slack-client-dist-logger.js
@@ -45,6 +45,12 @@ export class Logger {
 }
 
 /**
+ * INTERNAL interface for getting or creating a named Logger
+ * @param {string} name
+ * @returns {module:@slack/client/dist/logger.Logger}
+ */
+export function getLogger() {}
+/**
  * INTERNAL function for transforming an external LoggerFunc type into the internal Logger interface
  * @param {string} name
  * @param {module:@slack/client.LoggingFunc} loggingFunc

--- a/support/jsdoc/@slack-client-dist-methods.js
+++ b/support/jsdoc/@slack-client-dist-methods.js
@@ -3,6 +3,11 @@
  */
 
 /**
+ * @type {Map}
+ * @constant
+ */
+export var cursorPaginationEnabledMethods
+/**
  * @interface module:@slack/client/dist/methods.AttachmentAction
  * @property {string} [id]
  * @property {module:@slack/client/dist/methods.Confirmation} [confirm]
@@ -109,6 +114,16 @@ export class OptionField {
 }
 
 /**
+ * @interface module:@slack/client/dist/methods.Searchable
+ * @property {string} query
+ * @property {boolean} [highlight]
+ * @property {"score" | "timestamp"} sort
+ * @property {"asc" | "desc"} sort_dir
+ */
+export class Searchable {
+}
+
+/**
  * @interface module:@slack/client/dist/methods.SelectOption
  * @property {string} label
  * @property {string} value
@@ -130,5 +145,13 @@ export class TimelinePaginationEnabled {
  * @property {string} [token]
  */
 export class TokenOverridable {
+}
+
+/**
+ * @interface module:@slack/client/dist/methods.TraditionalPagingEnabled
+ * @property {number} [page]
+ * @property {number} [count]
+ */
+export class TraditionalPagingEnabled {
 }
 

--- a/support/jsdoc/@slack-client-dist-util.js
+++ b/support/jsdoc/@slack-client-dist-util.js
@@ -3,6 +3,21 @@
  */
 
 /**
+ * Reduce an asynchronous iterable into a single value.
+ * @param {module:node_modules/typescript/lib/lib.esnext.asynciterable.AsyncIterable<module:@slack/client/dist/util.T>} iterable the async iterable to be reduced
+ * @param {callback} callbackfn a function that implements one step of the reduction
+ * @param {module:@slack/client/dist/util.U} initialValue the initial value for the accumulator
+ * @returns {Promise<module:@slack/client/dist/util.U>}
+ */
+export function awaitAndReduce() {}
+/**
+ * Build a Promise that will resolve after the specified number of milliseconds.
+ * @param {number} ms milliseconds to wait
+ * @param {module:@slack/client/dist/util.T} value value for eventual resolution
+ * @returns {Promise<module:@slack/client/dist/util.T>}
+ */
+export function delay() {}
+/**
  * Returns the current User-Agent value for instrumentation
  * @returns {string}
  */

--- a/support/jsdoc/@slack-client.js
+++ b/support/jsdoc/@slack-client.js
@@ -1,4 +1,4 @@
-/** 
+/**
  * @module @slack/client
  */
 
@@ -157,12 +157,12 @@ export class RTMClient {
    * Generic method for sending an outgoing message of an arbitrary type. This method guards the higher-level methods
    * from concern of which state the client is in, because it places all messages into a queue. The tasks on the queue
    * will buffer until the client is in a state where they can be sent.
-   * 
+   *
    * If the awaitReply parameter is set to true, then the returned Promise is resolved with the platform's
    * acknowledgement response. Not all message types will result in an acknowledgement response, so use this carefully.
    * This promise may be rejected with an error containing code=RTMNoReplyReceivedError if the client disconnects or
    * reconnects before recieving the acknowledgement response.
-   * 
+   *
    * If the awaitReply parameter is set to false, then the returned Promise is resolved as soon as the message is sent
    * from the websocket.
    * @param {"undefined"} awaitReply whether to wait for an acknowledgement response from the platform before resolving the returned
@@ -322,6 +322,10 @@ export class WebAPICallResult {
  * @extends module:@slack/client.CodedError
  * @property {"slackclient_http_error"} code
  * @property {Error} original
+ * @property {number} statusCode
+ * @property {string} statusMessage
+ * @property {module:http.IncomingHttpHeaders} headers
+ * @property {any} [body]
  */
 export class WebAPIHTTPError {
 }
@@ -361,7 +365,7 @@ export class WebAPIResultCallback {
 
 /**
  * A client for Slack's Web API
- * 
+ *
  * This client provides an alias for each {@link https://api.slack.com/methods|Web API method}. Each method is
  * a convenience wrapper for calling the {@link WebClient#apiCall} method using the method name as the first parameter.
  * @extends EventEmitter
@@ -404,6 +408,7 @@ export class WebClient {
  * @property {module:@slack/client.RetryOptions} [retryConfig]
  * @property {"undefined" | "undefined" | module:http.Agent | module:@slack/client/dist/util.__type} [agent]
  * @property {module:@slack/client.TLSOptions} [tls]
+ * @property {number} [pageSize]
  */
 export class WebClientOptions {
 }

--- a/test/typescript/tsconfig-strict.json
+++ b/test/typescript/tsconfig-strict.json
@@ -8,6 +8,12 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "lib": [
+      "es5",
+      "es2015",
+      "es2016.array.include",
+      "esnext.asynciterable"
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "lib": [
       "es5",
       "es2015",
-      "es2016.array.include"
+      "es2016.array.include",
+      "esnext.asynciterable"
     ]
   },
   "include": [


### PR DESCRIPTION
###  Summary

The platform is expanding the set of methods which support the shiniest of our pagination specifications, cursor-based pagination!

This change allows apps who previously made API calls to methods (that support cursor pagination) without any explicit pagination arguments to transparently traverse pages. This solves two major problems:
1. Previously, if the list was too long to return in a reasonable amount of time, these requests may result in server errors (500 response code).
2. Some methods started to return partial lists (with default `limit` values) in situations where the client didn't provide pagination arguments. This would create a subtle bug, but now these apps should get the entire list.

This change also helps apps prepare for a future where pagination becomes mandatory in certain situations.

Fixes #343 

**Please review and provide feedback**

At this point, my biggest concern is that this is a _lot_ of new code, for what amounts to functionality we still strongly recommend developers do not use. More specifically, we still want developers to paginate requests themselves, and not to depend on the automatic pagination. Our reason is that this will result in more performant and optimized code. So, planting all this code is very intentionally a band-aid. My proposal for how we'd address this concern is to merge this now, and in  the next major version to remove automatic pagination; moving that code into an add-on that can be used in conjunction with the baseline package. That add-on would be a shim that's only for backwards compatibility, but not encouraged.

Another concern is now the `cursorPaginationEnabledMethods` in `methods.ts` value is starting to store metadata about API responses, but outside of the holistic design we're hoping to arrive in #496 and #509.

## TODO

- [x] Sync metadata with the latest round of cursor-pagination supporting methods
- [x] Implement tests and get acceptable coverage
- [x] ~Add configuration for rate-limit retires (simple boolean) #451~ This can be done in a separate, follow-up PR, which will make it easier to review.
- [x] Handle general httpError conditions (like 500 responses)
- [x] Audit error types and codes
- [x] Turn default page size into a configuration option
- [ ] Document the new feature(s)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
