### PR TITLE
Adds rejectRateLimitedCalls option for WebClient

### DIFF
--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -615,10 +615,9 @@ describe('WebClient', function () {
   });
 
   describe('has rate limit handling', function () {
-
     describe('when configured to reject rate-limited calls', function () {
       beforeEach(function () {
-        this.client = new WebClient(token, { rejectRateLimitedCalls: true, retryConfig: rapidRetryPolicy });
+        this.client = new WebClient(token, { rejectRateLimitedCalls: true });
       });
 
       it('should reject with a WebAPIRateLimitedError when a request fails due to rate-limiting', function (done) {
@@ -635,40 +634,81 @@ describe('WebClient', function () {
             done();
           });
       });
-    });
 
-    describe('when a request fails due to rate-limiting', function () {
-      it('should automatically retry the request after the specified timeout', function () {
-        const scope = nock('https://slack.com')
-          .post(/api/)
-          .reply(429, {}, { 'retry-after': 1 })
-          .post(/api/)
-          .reply(200, { ok: true });
-        const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
-        const startTime = new Date().getTime();
-        return client.apiCall('method')
-          .then((resp) => {
-            const time = new Date().getTime() - startTime;
-            assert.isAtLeast(time, 1000, 'elapsed time is at least a second');
-            assert.propertyVal(resp, 'ok', true);
-            scope.done();
-          });
-      });
-
-      it('should pause the remaining requests in queue');
-
-      it('should emit a rate_limited event on the client', function() {
+      it('should emit a rate_limited event on the client', function (done) {
         const spy = sinon.spy();
         const scope = nock('https://slack.com')
           .post(/api/)
           .reply(429, {}, { 'retry-after': 0 });
-        const client = new WebClient(token, { retryConfig: { retries: 0 } });
+        const client = new WebClient(token, { rejectRateLimitedCalls: true });
         client.on('rate_limited', spy);
-        return client.apiCall('method')
+        client.apiCall('method')
           .catch((err) => {
-            sinon.assert.calledOnce(spy);
+            assert(spy.calledOnceWith(0))
+            scope.done();
+            done();
           });
       });
+    });
+
+    it('should automatically retry the request after the specified timeout', function () {
+      const retryAfter = 1;
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(429, '', { 'retry-after': retryAfter })
+        .post(/api/)
+        .reply(200, { ok: true });
+      const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
+      const startTime = Date.now();
+      return client.apiCall('method')
+        .then(() => {
+          const diff = Date.now() - startTime;
+          assert.isAtLeast(diff, retryAfter * 1000, 'elapsed time is at least a second');
+          scope.done();
+        });
+    });
+
+    // TODO: seems like the queuing logic needs to be adjusted
+    it.skip('should pause the remaining requests in queue', function () {
+      const startTime = Date.now();
+      const retryAfter = 1;
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(429, '', { 'retry-after': retryAfter })
+        .post(/api/)
+        .reply(200, function (uri, requestBody) {
+          console.log('first success');
+          return JSON.stringify({ ok: true, diff: Date.now() - startTime });
+        })
+        .post(/api/)
+        .reply(200, function (uri, requestBody) {
+          console.log('second success');
+          return JSON.stringify({ ok: true, diff: Date.now() - startTime });
+        });
+      const client = new WebClient(token, { retryConfig: rapidRetryPolicy, maxRequestConcurrency: 1, logLevel: LogLevel.DEBUG });
+      const firstCall = client.apiCall('method');
+      const secondCall = client.apiCall('method');
+      return Promise.all([firstCall, secondCall])
+        .then(([firstResult, secondResult]) => {
+          assert.isAtLeast(firstResult.diff, retryAfter * 1000);
+          assert.isAtLeast(secondResult.diff, retryAfter * 1000);
+          scope.done();
+        });
+    });
+
+    it('should emit a rate_limited event on the client', function (done) {
+      const spy = sinon.spy();
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(429, {}, { 'retry-after': 0 });
+      const client = new WebClient(token, { retryConfig: { retries: 0 } });
+      client.on('rate_limited', spy);
+      client.apiCall('method')
+        .catch((err) => {
+          assert(spy.calledOnceWith(0))
+          scope.done();
+          done();
+        });
     });
   });
 

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -668,8 +668,7 @@ describe('WebClient', function () {
         });
     });
 
-    // TODO: seems like the queuing logic needs to be adjusted
-    it.skip('should pause the remaining requests in queue', function () {
+    it('should pause the remaining requests in queue', function () {
       const startTime = Date.now();
       const retryAfter = 1;
       const scope = nock('https://slack.com')
@@ -677,15 +676,13 @@ describe('WebClient', function () {
         .reply(429, '', { 'retry-after': retryAfter })
         .post(/api/)
         .reply(200, function (uri, requestBody) {
-          console.log('first success');
           return JSON.stringify({ ok: true, diff: Date.now() - startTime });
         })
         .post(/api/)
         .reply(200, function (uri, requestBody) {
-          console.log('second success');
           return JSON.stringify({ ok: true, diff: Date.now() - startTime });
         });
-      const client = new WebClient(token, { retryConfig: rapidRetryPolicy, maxRequestConcurrency: 1, logLevel: LogLevel.DEBUG });
+      const client = new WebClient(token, { retryConfig: rapidRetryPolicy, maxRequestConcurrency: 1 });
       const firstCall = client.apiCall('method');
       const secondCall = client.apiCall('method');
       return Promise.all([firstCall, secondCall])

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -216,11 +216,11 @@ export class WebClient extends EventEmitter {
               if (response.statusCode === 429) {
                 const retrySec = parseRetryHeaders(response);
                 if (retrySec !== undefined) {
-                  this.logger.info(`API Call failed due to rate limiting. Will retry in ${retrySec} seconds.`);
                   this.emit('rate_limited', retrySec);
                   if (this.rejectRateLimitedCalls) {
                     throw new pRetry.AbortError(rateLimitedErrorWithDelay(retrySec));
                   }
+                  this.logger.info(`API Call failed due to rate limiting. Will retry in ${retrySec} seconds.`);
                   // pause the request queue and then delay the rejection by the amount of time in the retry header
                   this.requestQueue.pause();
                   // NOTE: if there was a way to introspect the current RetryOperation and know what the next timeout

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,6 +19,7 @@ export enum ErrorCode {
   ReadError = 'slackclient_read_error', // Corresponds to WebAPIReadError
   HTTPError = 'slackclient_http_error', // Corresponds to WebAPIHTTPError
   PlatformError = 'slackclient_platform_error', // Corresponds to WebAPIPlatformError
+  RateLimitedError = 'slackclient_rate_limited_error', // Corresponds to WebAPIRateLimitedError
 
   // RTMClient
   RTMSendWhileDisconnectedError = 'slackclient_rtmclient_send_while_disconnected_error',

--- a/support/jsdoc/@slack-client-dist-WebClient.js
+++ b/support/jsdoc/@slack-client-dist-WebClient.js
@@ -1,0 +1,13 @@
+/** 
+ * @module @slack/client/dist/WebClient
+ */
+
+/**
+ * @interface module:@slack/client/dist/WebClient.WebAPIRateLimitedError
+ * @extends module:@slack/client.CodedError
+ * @property {"slackclient_rate_limited_error"} code
+ * @property {number} retryAfter
+ */
+export class WebAPIRateLimitedError {
+}
+

--- a/support/jsdoc/@slack-client.js
+++ b/support/jsdoc/@slack-client.js
@@ -10,6 +10,7 @@
  * @property ReadError
  * @property HTTPError
  * @property PlatformError
+ * @property RateLimitedError
  * @property RTMSendWhileDisconnectedError
  * @property RTMSendWhileNotReadyError
  * @property RTMSendMessagePlatformError
@@ -409,6 +410,7 @@ export class WebClient {
  * @property {"undefined" | "undefined" | module:http.Agent | module:@slack/client/dist/util.__type} [agent]
  * @property {module:@slack/client.TLSOptions} [tls]
  * @property {number} [pageSize]
+ * @property {boolean} [rejectRateLimitedCalls]
  */
 export class WebClientOptions {
 }


### PR DESCRIPTION
###  Summary

This adds a feature for users who choose to handle rate-limited requests on their own.

By setting `rejectRateLimitedCalls` to `true`, any time the Slack Web API response with a status code 429, the `WebClient#apiCall()` method's returned Promise will reject (or callback will invoke) with an error. That error is a new error type, denoted by the `code` property, which is equal to the `ErrorCode.RateLimitedError` value (another top-level export).

Builds upon #596 

Fixes #451 

## TODO

- [x] Tests
- [x] Documentation

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
