### PR TITLE
Fix syntax error in web_client.md

### DIFF
--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -167,7 +167,6 @@ web.channels.list()
     res.channels.forEach(c => console.log(c.name));
   })
   .catch(console.error);
-});
 ```
 
 ---


### PR DESCRIPTION
###  Summary

This PR fixes a syntax error in the documentation for `web_client.md`. See [#594](https://github.com/slackapi/node-slack-sdk/issues/594)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
