### PR TITLE
Add note about log level debug in rtm_client.md

### DIFF
--- a/docs/_pages/rtm_client.md
+++ b/docs/_pages/rtm_client.md
@@ -310,6 +310,8 @@ export.
 You can also capture the logs without writing them to stdout by setting the `logger` option. It should be set to a
 function that takes `fn(level: string, message: string)`.
 
+**Note** `logLevel: LogLevel.DEBUG` should not be used in production. Debug is helpful for diagnosing issues but it is a bad idea to use this in production because it will log the contents of messages in the RTMClient.
+
 ```javascript
 const fs = require('fs');
 const { RTMClient, LogLevel } = require('@slack/client');


### PR DESCRIPTION
###  Summary

Add a note to developer to not use log level debug in production. See [#577](https://github.com/slackapi/node-slack-sdk/issues/577)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
