### PR TITLE
allows RTMClient to transition from connecting to disconnecting

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -159,6 +159,7 @@ export class RTMClient extends EventEmitter {
             this.teardownWebsocket();
           })
         .on('failure').transitionTo('disconnected')
+        .on('explicit disconnect').transitionTo('disconnecting')
       .state('connected')
         .onEnter(() => {
           this.connected = true;
@@ -212,12 +213,10 @@ export class RTMClient extends EventEmitter {
         })
       .state('disconnecting')
         .onEnter(() => {
-          // invariant: websocket exists and is open at the start of this state
+          // Most of the time, a websocket will exist. The only time it does not is when transitioning from connecting,
+          // before the rtm.start() has finished and the websocket hasn't been set up.
           if (this.websocket !== undefined) {
             this.websocket.close();
-          } else {
-            this.logger.error('Websocket not found when transitioning into disconnecting state. Please report to ' +
-              '@slack/client package maintainers.');
           }
         })
         .on('websocket close').transitionTo('disconnected')


### PR DESCRIPTION
###  Summary

Implements a transition from `connecting` to `disconnecting`.

This removes the invariant that the disconnecting state was only reachable while a websocket already exists. There's a valid case now, which is calling `rtm.disconnect()` before `rtm.start()` has completely finished.

Fixes #576

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
