### PR TITLE
adds warning for use of deprecated file threads methods

### DIFF
--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -144,6 +144,15 @@ export class WebClient extends EventEmitter {
         throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
       }
 
+      // warn for methods whose functionality is deprecated
+      if (method === 'files.comments.add' || method === 'files.comments.edit') {
+        this.logger.warn(
+          `File comments are deprecated in favor of file threads. Replace uses of ${method} in your app ` +
+          'to take advantage of improvements. See https://api.slack.com/changelog/2018-05-file-threads-soon-tread ' +
+          'to learn more.',
+        );
+      }
+
       const methodSupportsCursorPagination = methods.cursorPaginationEnabledMethods.has(method);
       const optionsPaginationType = getOptionsPaginationType(options);
 


### PR DESCRIPTION
###  Summary

Fixes #583

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
