### PR TITLE
loosens type constraint on @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/got": "^7.1.7",
     "@types/is-stream": "^1.1.0",
     "@types/loglevel": "^1.5.3",
-    "@types/node": "^9.4.7",
+    "@types/node": ">=6.0.0",
     "@types/p-cancelable": "^0.3.0",
     "@types/p-queue": "^2.3.1",
     "@types/p-retry": "^1.0.1",

--- a/src/util.ts
+++ b/src/util.ts
@@ -69,6 +69,29 @@ export async function awaitAndReduce<T, U>(iterable: AsyncIterable<T>,
 }
 
 /**
+ * Instead of depending on the util.callbackify type in the `@types/node` package, we're copying the type defintion
+ * of that function into an interface here. This needs to be manually updated if the type definition in that package
+ * changes.
+ */
+// tslint:disable:max-line-length
+interface Callbackify {
+  (fn: () => Promise<void>): (callback: (err: NodeJS.ErrnoException) => void) => void;
+  <TResult>(fn: () => Promise<TResult>): (callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, TResult>(fn: (arg1: T1) => Promise<TResult>): (arg1: T1, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, T2>(fn: (arg1: T1, arg2: T2) => Promise<void>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException) => void) => void;
+  <T1, T2, TResult>(fn: (arg1: T1, arg2: T2) => Promise<TResult>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException) => void) => void;
+  <T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException) => void) => void;
+  <T1, T2, T3, T4, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, T2, T3, T4, T5>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException) => void) => void;
+  <T1, T2, T3, T4, T5, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+  <T1, T2, T3, T4, T5, T6>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void;
+  <T1, T2, T3, T4, T5, T6, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+}
+// tslint:enable:max-line-length
+
+/**
  * The following is a polyfill of Node >= 8.2.0's util.callbackify method. The source is copied (with some
  * modification) from:
  * https://github.com/nodejs/node/blob/bff5d5b8f0c462880ef63a396d8912d5188bbd31/lib/util.js#L1095-L1140
@@ -156,7 +179,7 @@ export const callbackify = util.callbackify !== undefined ? util.callbackify : (
 
   // tslint:enable
   return callbackify;
-}() as typeof util.callbackify);
+}() as Callbackify);
 
 export type AgentOption = Agent | {
   http?: Agent,

--- a/test/typescript/sources/webclient-callback-type.ts
+++ b/test/typescript/sources/webclient-callback-type.ts
@@ -1,0 +1,13 @@
+import { WebClient } from '../../../dist';
+
+const web = new WebClient('TOKEN');
+
+// calling a method with a callback function instead of returning a promise
+web.chat.postMessage({ channel: 'CHANNEL', text: 'TEXT' }, (error, result) => {
+  // TODO: type assertion checks (when the library supports this feature)
+  if (error) {
+    console.log(error.code);
+  }
+
+  console.log(result.ok);
+});

--- a/test/typescript/test.ts
+++ b/test/typescript/test.ts
@@ -9,5 +9,8 @@ describe('typescript typings tests', () => {
   it('should export method argument types and enforce strictness in the right ways', () => {
     check([`${__dirname}/sources/method-argument-types.ts`], `${__dirname}/tsconfig-strict.json`);
   });
-});
 
+  it('should properly type api calls with callback method parameters', () => {
+    check([`${__dirname}/sources/webclient-callback-type.ts`], `${__dirname}/tsconfig-strict.json`);
+  });
+});


### PR DESCRIPTION
###  Summary

When a user of this package wants to install a newer version of `@types/node` into their own application than the version specified in this package, bad things can happen (see #582). By loosening this constraint, it allows npm to resolve to a single version that works for the whole project. The risk this PR introduces is that future versions of node may specify new API that doesn't exist in older versions, so we have to be careful to only depend on node types which are identical across versions, or we have to offer implement a polyfill with its own type described (such as with `src/util.ts` `callbackify()`).

Fixes #582

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
