### PR TITLE
implement actor enabled methods

### DIFF
--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -9,6 +9,7 @@ headings:
     - title: Adding attachments to a message
     - title: Uploading a file
     - title: Getting a list of channels
+    - title: Calling methods on behalf of users
     - title: Using a callback instead of a Promise
     - title: Changing the retry configuration
     - title: Changing the request concurrency
@@ -166,6 +167,34 @@ web.channels.list()
   .then((res) => {
     // `res` contains information about the channels
     res.channels.forEach(c => console.log(c.name));
+  })
+  .catch(console.error);
+```
+
+---
+
+### Calling methods on behalf of users
+
+When using [workspace tokens](https://api.slack.com/docs/working-with-workspace-tokens), some methods allow your app
+to perform the action [on behalf of a user](https://api.slack.com/docs/working-for-users). To use one of these methods,
+your app will provide the user's ID in the options a property named `on_behalf_of`.
+
+```javascript
+const { WebClient } = require('@slack/client');
+
+// An access token (from your Slack workspace app - xoxa)
+const token = process.env.SLACK_TOKEN;
+
+// A user ID - this may be found in events or requests such as slash commands, interactive messages, actions, or dialogs
+const userId = 'U0123456';
+
+const web = new WebClient(token);
+
+// https://api.slack.com/methods/users.identity
+web.users.identity({ on_behalf_of: userId })
+  .then((res) => {
+    // `res` contains information about the user. the specific structure depends on the scopes your app was allowed.
+    console.log(res);
   })
   .catch(console.error);
 ```

--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -177,7 +177,7 @@ web.channels.list()
 
 When using [workspace tokens](https://api.slack.com/docs/working-with-workspace-tokens), some methods allow your app
 to perform the action [on behalf of a user](https://api.slack.com/docs/working-for-users). To use one of these methods,
-your app will provide the user's ID in the options a property named `on_behalf_of`.
+your app will provide the user's ID as an option named `on_behalf_of`.
 
 ```javascript
 const { WebClient } = require('@slack/client');

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -311,6 +311,21 @@ describe('WebClient', function () {
       });
     });
 
+    it('should embed an actor in the request headers', function () {
+      const userId = 'USERID';
+      const scope = nock('https://slack.com', {
+          reqheaders: {
+            'X-Slack-User': userId,
+          },
+        })
+        .post(/api/)
+        .reply(200, { ok: true });
+      return this.client.apiCall('method', { actor: userId })
+        .then(() => {
+          scope.done();
+        });
+    });
+
     describe('when API arguments contain binary to upload', function () {
       beforeEach(function () {
         const self = this;

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -311,7 +311,7 @@ describe('WebClient', function () {
       });
     });
 
-    it('should embed an actor in the request headers', function () {
+    it('should the user on whose behalf the method is called in the request headers', function () {
       const userId = 'USERID';
       const scope = nock('https://slack.com', {
           reqheaders: {
@@ -320,7 +320,7 @@ describe('WebClient', function () {
         })
         .post(/api/)
         .reply(200, { ok: true });
-      return this.client.apiCall('method', { actor: userId })
+      return this.client.apiCall('method', { on_behalf_of: userId })
         .then(() => {
           scope.done();
         });

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -157,9 +157,9 @@ export class WebClient extends EventEmitter {
       const headers = {
         'user-agent': this.userAgent,
       };
-      if (options !== undefined && (options as any).actor !== undefined) {
-        headers['X-Slack-User'] = (options as any).actor;
-        delete (options as any).actor;
+      if (options !== undefined && optionsAreUserPerspectiveEnabled(options)) {
+        headers['X-Slack-User'] = options.on_behalf_of;
+        delete options.on_behalf_of;
       }
 
       const methodSupportsCursorPagination = methods.cursorPaginationEnabledMethods.has(method);
@@ -801,6 +801,13 @@ function canBodyBeFormMultipart(body: FormCanBeURLEncoded | BodyCanBeFormMultipa
   // tried using `isStream.readable(body)` but that failes because the object doesn't have a `_read()` method or a
   // `_readableState` property
   return isStream(body);
+}
+
+/**
+ * Determines whether WebAPICallOptions conform to UserPerspectiveEnabled
+ */
+function optionsAreUserPerspectiveEnabled(options: WebAPICallOptions): options is methods.UserPerspectiveEnabled {
+  return (options as any).on_behalf_of !== undefined;
 }
 
 /**

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -153,6 +153,15 @@ export class WebClient extends EventEmitter {
         );
       }
 
+      // build headers
+      const headers = {
+        'user-agent': this.userAgent,
+      };
+      if (options !== undefined && (options as any).actor !== undefined) {
+        headers['X-Slack-User'] = (options as any).actor;
+        delete (options as any).actor;
+      }
+
       const methodSupportsCursorPagination = methods.cursorPaginationEnabledMethods.has(method);
       const optionsPaginationType = getOptionsPaginationType(options);
 
@@ -211,12 +220,10 @@ export class WebClient extends EventEmitter {
                 const response = await got.post(urlJoin(this.slackApiUrl, method),
                   // @ts-ignore
                   Object.assign({
+                    headers,
                     form: !canBodyBeFormMultipart(requestBody),
                     body: requestBody,
                     retries: 0,
-                    headers: {
-                      'user-agent': this.userAgent,
-                    },
                     throwHttpErrors: false,
                     agent: this.agentConfig,
                   }, this.tlsConfig),

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -37,8 +37,8 @@ export interface Searchable {
 }
 
 // For workspace apps, this argument allows calling a method on behalf of a user
-export interface ActorEnabled {
-  actor?: string;
+export interface UserPerspectiveEnabled {
+  on_behalf_of?: string;
 }
 
 // Pagination protocols
@@ -412,12 +412,12 @@ export type DialogOpenArguments = TokenOverridable & {
   /*
    * `dnd.*`
    */
-export type DndEndDndArguments = TokenOverridable & ActorEnabled;
-export type DndEndSnoozeArguments = TokenOverridable & ActorEnabled;
+export type DndEndDndArguments = TokenOverridable & UserPerspectiveEnabled;
+export type DndEndSnoozeArguments = TokenOverridable & UserPerspectiveEnabled;
 export type DndInfoArguments = TokenOverridable & {
   user: string;
 };
-export type DndSetSnoozeArguments = TokenOverridable & ActorEnabled & {
+export type DndSetSnoozeArguments = TokenOverridable & UserPerspectiveEnabled & {
   num_minutes: number;
 };
 export type DndTeamInfoArguments = TokenOverridable & {
@@ -680,21 +680,21 @@ export type ReactionsRemoveArguments = TokenOverridable & {
   /*
    * `reminders.*`
    */
-export type RemindersAddArguments = TokenOverridable & ActorEnabled & {
+export type RemindersAddArguments = TokenOverridable & UserPerspectiveEnabled & {
   text: string;
   time: string | number;
   user?: string;
 };
-export type RemindersCompleteArguments = TokenOverridable & ActorEnabled & {
+export type RemindersCompleteArguments = TokenOverridable & UserPerspectiveEnabled & {
   reminder: string;
 };
-export type RemindersDeleteArguments = TokenOverridable & ActorEnabled & {
+export type RemindersDeleteArguments = TokenOverridable & UserPerspectiveEnabled & {
   reminder: string;
 };
-export type RemindersInfoArguments = TokenOverridable & ActorEnabled & {
+export type RemindersInfoArguments = TokenOverridable & UserPerspectiveEnabled & {
   reminder: string;
 };
-export type RemindersListArguments = TokenOverridable & ActorEnabled;
+export type RemindersListArguments = TokenOverridable & UserPerspectiveEnabled;
 
   /*
    * `rtm.*`
@@ -821,7 +821,7 @@ export type UsersDeletePhotoArguments = TokenOverridable;
 export type UsersGetPresenceArguments = TokenOverridable & {
   user: string;
 };
-export type UsersIdentityArguments = TokenOverridable & ActorEnabled;
+export type UsersIdentityArguments = TokenOverridable & UserPerspectiveEnabled;
 export type UsersInfoArguments = TokenOverridable & LocaleAware & {
   user: string;
 };
@@ -846,7 +846,7 @@ export type UsersProfileGetArguments = TokenOverridable & {
   include_labels?: boolean;
   user?: string;
 };
-export type UsersProfileSetArguments = TokenOverridable & ActorEnabled &{
+export type UsersProfileSetArguments = TokenOverridable & UserPerspectiveEnabled &{
   profile?: string; // url-encoded json
   user?: string;
   name?: string; // usable if `profile` is not passed

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -36,6 +36,11 @@ export interface Searchable {
   sort_dir: 'asc' | 'desc';
 }
 
+// For workspace apps, this argument allows calling a method on behalf of a user
+export interface ActorEnabled {
+  actor?: string;
+}
+
 // Pagination protocols
 // --------------------
 // In order to support automatic pagination in the WebClient, the following pagination types are not only defined as an
@@ -407,12 +412,12 @@ export type DialogOpenArguments = TokenOverridable & {
   /*
    * `dnd.*`
    */
-export type DndEndDndArguments = TokenOverridable;
-export type DndEndSnoozeArguments = TokenOverridable;
+export type DndEndDndArguments = TokenOverridable & ActorEnabled;
+export type DndEndSnoozeArguments = TokenOverridable & ActorEnabled;
 export type DndInfoArguments = TokenOverridable & {
   user: string;
 };
-export type DndSetSnoozeArguments = TokenOverridable & {
+export type DndSetSnoozeArguments = TokenOverridable & ActorEnabled & {
   num_minutes: number;
 };
 export type DndTeamInfoArguments = TokenOverridable & {
@@ -675,21 +680,21 @@ export type ReactionsRemoveArguments = TokenOverridable & {
   /*
    * `reminders.*`
    */
-export type RemindersAddArguments = TokenOverridable & {
+export type RemindersAddArguments = TokenOverridable & ActorEnabled & {
   text: string;
   time: string | number;
   user?: string;
 };
-export type RemindersCompleteArguments = TokenOverridable & {
+export type RemindersCompleteArguments = TokenOverridable & ActorEnabled & {
   reminder: string;
 };
-export type RemindersDeleteArguments = TokenOverridable & {
+export type RemindersDeleteArguments = TokenOverridable & ActorEnabled & {
   reminder: string;
 };
-export type RemindersInfoArguments = TokenOverridable & {
+export type RemindersInfoArguments = TokenOverridable & ActorEnabled & {
   reminder: string;
 };
-export type RemindersListArguments = TokenOverridable;
+export type RemindersListArguments = TokenOverridable & ActorEnabled;
 
   /*
    * `rtm.*`
@@ -816,7 +821,7 @@ export type UsersDeletePhotoArguments = TokenOverridable;
 export type UsersGetPresenceArguments = TokenOverridable & {
   user: string;
 };
-export type UsersIdentityArguments = TokenOverridable;
+export type UsersIdentityArguments = TokenOverridable & ActorEnabled;
 export type UsersInfoArguments = TokenOverridable & LocaleAware & {
   user: string;
 };
@@ -841,7 +846,7 @@ export type UsersProfileGetArguments = TokenOverridable & {
   include_labels?: boolean;
   user?: string;
 };
-export type UsersProfileSetArguments = TokenOverridable & {
+export type UsersProfileSetArguments = TokenOverridable & ActorEnabled &{
   profile?: string; // url-encoded json
   user?: string;
   name?: string; // usable if `profile` is not passed


### PR DESCRIPTION
###  Summary

Implements an additional method argument `actor`, which is used to fill the `X-Slack-User` request header on API calls.

Fixes #608

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
