### PR TITLE
Add Promises to RTMClient `start` and `disconnect`

### DIFF
--- a/src/RTMClient.ts
+++ b/src/RTMClient.ts
@@ -235,9 +235,13 @@ export class RTMClient extends EventEmitter {
       .global()
         .onStateEnter((state, context) => {
           this.logger.debug(`transitioning to state: ${state}`);
-          // Emits events: `disconnected`, `connecting`, `connected`, 'disconnecting', 'reconnecting'
-          // event payload is anything related to the event, i.e. an error on disconnect
-          this.emit(state, context.eventPayload);
+          if (state === 'disconnected') {
+            // Emits a `disconnected` event with a possible error object (might be undefined)
+            this.emit(state, context.eventPayload);
+          } else {
+            // Emits events: `connecting`, `connected`, `disconnecting`, `reconnecting`
+            this.emit(state);
+          }
         })
     .getConfig();
 


### PR DESCRIPTION
###  Summary

Fixes #198 and #610:

- Fixes the RTM `connecting` submachine to transition to a `failed` state, which emits a `failure` event on the parent machine, allowing for the `disconnected` state to be reached from a failure to reconnect (tl;dr: it works 👍)
- Changes the return types of `RTMClient#start` to `Promise<WebAPICallResult>` and `RTMClient#disconnect` to `Promise<void>`

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
