### PR TITLE
Upgrade https-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^1.5.0",
     "bluebird": "^3.3.3",
     "eventemitter3": "^1.1.1",
-    "https-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^2.2.0",
     "inherits": "^2.0.1",
     "lodash": "^4.13.1",
     "pkginfo": "^0.4.0",


### PR DESCRIPTION
###  Summary

This upgrades to the latest https-proxy-agent. Looking at the [changelog](https://github.com/TooTallNate/node-https-proxy-agent/blob/master/History.md#220--2018-03-03) in the v2.x cycle, it looks like it would be desirable to upgrade, even just for a 3.x maintenance release.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
