### PR TITLE
Static headers on WebClient

### DIFF
--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -20,9 +20,6 @@ const token = 'xoxa-faketoken';
 const refreshToken = 'xoxr-refreshtoken';
 const clientId = 'CLIENTID';
 const clientSecret = 'CLIENTSECRET';
-const staticHeaders = {
-  'X-ABC': 'value'
-};
 
 describe('WebClient', function () {
 
@@ -37,12 +34,6 @@ describe('WebClient', function () {
     it('should build a client without a token', function () {
       const client = new WebClient();
       assert.instanceOf(client, WebClient);
-    });
-
-    it('should build a client with static headers', function () {
-      const client = new WebClient(token, { headers: staticHeaders});
-      assert.instanceOf(client, WebClient);
-      assert.equal(client.staticHeaders, staticHeaders);
     });
   });
 
@@ -87,7 +78,7 @@ describe('WebClient', function () {
 
   describe('apiCall()', function () {
     beforeEach(function () {
-      this.client = new WebClient(token, { retryConfig: rapidRetryPolicy, headers: staticHeaders });
+      this.client = new WebClient(token, { retryConfig: rapidRetryPolicy });
     });
 
     describe('when making a successful call', function () {
@@ -488,6 +479,23 @@ describe('WebClient', function () {
 
       const r = client.apiCall('method', { foo: 'stringval' });
       assert(isPromise(r));
+      return r.then((result) => {
+        scope.done();
+      });
+    });
+  });
+
+  describe('apiCall() - when using static headers', function () {
+    it('should include static headers on api request', function () {
+      const client = new WebClient(token, { headers: { 'X-XYZ': 'value' } });
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(200, { ok: true })
+        .on('request', function (req, interceptor, body) {
+          const headerKey = req.headers['x-xyz'];
+          assert.isDefined(headerKey);
+        });
+      const r = client.apiCall('method');
       return r.then((result) => {
         scope.done();
       });

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -488,13 +488,13 @@ describe('WebClient', function () {
   describe('apiCall() - when using static headers', function () {
     it('should include static headers on api request', function () {
       const client = new WebClient(token, { headers: { 'X-XYZ': 'value' } });
-      const scope = nock('https://slack.com')
+      const scope = nock('https://slack.com', {
+        reqheaders: {
+          'X-XYZ': 'value'
+        }
+      })
         .post(/api/)
-        .reply(200, { ok: true })
-        .on('request', function (req, interceptor, body) {
-          const headerKey = req.headers['x-xyz'];
-          assert.isDefined(headerKey);
-        });
+        .reply(200, { ok: true });
       const r = client.apiCall('method');
       return r.then((result) => {
         scope.done();

--- a/src/WebClient.spec.js
+++ b/src/WebClient.spec.js
@@ -20,6 +20,9 @@ const token = 'xoxa-faketoken';
 const refreshToken = 'xoxr-refreshtoken';
 const clientId = 'CLIENTID';
 const clientSecret = 'CLIENTSECRET';
+const staticHeaders = {
+  'X-ABC': 'value'
+};
 
 describe('WebClient', function () {
 
@@ -34,6 +37,12 @@ describe('WebClient', function () {
     it('should build a client without a token', function () {
       const client = new WebClient();
       assert.instanceOf(client, WebClient);
+    });
+
+    it('should build a client with static headers', function () {
+      const client = new WebClient(token, { headers: staticHeaders});
+      assert.instanceOf(client, WebClient);
+      assert.equal(client.staticHeaders, staticHeaders);
     });
   });
 
@@ -78,7 +87,7 @@ describe('WebClient', function () {
 
   describe('apiCall()', function () {
     beforeEach(function () {
-      this.client = new WebClient(token, { retryConfig: rapidRetryPolicy });
+      this.client = new WebClient(token, { retryConfig: rapidRetryPolicy, headers: staticHeaders });
     });
 
     describe('when making a successful call', function () {

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -170,10 +170,9 @@ export class WebClient extends EventEmitter {
 
     this.axios = axios.create({
       baseURL: slackApiUrl,
-      headers: {
+      headers: Object.assign({
         'User-Agent': getUserAgent(),
-        ...this.staticHeaders,
-      },
+      }, this.staticHeaders),
       httpAgent: agentForScheme('http', agent),
       httpsAgent: agentForScheme('https', agent),
       transformRequest: [this.serializeApiCallOptions.bind(this)],

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -123,11 +123,6 @@ export class WebClient extends EventEmitter {
   private logger: Logger;
 
   /**
-   * Static headers on every request.
-   */
-  private staticHeaders?: object;
-
-  /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`, or `xoxa`)
    */
   constructor(token?: string, {
@@ -151,7 +146,6 @@ export class WebClient extends EventEmitter {
     this.clientSecret = clientSecret;
     this.refreshToken = refreshToken;
     this.slackApiUrl = slackApiUrl;
-    this.staticHeaders = headers;
 
     this.retryConfig = retryConfig;
     this.requestQueue = new PQueue({ concurrency: maxRequestConcurrency });
@@ -172,7 +166,7 @@ export class WebClient extends EventEmitter {
       baseURL: slackApiUrl,
       headers: Object.assign({
         'User-Agent': getUserAgent(),
-      }, this.staticHeaders),
+      }, headers),
       httpAgent: agentForScheme('http', agent),
       httpsAgent: agentForScheme('https', agent),
       transformRequest: [this.serializeApiCallOptions.bind(this)],

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -123,6 +123,11 @@ export class WebClient extends EventEmitter {
   private logger: Logger;
 
   /**
+   * Static headers on every request.
+   */
+  private staticHeaders?: object;
+
+  /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`, or `xoxa`)
    */
   constructor(token?: string, {
@@ -138,6 +143,7 @@ export class WebClient extends EventEmitter {
     clientId = undefined,
     clientSecret = undefined,
     refreshToken = undefined,
+    headers = {},
   }: WebClientOptions = {}) {
     super();
     this._accessToken = token;
@@ -145,6 +151,7 @@ export class WebClient extends EventEmitter {
     this.clientSecret = clientSecret;
     this.refreshToken = refreshToken;
     this.slackApiUrl = slackApiUrl;
+    this.staticHeaders = headers;
 
     this.retryConfig = retryConfig;
     this.requestQueue = new PQueue({ concurrency: maxRequestConcurrency });
@@ -165,6 +172,7 @@ export class WebClient extends EventEmitter {
       baseURL: slackApiUrl,
       headers: {
         'User-Agent': getUserAgent(),
+        ...this.staticHeaders,
       },
       httpAgent: agentForScheme('http', agent),
       httpsAgent: agentForScheme('https', agent),
@@ -873,6 +881,7 @@ export interface WebClientOptions {
   clientId?: string;
   clientSecret?: string;
   refreshToken?: string;
+  headers?: object;
 }
 
 export interface WebAPICallOptions {


### PR DESCRIPTION
###  Summary

Add the ability to add static headers on an instance of `WebClient` that will be included in every request to Slack's API.

See #628 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
