### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/_pages/getting_started.md
+++ b/docs/_pages/getting_started.md
@@ -91,6 +91,8 @@ $ export SLACK_ACCESS_TOKEN=xoxa-...
 Create a file called `tutorial.js` and add the following code:
 
 ```javascript
+// Create a new instance of the WebClient class with the token stored in your environment variable
+const web = new WebClient(process.env.SLACK_ACCESS_TOKEN);
 // The current date
 const currentTime = new Date().toTimeString();
 


### PR DESCRIPTION
add missing WebClient instance

###  Summary

The getting started was missing the line to instantiate the WebClient.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
