### PR TITLE
Fix isAgent check by using looser constraints

### DIFF
--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -953,7 +953,9 @@ const requestTimePropName = 'slack_webclient_request_time';
  * Detects whether an object is an http.Agent
  */
 function isAgent(obj: any): obj is Agent {
-  return typeof obj.maxSockets === 'number' && typeof obj.destroy === 'function';
+  // This check is not perfect, but we're borrowing this from a very common library where agent are generated.
+  // https://github.com/TooTallNate/node-agent-base/blob/c7ffe87ca4cd996f94ef70b5665c582b88791dca/index.js#L10
+  return obj && typeof obj.addRequest === 'function';
 }
 
 /**


### PR DESCRIPTION
###  Summary

Currently, we use a check for whether an object is an `Agent` instance or not that is derived from the node core codebase. It turns out that in the wild, `Agent`s are produced from many other libraries, most commonly `https-proxy-agent`. The most common interface for an agent is that it has an `addRequest()` method, so this PR adjusts the check to use that instead.

fixes #642

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
