### PR TITLE
ignore documentation build dependencies

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 _site
+Gemfile.lock


### PR DESCRIPTION
###  Summary

There's no reason for us to check in `Gemfile.lock`, it just generates security related warnings that are not meaningful to this project.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
