### PR TITLE
Removed mention of es2018.asynciterable from TypeScript documentation

### DIFF
--- a/docs/_pages/typescript.md
+++ b/docs/_pages/typescript.md
@@ -46,8 +46,7 @@ For versions of TypeScript >= 3.1:
     "lib": [
       "es5",
       "es2015",
-      "es2016.array.include",
-      "es2018.asynciterable"
+      "es2016.array.include"
     ]
   }
 }

--- a/docs/_pages/typescript.md
+++ b/docs/_pages/typescript.md
@@ -25,7 +25,6 @@ a `tsconfig.json` file at the root of your project. If you haven't already creat
 using `tsc --init` on the command line. Below is an example of what the `lib` should _at a minimum_ contain for a
 project using this package.
 
-For versions of TypeScript < 3.1:
 ```
 {
   "compilerOptions": {
@@ -34,19 +33,6 @@ For versions of TypeScript < 3.1:
       "es2015",
       "es2016.array.include",
       "esnext.asynciterable"
-    ]
-  }
-}
-```
-
-For versions of TypeScript >= 3.1:
-```
-{
-  "compilerOptions": {
-    "lib": [
-      "es5",
-      "es2015",
-      "es2016.array.include"
     ]
   }
 }


### PR DESCRIPTION
###  Summary

Removed mention of es2018.asynciterable, as per #649 

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
