### PR TITLE
[Miscellaneous] Add types for AttachmentAction interface

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -134,7 +134,7 @@ export interface MessageAttachment {
 export interface AttachmentAction {
   id?: string;
   confirm?: Confirmation;
-  data_source?: string;
+  data_source?: 'static' | 'channels' | 'conversations' | 'users' | 'external';
   min_query_length?: number;
   name?: string;
   options?: OptionField[];
@@ -143,9 +143,9 @@ export interface AttachmentAction {
     options: OptionField[];
   }[];
   selected_options?: OptionField[];
-  style?: string;
+  style?: 'default' | 'primary' | 'danger';
   text: string;
-  type: string;
+  type: 'button' | 'select';
   value?: string;
   url?: string;
 }


### PR DESCRIPTION
###  Summary
Adds type hinting for some of the fields in the AttachmentAction interface.

These types are based off of what I found at:
https://api.slack.com/docs/interactive-message-field-guide

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
