### PR TITLE
Fix sidebar navigation bug

### DIFF
--- a/docs/_includes/side_nav.html
+++ b/docs/_includes/side_nav.html
@@ -1,7 +1,7 @@
 <div id="api_sections">
 
     {% comment %}https://github.com/pages-themes/primer/issues/15{% endcomment %}
-    {% assign sorted_pages = site.pages | where_exp:"page", "page.name != 'style.scss'" | where_exp: "page", "page.layout != 'redirect'" | sort:"order" %}
+    {% assign sorted_pages = site.pages | where_exp:"page", "page.name != 'style.scss'" | where_exp: "page", "page.name != 'redirects.json'" | where_exp: "page", "page.layout != 'redirect'" | sort:"order" %}
 
     {% for node in sorted_pages %}
         {% if node.hidden != true %}


### PR DESCRIPTION
###  Summary

Fixes a bug where multiple "Slack Development Kit for Node.JS" headers appear on the documentation site

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
