### PR TITLE
Add thread_ts to files.upload type definition

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -464,6 +464,7 @@ export type FilesUploadArguments = TokenOverridable & {
   filetype?: string;
   initial_comment?: string;
   title?: string;
+  thread_ts?: string; // if specified, `channels` must be set
 };
 export type FilesCommentsAddArguments = TokenOverridable & {
   comment: string;


### PR DESCRIPTION
###  Summary

`thread_ts` is a possible value to supply to `files.upload`, but it currently does not exist in the type definition. This PR adds `thread_ts` to the type definition, as well as a comment to specify that you must supply `channels` in order for the `thread_ts` value to work properly.

#660 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
