### PR TITLE
Fix documentation sample

### DIFF
--- a/docs/_pages/rtm_client.md
+++ b/docs/_pages/rtm_client.md
@@ -88,8 +88,8 @@ in which your bot has access. The client can handle messages using the `on('mess
 const { RTMClient } = require('@slack/client');
 // SNIP: the initialization code shown above is skipped for brevity
 
-rtm.on('message', (event) => {
-  // For structure of `event`, see https://api.slack.com/events/message
+rtm.on('message', (message) => {
+  // For structure of `message`, see https://api.slack.com/events/message
 
   // Skip messages that are from a bot or my own user ID
   if ( (message.subtype && message.subtype === 'bot_message') ||


### PR DESCRIPTION
###  Summary

Fixes a sample in the RTM docs with a mismatched parameter name. #664

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).