### PR TITLE
Remove workspace app references from docs

### DIFF
--- a/docs/_pages/getting_started.md
+++ b/docs/_pages/getting_started.md
@@ -17,9 +17,7 @@ This guide introduces fundamentals of the Slack Developer Kit for Node.js and Sl
 ## Create a Slack app
 
 The first step is to [register a new app](https://api.slack.com/apps/new) with Slack at the API
-website. You have the option to build a user-token app or a workspace app. Give your app a fun name and choose a Development Slack Workspace. We recommend using a workspace where you aren't going to disrupt real work getting done -- you can create a new workspace for free.
-
-> ⚠️ For this guide, we'll assume you're building a [workspace app](https://api.slack.com/workspace-apps-preview). Workspace apps support Slack's latest and greatest platform features. However, most steps are the same for user-token apps.
+website. Give your app a fun name and choose a Development Slack Workspace. We recommend using a workspace where you aren't going to disrupt real work getting done -- you can create a new workspace for free.
 
 After you create an app, you'll be greeted with some basic information. In this guide we'll be making a request to the Web API to post a message to a channel. Aside from posting messages, the Web API allows your app to call [methods](https://api.slack.com/methods) that can be used for everything from creating a channel to searching messages. Let's configure our new app with proper permissions.
 
@@ -31,13 +29,13 @@ various permissions your app could obtain from a user as **scopes**. There are a
 of data, while others are very specific and let your app touch just a tiny sliver. Your users (and
 their IT admins) will have opinions about which data your app should access, so we recommend finding
 the scope(s) with the least amount of privilege for your app's needs. In this guide we will use the
-Web API to post a message. The scope required for this is called `chat:write` (or `chat:write:user` for user-token apps). Use the dropdown or start typing its name to select and add the scope, then click "Save Changes".
+Web API to post a message. The scope required for this is called `chat:write:user`. Use the dropdown or start typing its name to select and add the scope, then click "Save Changes".
 
 Our app has described which scope it desires in the workspace, but a user hasn't authorized those scopes for the development workspace yet. Scroll up and click "Install App". You'll be taken to your app installation page. This page is asking you for permission to install the app in your development workspace with specific capabilities. That's right, the development workspace is like every other workspace -- apps must be authorized by a user each time it asks for more permissions. 
 
 Go ahead and click "Continue". The next page asks you which conversations the app should be able to post messages in. In this case, choose "No channels", which still allows the app to directly message users who install the App -- which means you. 
 
-When you return to the OAuth & Permissions page copy the OAuth Access Token (it should begin with `xoxa`). Treat this value like a password and keep it safe. The Web API uses tokens to to authenticate the requests your app makes. In a later step, you'll be asked to use this token in your code.
+When you return to the OAuth & Permissions page copy the OAuth Access Token (it should begin with `xoxp`). Treat this value like a password and keep it safe. The Web API uses tokens to to authenticate the requests your app makes. In a later step, you'll be asked to use this token in your code.
 
 ## Set up your local project
 
@@ -85,7 +83,7 @@ but [similar commands are available on Windows](https://superuser.com/a/212153/9
 value with OAuth Access Token that you copied above.
 
 ```shell
-$ export SLACK_ACCESS_TOKEN=xoxa-...
+$ export SLACK_ACCESS_TOKEN=xoxp-...
 ```
 
 Create a file called `tutorial.js` and add the following code:

--- a/docs/_pages/web_client.md
+++ b/docs/_pages/web_client.md
@@ -9,6 +9,8 @@ headings:
     - title: Adding attachments to a message
     - title: Uploading a file
     - title: Getting a list of channels
+    - title: Using refresh tokens
+    - title: Manually handling token rotation
     - title: Calling methods on behalf of users
     - title: Using a callback instead of a Promise
     - title: Changing the retry configuration
@@ -47,7 +49,7 @@ how to post a message into a channel, DM, MPDM, or group. This will require the 
 ```javascript
 const { WebClient } = require('@slack/client');
 
-// An access token (from your Slack app or custom integration - xoxp or xoxb)
+// An access token (from your Slack app or custom integration - xoxp, xoxb)
 const token = process.env.SLACK_TOKEN;
 
 const web = new WebClient(token);
@@ -121,7 +123,7 @@ scope.
 const fs = require('fs');
 const { WebClient } = require('@slack/client');
 
-// An access token (from your Slack app or custom integration - xoxp, or xoxb)
+// An access token (from your Slack app or custom integration - xoxp, xoxb, or the deprecated xoxa)
 const token = process.env.SLACK_TOKEN;
 
 const web = new WebClient(token);
@@ -145,6 +147,170 @@ web.files.upload({
     console.log('File uploaded: ', res.file.id);
   })
   .catch(console.error);
+```
+
+---
+
+### Using refresh tokens
+> WARNING: This feature is only supported for the now-deprecated workspace app tokens (xoxa). Refresh
+> tokens will be available in the future to classic Slack apps in a couple of months. You may find more
+> details [on the related blog post.](https://medium.com/slack-developer-blog/an-update-on-workspace-apps-aabc9e42a98b).
+
+If you're using workspace apps, refresh tokens can be used to obtain short-lived access tokens that power your Web API calls from the `WebClient` (this is *required* for distributed apps). This can increase the security of your app since, in the event of a token being exposed accidentally, it won't be able to be used against your app or users after a short time. To enable the `WebClient` to automatically refresh and swap your access tokens, you need to pass your app's refresh token, client ID, and client secret in the `WebClientOptions`.
+
+At the time of refresh, the `WebClient` will emit a `token_refreshed` event that will contain the new access token (`access_token`), time to expiration (`expires_in`), an associated team ID (`team_id`), and an associated enterprise ID (`enterprise_id`). It's recommended to listen to this event and store the access token in a database so you have access to your active token.
+
+```javascript
+const { WebClient } = require('@slack/client');
+
+const refreshToken = process.env.SLACK_REFRESH_TOKEN;
+const teamId = process.env.SLACK_TEAM_ID;
+const enterpriseId = process.env.SLACK_ENTERPRISE_ID;
+const clientId = process.env.SLACK_CLIENT_ID;
+const clientSecret = process.env.SLACK_CLIENT_SECRET;
+
+
+// Intialize a data structure to store team access token info (typically stored in a database)
+const slackAuthorizations = [];
+
+// Set authorization info in data structure
+function setAuthorization(authorization) {
+  // Get existing authorization, if it exists
+  const authIndex = getAuthorizationIndex(teamId, enterpriseId);
+  // If an existing authorization doesn't exist, add to end of array
+  if (authIndex === -1) {
+    authIndex = slackAuthorizations.length;
+  }
+
+  // Set authorization in data structure
+  slackAuthorizations[authIndex] = {
+    accessToken: authorization.access_token,
+    expiresIn: authorization.expires_in,
+    teamId: authorization.teamId,
+    enterpriseId: authorization.enterpriseId
+  };
+}
+
+// Gets index of authorization in data structure
+function getAuthorizationIndex(teamId, enterpriseId) {
+  slackAuthorizations.findIndex(function(authorization) {
+    return (authorization.team_id === teamId &&
+      authorization.enterprise_id === enterpriseId);
+  })
+}
+
+// Get authorization from data structure
+function getAuthorizationToken(teamId, enterpriseId) {
+  return new Promise((resolve, reject) => {
+    const authIndex = getAuthorizationIndex(teamId, enterpriseId);
+    if (authIndex > -1) {
+      return slackAuthorizations[authIndex].accessToken;
+    } else {
+      return undefined;
+    }
+  });
+}
+
+// Initiate WebClient
+getAuthorization(teamId, enterpriseId).then((res) => {
+  // If authorization doesn't exist, res will be undefined and the WebClient will fetch token
+  // Instantiate the WebClient
+  const web = new WebClient(res, {
+    clientId: clientId,
+    clientSecret: clientSecret,
+    refreshToken: refreshToken
+  });
+
+  // WebClient is up and running, so let's post a message!
+  const conversationId = 'C123456';
+  web.chat.postMessage({ channel: conversationId, text: 'Hello world!'});
+});
+
+
+/* When a token is refreshed, a token_refreshed event is triggered:
+ * {
+ *    "access_token": "xoxa-...",
+ *    "expires_in": 86400,
+ *    "team_id": "T12345",
+ *    "enterprise_id": "E1234A12AB"
+ * }
+ */
+web.on('token_refreshed', (event) => {
+  // It's recommended you store your new access token in a database to access it later
+  setAuthorization(event);
+
+  console.log(`Access token expires in ${event.expires_in}`);
+});
+```
+
+
+---
+
+### Manually handling token rotation
+> WARNING: This feature is only supported for the now-deprecated workspace app tokens (xoxa). Token
+> rotation will be available in the future to classic Slack apps in a couple of months. You may find more
+> details [on the related blog post.](https://medium.com/slack-developer-blog/an-update-on-workspace-apps-aabc9e42a98b).
+
+Note: Before implementing it on your own, it's suggested you read through the [token rotation documentation](http://api.slack.com/docs/rotating-and-refreshing-credentials).
+
+If you need more control over token refreshing, you don't need to pass in your refresh token, client ID, or client secret. However, you'll need to listen for `invalid_auth` errors and make calls to `oauth.access` to fetch new access tokens:
+
+```javascript
+const { WebClient } = require('@slack/client');
+
+const accessToken = process.env.SLACK_TOKEN;
+const refreshToken = process.env.SLACK_REFRESH_TOKEN;
+const id = process.env.SLACK_CLIENT_ID;
+const secret = process.env.SLACK_CLIENT_SECRET;
+
+const web = new WebClient(accessToken);
+
+function refreshToken() {
+  // Custom logic to refresh a token, possibly purging other stale data from db
+  return new Promise((resolve, reject) => {
+    web.oauth.access({
+      client_id: id,
+      client_secret: secret,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    }).then((res) => {
+      /* Response contains new access token and time until expiration
+       * {
+       *    "access_token": "xoxa-...",
+       *    "expires_in": 86400,
+       *    "team_id": "T12345",
+       *    "enterprise_id": "E1234A12AB"
+       * }
+       */
+      accessToken = res.access_token;
+      // web.token allows you to update the access token for WebClient
+      web.token = accessToken;
+      // Probably purge stale data from db at this point
+
+      resolve();
+    }).catch((err) => {
+      console.log(err);
+      reject();
+    });
+  });
+}
+
+function sendMessage(msg) {
+  return web.chat.postMessage(msg)
+    .then(console.log)
+    .catch((error) => {
+      if (error.code === ErrorCode.PlatformError && error.data.error === 'invalid_auth') {
+        // This error could have occured because of an expired access token -- refresh, and try again.
+        return refreshToken()
+          .then(() => sendMessage(msg));
+      }
+      throw error;
+    })
+}
+
+sendMessage({ channel: conversationId, text: 'Hello world!' })
+  .catch((error) => console.error(`failed to send message: ${error.message}`));
+
 ```
 
 ---
@@ -184,7 +350,7 @@ getAllChannels()
 
 ### Calling methods on behalf of users
 
-When using [User tokens/Personal tokens](https://api.slack.com/docs/token-types#user), some methods allow your app
+When using [user tokens](https://api.slack.com/docs/token-types#user), some methods allow your app
 to perform the action _on behalf of a user_. To use one of these methods,
 your app will provide the user's ID as an option named `on_behalf_of`.
 

--- a/docs/_reference/WebClient.md
+++ b/docs/_reference/WebClient.md
@@ -14,8 +14,8 @@ a convenience wrapper for calling the [WebClient#apiCall](WebClient#apiCall) met
 
 | Name | Type | Description |
 | --- | --- | --- |
-| token | <code>string</code> \| <code>undefined</code> | Authentication and authorization token for accessing Slack Web API (usually begins with `xoxa`, xoxp`, or `xoxb`) |
-| [refreshToken] | <code>string</code> | OAuth 2.0 refresh token used to automatically create new access tokens (`token`) when the current is expired. |
+| token | <code>string</code> \| <code>undefined</code> | Authentication and authorization token for accessing Slack Web API (usually begins with `xoxp` or `xoxb`) |
+| [refreshToken] | <code>string</code> | OAuth 2.0 refresh token used to automatically create new access tokens (`token`) when the current is expired. __Warning: This is only available to the legacy workspace apps.__ |
 | [clientId] | <code>string</code> | OAuth 2.0 client identifier |
 | [clientSecret] | <code>string</code> | OAuth 2.0 client secret |
 | [slackApiUrl] | <code>string</code> | The base URL for reaching Slack's Web API. Consider changing this value for testing purposes. |


### PR DESCRIPTION
###  Summary

- Related issue: https://github.com/slackapi/node-slack-sdk/issues/656
- References to xoxa tokens and workspace apps have been removed.
- A warning is placed on the refresh token option that is available on the WebClient to notify users that it is only available on the legacy workspace apps preview.
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
