### PR TITLE
Fix incoming webhook agent test

### DIFF
--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -108,16 +108,24 @@ describe('IncomingWebhook', function () {
   });
 
   describe('has an option to set a custom HTTP agent', function () {
-    it('should send a request using the custom agent', function (done) {
-      const agent = new Agent({keepAlive: true});
+    it('should send a request using the custom agent', function () {
+      const agent = new Agent({ keepAlive: true });
       const spy = sinon.spy(agent, 'addRequest');
-      const webhook = new IncomingWebhook(url, {agent});
-      webhook.send('Hello', () => {
-        // assert(spy.called);
-        agent.addRequest.restore();
-        agent.destroy();
-        done();
-      });
+      const webhook = new IncomingWebhook(url, { agent });
+
+      return webhook.send('Hello')
+        .catch((error) => {
+          assert(spy.called);
+        })
+        .then(() => {
+          agent.addRequest.restore();
+          agent.destroy();
+        })
+        .catch((error) => {
+          agent.addRequest.restore();
+          agent.destroy();
+          throw error;
+        });
     });
 
     it('should use the right custom agent when providing agents for many schemes', function () {
@@ -129,24 +137,35 @@ describe('IncomingWebhook', function () {
         http: badAgent,
       } });
 
-      webhook.send('Hello')
-      .catch(() => {
-        assert(spy.called);
-      }).then( () => {
-        agent.addRequest.restore();
-        agent.destroy();
-      }).catch((error) => {
-        agent.addRequest.restore();
-        agent.destroy();
-        throw error;
-      });
+      return webhook.send('Hello')
+        .catch((error) => {
+          assert(spy.called);
+        }).then( () => {
+          agent.addRequest.restore();
+          agent.destroy();
+        }).catch((error) => {
+          agent.addRequest.restore();
+          agent.destroy();
+          throw error;
+        });
     });
 
+<<<<<<< Updated upstream
     it('should use accept a boolean (false) agent', function (done) {
       const webhook = new IncomingWebhook(url, {agent: false});
       webhook.send('Hello', () => {
         done();
       });
+=======
+    it('should use accept a boolean (false) agent', function () {
+      const webhook = new IncomingWebhook(url, { agent: false });
+      const result = webhook.send('Hello');
+      return result.catch((error) => { });
+>>>>>>> Stashed changes
     });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
   });
 });

--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -114,7 +114,7 @@ describe('IncomingWebhook', function () {
       const webhook = new IncomingWebhook(url, { agent });
 
       return webhook.send('Hello')
-        .catch((error) => {
+        .catch(() => {
           assert(spy.called);
         })
         .then(() => {
@@ -138,7 +138,7 @@ describe('IncomingWebhook', function () {
       } });
 
       return webhook.send('Hello')
-        .catch((error) => {
+        .catch(() => {
           assert(spy.called);
         }).then( () => {
           agent.addRequest.restore();

--- a/src/IncomingWebhook.spec.js
+++ b/src/IncomingWebhook.spec.js
@@ -150,18 +150,10 @@ describe('IncomingWebhook', function () {
         });
     });
 
-<<<<<<< Updated upstream
-    it('should use accept a boolean (false) agent', function (done) {
-      const webhook = new IncomingWebhook(url, {agent: false});
-      webhook.send('Hello', () => {
-        done();
-      });
-=======
     it('should use accept a boolean (false) agent', function () {
       const webhook = new IncomingWebhook(url, { agent: false });
       const result = webhook.send('Hello');
       return result.catch((error) => { });
->>>>>>> Stashed changes
     });
   });
 

--- a/src/IncomingWebhook.ts
+++ b/src/IncomingWebhook.ts
@@ -38,6 +38,8 @@ export class IncomingWebhook {
       proxy: false,
     });
 
+    delete this.defaults.agent;
+
   }
 
   /**


### PR DESCRIPTION
###  Summary

It turned out that the tests committed in #640 didn't actually test anything. The first tests conveniently had the assertion that mattered commented out, and the second test never returned the Promise, so the unhandled rejection was going unnoticed in our CI for quite some time.

The feature they meant to test *does actually work*. I only added one line to the implementation, and that was for clarity, not because the tests wouldn't pass without it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
