### PR TITLE
Add scheduled message support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "object.entries": "^1.1.0",
     "object.getownpropertydescriptors": "^2.0.3",
     "object.values": "^1.1.0",
-    "p-cancelable": "^1.0.0",
+    "p-cancelable": "~1.0.0",
     "p-queue": "^2.4.2",
     "p-retry": "^3.0.1",
     "retry": "^0.12.0",

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -430,10 +430,17 @@ export class WebClient extends EventEmitter {
    */
   public readonly chat = {
     delete: (this.apiCall.bind(this, 'chat.delete')) as Method<methods.ChatDeleteArguments>,
+    deleteScheduledMessage:
+      (this.apiCall.bind(this, 'chat.deleteScheduledMessage')) as Method<methods.ChatDeleteScheduledMessagesArguments>,
     getPermalink: (this.apiCall.bind(this, 'chat.getPermalink')) as Method<methods.ChatGetPermalinkArguments>,
     meMessage: (this.apiCall.bind(this, 'chat.meMessage')) as Method<methods.ChatMeMessageArguments>,
     postEphemeral: (this.apiCall.bind(this, 'chat.postEphemeral')) as Method<methods.ChatPostEphemeralArguments>,
     postMessage: (this.apiCall.bind(this, 'chat.postMessage')) as Method<methods.ChatPostMessageArguments>,
+    scheduleMessage: (this.apiCall.bind(this, 'chat.scheduleMessage')) as Method<methods.ChatScheduleMessageArguments>,
+    scheduledMessages: {
+      list:
+        (this.apiCall.bind(this, 'chat.scheduledMessages.list')) as Method<methods.ChatListScheduledMessagesArguments>,
+    },
     unfurl: (this.apiCall.bind(this, 'chat.unfurl')) as Method<methods.ChatUnfurlArguments>,
     update: (this.apiCall.bind(this, 'chat.update')) as Method<methods.ChatUpdateArguments>,
   };

--- a/src/WebClient.ts
+++ b/src/WebClient.ts
@@ -431,7 +431,7 @@ export class WebClient extends EventEmitter {
   public readonly chat = {
     delete: (this.apiCall.bind(this, 'chat.delete')) as Method<methods.ChatDeleteArguments>,
     deleteScheduledMessage:
-      (this.apiCall.bind(this, 'chat.deleteScheduledMessage')) as Method<methods.ChatDeleteScheduledMessagesArguments>,
+      (this.apiCall.bind(this, 'chat.deleteScheduledMessage')) as Method<methods.ChatDeleteScheduledMessageArguments>,
     getPermalink: (this.apiCall.bind(this, 'chat.getPermalink')) as Method<methods.ChatGetPermalinkArguments>,
     meMessage: (this.apiCall.bind(this, 'chat.meMessage')) as Method<methods.ChatMeMessageArguments>,
     postEphemeral: (this.apiCall.bind(this, 'chat.postEphemeral')) as Method<methods.ChatPostEphemeralArguments>,

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -428,7 +428,7 @@ export type ChatDeleteArguments = TokenOverridable & {
   ts: string;
   as_user?: boolean
 };
-export type ChatDeleteScheduledMessagesArguments = TokenOverridable & {
+export type ChatDeleteScheduledMessageArguments = TokenOverridable & {
   channel: string;
   scheduled_message_id: string;
   as_user?: boolean

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -428,9 +428,19 @@ export type ChatDeleteArguments = TokenOverridable & {
   ts: string;
   as_user?: boolean
 };
+export type ChatDeleteScheduledMessagesArguments = TokenOverridable & {
+  channel: string;
+  scheduled_message_id: string;
+  as_user?: boolean
+};
 export type ChatGetPermalinkArguments = TokenOverridable & {
   channel: string;
   message_ts: string;
+};
+export type ChatListScheduledMessagesArguments = TokenOverridable & CursorPaginationEnabled & {
+  channel: string;
+  latest: number;
+  oldest: number;
 };
 export type ChatMeMessageArguments = TokenOverridable & {
   channel: string;
@@ -462,6 +472,20 @@ export type ChatPostMessageArguments = TokenOverridable & {
   unfurl_links?: boolean;
   unfurl_media?: boolean;
   username?: string; // if specified, as_user must be false
+};
+export type ChatScheduleMessageArguments = TokenOverridable & {
+  channel: string;
+  text: string;
+  post_at: number;
+  as_user?: boolean;
+  attachments?: MessageAttachment[];
+  blocks?: (KnownBlock | Block)[];
+  link_names?: boolean;
+  parse?: 'full' | 'none';
+  reply_broadcast?: boolean; // if specified, thread_ts must be set
+  thread_ts?: string;
+  unfurl_links?: boolean;
+  unfurl_media?: boolean;
 };
 export type ChatUnfurlArguments = TokenOverridable & {
   channel: string;

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -476,7 +476,7 @@ export type ChatPostMessageArguments = TokenOverridable & {
 export type ChatScheduleMessageArguments = TokenOverridable & {
   channel: string;
   text: string;
-  post_at: number;
+  post_at: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];


### PR DESCRIPTION
###  Summary

Adds native support for `chat.scheduleMessage`, `chat.deleteScheduledMessage` and `chat.scheduledMessages.list`

Also changes pcancelable to `~1.0.0` because we don't want to use their types at the moment

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
