### PR TITLE
Fix eventemitter3 import

### DIFF
--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -1,6 +1,6 @@
 import { Agent } from 'http';
 
-import EventEmitter from 'eventemitter3'; // tslint:disable-line:import-name
+import EventEmitter = require('eventemitter3'); // tslint:disable-line:import-name no-require-imports
 import WebSocket from 'ws'; // tslint:disable-line:import-name
 import Finity, { StateMachine } from 'finity'; // tslint:disable-line:import-name
 import PQueue from 'p-queue'; // tslint:disable-line:import-name

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -11,7 +11,7 @@ import { Readable } from 'stream';
 import { SecureContextOptions } from 'tls';
 
 import isStream from 'is-stream';
-import EventEmitter from 'eventemitter3'; // tslint:disable-line:import-name
+import EventEmitter = require('eventemitter3'); // tslint:disable-line:import-name no-require-imports
 import PQueue from 'p-queue'; // tslint:disable-line:import-name
 import pRetry, { AbortError } from 'p-retry';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';


### PR DESCRIPTION
###  Summary

Latest v5.0.0 fails to build on our typescript project with this:
```
node_modules/@slack/web-api/dist/WebClient.d.ts:5:8 - error TS1192: Module '"node_modules/eventemitter3/index"' has no default export.
```

This is very likely due to your modules using `esModuleInterop: true`, while we don't.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
