### PR TITLE
Change eventemitter3 import for compatibility without esModuleInterop

### DIFF
--- a/integration-tests/types/tsconfig.json
+++ b/integration-tests/types/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
-    "esModuleInterop": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,

--- a/packages/rtm-api/src/KeepAlive.ts
+++ b/packages/rtm-api/src/KeepAlive.ts
@@ -1,4 +1,4 @@
-import EventEmitter = require('eventemitter3'); // tslint:disable-line:import-name no-require-imports
+import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
 import { RTMClient } from './RTMClient';
 import { LogLevel, Logger, getLogger } from './logger';
 import { ErrorCode, CodedError } from './errors';

--- a/packages/rtm-api/src/KeepAlive.ts
+++ b/packages/rtm-api/src/KeepAlive.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
+import { EventEmitter } from 'eventemitter3';
 import { RTMClient } from './RTMClient';
 import { LogLevel, Logger, getLogger } from './logger';
 import { ErrorCode, CodedError } from './errors';

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -1,6 +1,6 @@
 import { Agent } from 'http';
 
-import EventEmitter from 'eventemitter3'; // tslint:disable-line:import-name
+import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
 import WebSocket from 'ws'; // tslint:disable-line:import-name
 import Finity, { StateMachine } from 'finity'; // tslint:disable-line:import-name
 import PQueue from 'p-queue'; // tslint:disable-line:import-name

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -1,6 +1,6 @@
 import { Agent } from 'http';
 
-import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
+import { EventEmitter } from 'eventemitter3';
 import WebSocket from 'ws'; // tslint:disable-line:import-name
 import Finity, { StateMachine } from 'finity'; // tslint:disable-line:import-name
 import PQueue from 'p-queue'; // tslint:disable-line:import-name

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -11,7 +11,7 @@ import { Readable } from 'stream';
 import { SecureContextOptions } from 'tls';
 
 import isStream from 'is-stream';
-import EventEmitter from 'eventemitter3'; // tslint:disable-line:import-name
+import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
 import PQueue from 'p-queue'; // tslint:disable-line:import-name
 import pRetry, { AbortError } from 'p-retry';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -11,7 +11,7 @@ import { Readable } from 'stream';
 import { SecureContextOptions } from 'tls';
 
 import isStream from 'is-stream';
-import { EventEmitter } from 'eventemitter3'; // tslint:disable-line:import-name
+import { EventEmitter } from 'eventemitter3';
 import PQueue from 'p-queue'; // tslint:disable-line:import-name
 import pRetry, { AbortError } from 'p-retry';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';


### PR DESCRIPTION
###  Summary

When working in a TypeScript project whose configuration doesn't set `esModuleInterop` to true, compilation would fail with the following error:

```
node_modules/@slack/web-api/dist/WebClient.d.ts:5:8 - error TS1192: Module '"/mypath/node_modules/eventemitter3/index"' has no default export.

5 import EventEmitter from 'eventemitter3';
         ~~~~~~~~~~~~
```

The `eventemitter3` package has a tricky export where it uses both a value in CommonJS and a named export. This PR adjust the import statement to rely on the named export.

It also adjusts the integration tests to check for this compatibility (the test failed before the change in import was applied).

#759 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
