### PR TITLE
Fix incorrect import in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ to instantiate it with a token, usually a bot token, that you received from Slac
 for the RTM connection to be established, and then send a simple string message to a channel.
 
 ```javascript
-const { RTMClient } = require('@slack/web-api');
+const { RTMClient } = require('@slack/rtm-api');
 
 // An access token (from your Slack app or custom integration - usually xoxb)
 const token = process.env.SLACK_TOKEN;


### PR DESCRIPTION
Fix incorrect import in readme example

###  Summary

Example as is gives this error:

```
const rtm = new RTMClient(token);
            ^

TypeError: RTMClient is not a constructor
    at Object.<anonymous> (/Users/jmumm/src/beepboop/app.js:33:13)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
```

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
