### PR TITLE
fix typo: web-api -> rtm-api on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ to instantiate it with a token, usually a bot token, that you received from Slac
 for the RTM connection to be established, and then send a simple string message to a channel.
 
 ```javascript
-const { RTMClient } = require('@slack/web-api');
+const { RTMClient } = require('@slack/rtm-api');
 
 // An access token (from your Slack app or custom integration - usually xoxb)
 const token = process.env.SLACK_TOKEN;


### PR DESCRIPTION
###  Summary

fix typo on README.md

`import { RTMClient } from "web-api"` -> `import { RTMClient } from "rtm-api"`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
