### PR TITLE
Use destructuring import for IncomingWebhook

### DIFF
--- a/docs/_packages/webhook.md
+++ b/docs/_packages/webhook.md
@@ -52,7 +52,7 @@ The webhook can be initialized with default arguments that are reused each time 
 parameter to the constructor to set the default arguments.
 
 ```javascript
-const IncomingWebhook = require('@slack/webhook');
+const { IncomingWebhook } = require('@slack/webhook');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 // Initialize with defaults
@@ -72,7 +72,7 @@ Something interesting just happened in your app, so its time to send the notific
 the message. The method returns a `Promise` that resolves once the notification is sent.
 
 ```javascript
-const IncomingWebhook = require('@slack/webhook');
+const { IncomingWebhook } = require('@slack/webhook');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 const webhook = new IncomingWebhook(url);

--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -50,7 +50,7 @@ The webhook can be initialized with default arguments that are reused each time 
 parameter to the constructor to set the default arguments.
 
 ```javascript
-const IncomingWebhook = require('@slack/webhook');
+const { IncomingWebhook } = require('@slack/webhook');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 // Initialize with defaults
@@ -70,7 +70,7 @@ Something interesting just happened in your app, so its time to send the notific
 the message. The method returns a `Promise` that resolves once the notification is sent.
 
 ```javascript
-const IncomingWebhook = require('@slack/webhook');
+const { IncomingWebhook } = require('@slack/webhook');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 const webhook = new IncomingWebhook(url);


### PR DESCRIPTION
###  Summary

This PR updates the `@slack/webhook` documentation to properly mention how to import `IncomingWebhook`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
