### PR TITLE
fix examples of proxy agent usage

### DIFF
--- a/docs/_packages/rtm_api.md
+++ b/docs/_packages/rtm_api.md
@@ -550,7 +550,7 @@ Import the `HttpsProxyAgent` class, and create an instance that can be used as t
 
 ```javascript
 const { RTMClient } = require('@slack/rtm-api');
-const { HttpsProxyAgent } = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 const token = process.env.SLACK_BOT_TOKEN;
 
 // One of the ways you can configure HttpsProxyAgent is using a simple string.

--- a/docs/_packages/web_api.md
+++ b/docs/_packages/web_api.md
@@ -415,7 +415,7 @@ Import the `HttpsProxyAgent` class, and create an instance that can be used as t
 
 ```javascript
 const { WebClient } = require('@slack/web-api');
-const { HttpsProxyAgent } = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 const token = process.env.SLACK_TOKEN;
 
 // One of the ways you can configure HttpsProxyAgent is using a simple string.

--- a/docs/_packages/webhook.md
+++ b/docs/_packages/webhook.md
@@ -107,7 +107,7 @@ Import the `HttpsProxyAgent` class, and create an instance that can be used as t
 
 ```javascript
 const { IncomingWebhook } = require('@slack/webhook');
-const { HttpsProxyAgent } = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 // One of the ways you can configure HttpsProxyAgent is using a simple string.

--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -105,7 +105,7 @@ Import the `HttpsProxyAgent` class, and create an instance that can be used as t
 
 ```javascript
 const { IncomingWebhook } = require('@slack/webhook');
-const { HttpsProxyAgent } = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 // One of the ways you can configure HttpsProxyAgent is using a simple string.


### PR DESCRIPTION
###  Summary

Fix documentation for using https-proxy-agent. If I follow the current docs about this, I get this error:

TypeError: HttpsProxyAgent is not a constructor

Checking original lib https://github.com/TooTallNate/node-https-proxy-agent I see the right way to initialize the agent:
```
const HttpsProxyAgent = require('https-proxy-agent');
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
