### PR TITLE
Add Logger#getLevel(): LogLevel (to test what current level is)

### DIFF
--- a/packages/logger/.mocharc.json
+++ b/packages/logger/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": ["ts-node/register", "source-map-support/register"],
+  "timeout": 3000
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -30,13 +30,19 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist",
     "lint": "tslint --project .",
-    "test": "npm run build && echo \"Tests are not implemented.\" && exit 0"
+    "test": "npm run build && nyc mocha --config .mocharc.json src/*.spec.js"
   },
   "dependencies": {
     "@types/node": ">=8.9.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.6",
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.1",
     "shx": "^0.3.2",
+    "ts-node": "^8.2.0",
     "tslint": "^5.13.1",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.3.3333"

--- a/packages/logger/src/index.spec.js
+++ b/packages/logger/src/index.spec.js
@@ -1,0 +1,42 @@
+require('mocha');
+const { assert } = require('chai');
+const { ConsoleLogger, LogLevel } = require('./index');
+
+describe('logger', () => {
+  it('should have the default LogLevel', () => {
+    const logger = new ConsoleLogger();
+    assert.equal(logger.getLevel(), LogLevel.INFO);
+  });
+
+  it('should set LogLevel corrrectly', () => {
+    const logger = new ConsoleLogger();
+    assert.equal(logger.getLevel(), LogLevel.INFO);
+
+    [LogLevel.DEBUG, LogLevel.ERROR, LogLevel.WARN, LogLevel.INFO].forEach((level) => {
+      logger.setLevel(level);
+      assert.equal(logger.getLevel(), level);
+    });
+  });
+
+  it('should offer getLevel to test which level is currently set', () => {
+    let largeObjectGenerated = false;
+    function generateSomethingExpensive() {
+      largeObjectGenerated = true;
+      return JSON.stringify('{ description: "Something expensive to load" }');
+    }
+
+    const logger = new ConsoleLogger();
+    logger.setLevel(LogLevel.INFO);
+    if (logger.getLevel() === LogLevel.DEBUG) {
+      const largeObj = generateSomethingExpensive();
+      logger.debug(`debug: ${largeObj}`);
+    }
+    assert.isFalse(largeObjectGenerated);
+
+    logger.setLevel(LogLevel.DEBUG);
+    if (logger.getLevel() === LogLevel.DEBUG) {
+      generateSomethingExpensive();
+    }
+    assert.isTrue(largeObjectGenerated);
+  });
+});

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -49,6 +49,11 @@ export interface Logger {
   setLevel(level: LogLevel): void;
 
   /**
+   * Return the current LogLevel.
+   */
+  getLevel(): LogLevel;
+
+  /**
    * This allows the instance to be named so that they can easily be filtered when many loggers are sending output
    * to the same destination.
    *
@@ -84,6 +89,10 @@ export class ConsoleLogger implements Logger {
   constructor() {
     this.level = LogLevel.INFO;
     this.name = '';
+  }
+
+  public getLevel(): LogLevel {
+    return this.level;
   }
 
   /**


### PR DESCRIPTION
###  Summary

This pull request adds a new method `getLevel(): LogLevel` to `Logger` interface. Having the method means to enable developers to do expensive operations only when debug logging is enabled. For example, dumping request headers only when debug level logging is enabled is a common use case. 

My motivation to add this method is to have more detailed logging in node-slack-sdk & bolt without any performance compromise in production env.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
