### PR TITLE
fix incorrect homepage for legacy wrapper

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
     "npm": ">= 5.5.1"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/tutorials/migrating-to-v5/",
+  "homepage": "https://slack.dev/node-slack-sdk/tutorials/migrating-to-v5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
###  Summary

:wave: The link on https://www.npmjs.com/package/@slack/client is incorrect. We don't handle a final `/`, which in itself is probably worth looking at, but this ensures that npm doesn't route people to a disappointing 404 🙇 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
