### PR TITLE
Adding support for pre-parsed requests

### DIFF
--- a/packages/interactive-messages/src/adapter.js
+++ b/packages/interactive-messages/src/adapter.js
@@ -14,10 +14,6 @@ import { packageIdentifier, promiseTimeout, errorCodes as utilErrorCodes } from 
 
 const debug = debugFactory('@slack/interactive-messages:adapter');
 
-export const errorCodes = {
-  BODY_PARSER_NOT_PERMITTED: 'SLACKADAPTER_BODY_PARSER_NOT_PERMITTED_FAILURE',
-};
-
 /**
  * Transforms various forms of matching constraints to a single standard object shape
  * @param {string|RegExp|Object} matchingConstraints - the various forms of matching constraints
@@ -196,14 +192,7 @@ export class SlackMessageAdapter {
    */
   expressMiddleware() {
     const requestListener = this.requestListener();
-    return (req, res, next) => {
-      // If parser is being used, we can't verify request signature
-      if (req.body) {
-        const error = new Error('Parsing request body prohibits request signature verification');
-        error.code = errorCodes.BODY_PARSER_NOT_PERMITTED;
-        next(error);
-        return;
-      }
+    return (req, res, next) => { // eslint-disable-line no-unused-vars
       requestListener(req, res);
     };
   }

--- a/packages/interactive-messages/src/http-handler.js
+++ b/packages/interactive-messages/src/http-handler.js
@@ -10,6 +10,7 @@ const debug = debugFactory('@slack/interactive-messages:http-handler');
 export const errorCodes = {
   SIGNATURE_VERIFICATION_FAILURE: 'SLACKHTTPHANDLER_REQUEST_SIGNATURE_VERIFICATION_FAILURE',
   REQUEST_TIME_FAILURE: 'SLACKHTTPHANDLER_REQUEST_TIMELIMIT_FAILURE',
+  BODY_PARSER_NOT_PERMITTED: 'SLACKADAPTER_BODY_PARSER_NOT_PERMITTED_FAILURE', // moved constant from adapter
 };
 
 export function createHTTPHandler(adapter) {
@@ -72,7 +73,7 @@ export function createHTTPHandler(adapter) {
 
     if (ts < fiveMinutesAgo) {
       debug('request is older than 5 minutes');
-      const error = new Error('Slack request signing verification failed');
+      const error = new Error('Slack request signing verification outdated');
       error.code = errorCodes.REQUEST_TIME_FAILURE;
       throw error;
     }
@@ -104,11 +105,38 @@ export function createHTTPHandler(adapter) {
     // Function used to send response
     const respond = sendResponse(res);
 
+    // If parser is being used and we don't receive the raw payload via `rawBody`,
+    // we can't verify request signature
+    if (req.body && !req.rawBody) {
+      const error = new Error('Parsing request body prohibits request signature verification');
+      error.code = errorCodes.BODY_PARSER_NOT_PERMITTED;
+      if (process.env.NODE_ENV === 'development') {
+        respond({ status: 500, content: error.message });
+      } else {
+        respond({ status: 500 });
+      }
+      return;
+    }
+
+    // Some serverless cloud providers (e.g. Google Firebase Cloud Functions) might populate
+    // the request with a bodyparser before it can be populated by the SDK.
+    // To prevent throwing an error here, we check the `rawBody` field before parsing the request
+    // through the `raw-body` module (see Issue #90 - https://github.com/slackapi/node-slack-events-api/pull/90)
+    let parseRawBody;
+    if (req.rawBody) {
+      debug('Parsing request with a rawBody attribute');
+      parseRawBody = new Promise((resolve) => {
+        resolve(req.rawBody);
+      });
+    } else {
+      debug('Parsing raw request');
+      parseRawBody = getRawBody(req);
+    }
+
     // Builds body of the request from stream and returns the raw request body
-    getRawBody(req)
+    parseRawBody
       .then((r) => {
         const rawBody = r.toString();
-
         if (verifyRequestSignature(adapter.signingSecret, req.headers, rawBody)) {
           // Request signature is verified
           // Parse raw body

--- a/packages/interactive-messages/test/helpers.js
+++ b/packages/interactive-messages/test/helpers.js
@@ -31,7 +31,26 @@ function createRequest(signingSecret, ts, rawBody) {
     'content-type': 'application/x-www-form-urlencoded'
   };
   return {
-    body: rawBody,
+    headers: headers
+  };
+}
+
+/**
+ * Creates request object with proper headers and a rawBody field payload
+ * @param {string} signingSecret - A Slack signing secret for request verification
+ * @param {Integer} ts - A timestamp for request verification and header
+ * @param {string} rawBody - String of raw body to be put in rawBody field
+ * @returns {Object} pseudo request object
+ */
+function createRawBodyRequest(signingSecret, ts, rawBody) {
+  const signature = createRequestSignature(signingSecret, ts, rawBody);
+  const headers = {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': ts,
+    'content-type': 'application/json'
+  };
+  return {
+    rawBody: Buffer.from(rawBody),
     headers: headers
   };
 }
@@ -89,6 +108,7 @@ function delayed(ms, value, rejectionReason) {
 }
 
 module.exports.createRequest = createRequest;
+module.exports.createRawBodyRequest = createRawBodyRequest;
 module.exports.createRequestSignature = createRequestSignature;
 module.exports.createStreamRequest = createStreamRequest;
 module.exports.delayed = delayed;

--- a/packages/interactive-messages/test/unit/test-adapter.js
+++ b/packages/interactive-messages/test/unit/test-adapter.js
@@ -7,7 +7,6 @@ var nop = require('nop');
 var getRandomPort = require('get-random-port');
 var systemUnderTest = require('../../dist/adapter');
 var createStreamRequest = require('../helpers').createStreamRequest;
-var errorCodes = systemUnderTest.errorCodes;
 var SlackMessageAdapter = systemUnderTest.default;
 var delayed = require('../helpers').delayed;
 
@@ -122,17 +121,6 @@ describe('SlackMessageAdapter', function () {
     it('should return a function', function () {
       var middleware = this.adapter.expressMiddleware();
       assert.isFunction(middleware);
-    });
-    it('should error when body parser is used', function (done) {
-      var middleware = this.adapter.expressMiddleware();
-      var req = { body: { } };
-      var res = this.res;
-      var next = this.next;
-      next.callsFake(function (err) {
-        assert.equal(err.code, errorCodes.BODY_PARSER_NOT_PERMITTED);
-        done();
-      });
-      middleware(req, res, next);
     });
     it('should verify correctly signed request bodies', function (done) {
       var ts = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
###  Summary

- Issue: https://github.com/slackapi/node-slack-sdk/issues/758
- Ported most of the work from: https://github.com/slackapi/node-slack-events-api/pull/90

This fix allows using the `@slack/interactive-messages` inside serverless environments (like `Firebase Functions` which pre-parse the `body`. A similar fix was already applied to `@slack/events-api` and was used as the basis of this pull request.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
