### PR TITLE
add tests to logger package

### DIFF
--- a/packages/logger/.nycrc.json
+++ b/packages/logger/.nycrc.json
@@ -1,0 +1,14 @@
+{
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**.spec.js"
+  ],
+  "reporter": ["lcov"],
+  "extension": [
+    ".ts"
+  ],
+  "all": false,
+  "cache": true
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -43,6 +43,8 @@
     "nyc": "^14.1.1",
     "shx": "^0.3.2",
     "ts-node": "^8.2.0",
+    "sinon": "^7.3.2",
+    "source-map-support": "^0.5.12",
     "tslint": "^5.13.1",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.3.3333"

--- a/packages/logger/src/index.spec.js
+++ b/packages/logger/src/index.spec.js
@@ -1,42 +1,147 @@
-require('mocha');
 const { assert } = require('chai');
-const { ConsoleLogger, LogLevel } = require('./index');
+const sinon = require('sinon');
+const { Logger, ConsoleLogger, LogLevel } = require('./index');
 
-describe('logger', () => {
-  it('should have the default LogLevel', () => {
-    const logger = new ConsoleLogger();
-    assert.equal(logger.getLevel(), LogLevel.INFO);
-  });
+describe('Logger', () => {
+  describe('ConsoleLogger', () => {
+    let logger: Logger;
 
-  it('should set LogLevel corrrectly', () => {
-    const logger = new ConsoleLogger();
-    assert.equal(logger.getLevel(), LogLevel.INFO);
-
-    [LogLevel.DEBUG, LogLevel.ERROR, LogLevel.WARN, LogLevel.INFO].forEach((level) => {
-      logger.setLevel(level);
-      assert.equal(logger.getLevel(), level);
+    beforeEach(() => {
+      logger = new ConsoleLogger();
     });
-  });
 
-  it('should offer getLevel to test which level is currently set', () => {
-    let largeObjectGenerated = false;
-    function generateSomethingExpensive() {
-      largeObjectGenerated = true;
-      return JSON.stringify('{ description: "Something expensive to load" }');
-    }
+    afterEach(() => {
+      sinon.restore();
+    });
 
-    const logger = new ConsoleLogger();
-    logger.setLevel(LogLevel.INFO);
-    if (logger.getLevel() === LogLevel.DEBUG) {
-      const largeObj = generateSomethingExpensive();
-      logger.debug(`debug: ${largeObj}`);
-    }
-    assert.isFalse(largeObjectGenerated);
+    describe('getLevel', () => {
+      it('should have the default LogLevel', () => {
+        assert.equal(logger.getLevel(), LogLevel.INFO);
+      });
 
-    logger.setLevel(LogLevel.DEBUG);
-    if (logger.getLevel() === LogLevel.DEBUG) {
-      generateSomethingExpensive();
-    }
-    assert.isTrue(largeObjectGenerated);
+      it('should get LogLevel corrrectly', () => {
+        [LogLevel.DEBUG, LogLevel.ERROR, LogLevel.WARN, LogLevel.INFO].forEach((level) => {
+          logger.setLevel(level);
+          assert.equal(logger.getLevel(), level);
+        });
+      });
+    });
+
+    describe('setLevel', () => {
+      it('should set the log level', () => {
+        const debugStub = sinon.stub(console, 'debug');
+        const infoStub = sinon.stub(console, 'info');
+
+        logger.setLevel(LogLevel.DEBUG);
+
+        logger.debug('i am debug');
+        logger.info('i am info');
+
+        assert.equal(debugStub.callCount, 1);
+        assert.equal(infoStub.callCount, 1);
+
+        logger.setLevel(LogLevel.INFO);
+
+        logger.debug('i am debug');
+        logger.info('i am info');
+
+        assert.equal(debugStub.callCount, 1);
+        assert.equal(infoStub.callCount, 2);
+      });
+    });
+
+    describe('setName', () => {
+      it('should set the name', () => {
+        const infoStub = sinon.stub(console, 'info');
+
+        logger.setName('foobles');
+
+        logger.info('test');
+
+        assert.deepEqual(infoStub.firstCall.args, [
+          '[INFO] ',
+          'foobles',
+          'test',
+        ]);
+      });
+    });
+
+    describe('log levels', () => {
+      let debugStub: sinon.SinonStub;
+      let infoStub: sinon.SinonStub;
+      let warnStub: sinon.SinonStub;
+      let errorStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        debugStub = sinon.stub(console, 'debug');
+        infoStub = sinon.stub(console, 'info');
+        warnStub = sinon.stub(console, 'warn');
+        errorStub = sinon.stub(console, 'error');
+      });
+
+      describe('debug', () => {
+        it('should write debug level messages', () => {
+          logger.setLevel(LogLevel.DEBUG);
+
+          logger.debug('debug');
+          logger.info('info');
+          logger.warn('warn');
+          logger.error('error');
+
+          assert.equal(debugStub.called, true);
+          assert.equal(infoStub.called, true);
+          assert.equal(warnStub.called, true);
+          assert.equal(errorStub.called, true);
+        });
+      });
+
+      describe('info', () => {
+        it('should write info level messages', () => {
+          logger.setLevel(LogLevel.INFO);
+
+          logger.debug('debug');
+          logger.info('info');
+          logger.warn('warn');
+          logger.error('error');
+
+          assert.equal(debugStub.called, false);
+          assert.equal(infoStub.called, true);
+          assert.equal(warnStub.called, true);
+          assert.equal(errorStub.called, true);
+        });
+      });
+
+      describe('warn', () => {
+        it('should write warn level messages', () => {
+          logger.setLevel(LogLevel.WARN);
+
+          logger.debug('debug');
+          logger.info('info');
+          logger.warn('warn');
+          logger.error('error');
+
+          assert.equal(debugStub.called, false);
+          assert.equal(infoStub.called, false);
+          assert.equal(warnStub.called, true);
+          assert.equal(errorStub.called, true);
+        });
+      });
+
+      describe('error', () => {
+        it('should write error level messages', () => {
+          logger.setLevel(LogLevel.ERROR);
+
+          logger.debug('debug');
+          logger.info('info');
+          logger.warn('warn');
+          logger.error('error');
+
+          assert.equal(debugStub.called, false);
+          assert.equal(infoStub.called, false);
+          assert.equal(warnStub.called, false);
+          assert.equal(errorStub.called, true);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
felt like adding some tests to this package, let me know if you think they're worth merging in.

couple of oddities i noticed along the way you might want to think about in future:

* most of your tests are in JS but can be in typescript as you already pass them through 'ts-node'
* your types (e.g. `@types/mocha`) are often or always unused because of this
* weirdly you get the older (typescript <3.1) sinon types, im not too sure this is as you're on a recent enough typescript, maybe its some mistake by ts-node