### PR TITLE
Add KnownBlock to incoming webhook argument

### DIFF
--- a/packages/webhook/src/IncomingWebhook.ts
+++ b/packages/webhook/src/IncomingWebhook.ts
@@ -2,7 +2,7 @@ import { Agent } from 'http';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { httpErrorWithOriginal, requestErrorWithOriginal } from './errors';
 import { getUserAgent } from './instrument';
-import { MessageAttachment, Block } from '@slack/types';
+import { MessageAttachment, Block, KnownBlock } from '@slack/types';
 
 /**
  * A client for Slack's Incoming Webhooks
@@ -100,7 +100,7 @@ export interface IncomingWebhookDefaultArguments {
 
 export interface IncomingWebhookSendArguments extends IncomingWebhookDefaultArguments {
   attachments?: MessageAttachment[];
-  blocks?: Block[];
+  blocks?: (KnownBlock | Block)[];
   unfurl_links?: boolean;
   unfurl_media?: boolean;
 }


### PR DESCRIPTION
Added KnownBlock to the blocks property for incoming webhooks. This change bring the webhook configuration in line with the MessageAttachment type.

https://github.com/slackapi/node-slack-sdk/blob/master/packages/types/src/index.ts#L183

###  Summary

This PR makes it possible to build block style webhook integrations while taking full advantage of type checking.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
