### PR TITLE
async/await in tests

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -152,8 +152,8 @@ describe('WebClient', function () {
           await this.client.apiCall('method');
           assert.fail();
         } catch (error) {
-          assert.instanceOf(error, Error);
           this.scope.done();
+          assert.instanceOf(error, Error);
         }
       });
     });
@@ -166,11 +166,11 @@ describe('WebClient', function () {
         await this.client.apiCall('method');
         assert.fail();
       } catch (error) {
+        scope.done();
         assert.instanceOf(error, Error);
         assert.equal(error.code, ErrorCode.PlatformError);
         assert.nestedPropertyVal(error, 'data.ok', false);
         assert.nestedPropertyVal(error, 'data.error', 'bad error');
-        scope.done();
       }
     });
 
@@ -184,12 +184,12 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (error) {
+        scope.done();
         assert.instanceOf(error, Error);
         assert.equal(error.code, ErrorCode.HTTPError);
         assert.equal(error.statusCode, 500);
         assert.exists(error.headers);
         assert.deepEqual(error.body, body);
-        scope.done();
       }
     });
 
@@ -626,9 +626,9 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (error) {
-        assert(spy.called);
         agent.addRequest.restore();
         agent.destroy();
+        assert(spy.called);
       }
     });
   });
@@ -736,10 +736,10 @@ describe('WebClient', function () {
           await this.client.apiCall('method');
           assert.fail();
         } catch (error) {
+          scope.done();
           assert.instanceOf(error, Error);
           assert.equal(error.code, ErrorCode.RateLimitedError);
           assert.equal(error.retryAfter, retryAfter);
-          scope.done();
         }
       });
 
@@ -754,8 +754,8 @@ describe('WebClient', function () {
           await client.apiCall('method');
           assert.fail();
         } catch (err) {
-          assert(spy.calledOnceWith(0))
           scope.done();
+          assert(spy.calledOnceWith(0))
         }
       });
     });
@@ -819,8 +819,8 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (err) {
-        assert(spy.calledOnceWith(0));
         scope.done();
+        assert(spy.calledOnceWith(0));
       }
     });
   });
@@ -834,8 +834,8 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (err) {
-        assert.instanceOf(err, Error);
         scope.done();
+        assert.instanceOf(err, Error);
       }
   });
 
@@ -848,8 +848,8 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (err) {
-        assert.instanceOf(err, Error);
         scope.done();
+        assert.instanceOf(err, Error);
       }
   });
 

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -2,7 +2,7 @@ require('mocha');
 const fs = require('fs');
 const path = require('path');
 const { Agent } = require('https');
-const { assert } = require('chai');
+const { assert, AssertionError } = require('chai');
 const { WebClient } = require('./WebClient');
 const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
@@ -153,6 +153,7 @@ describe('WebClient', function () {
           assert.fail();
         } catch (error) {
           this.scope.done();
+          assert.notInstanceOf(error, AssertionError);
           assert.instanceOf(error, Error);
         }
       });
@@ -167,6 +168,7 @@ describe('WebClient', function () {
         assert.fail();
       } catch (error) {
         scope.done();
+        assert.notInstanceOf(error, AssertionError);
         assert.instanceOf(error, Error);
         assert.equal(error.code, ErrorCode.PlatformError);
         assert.nestedPropertyVal(error, 'data.ok', false);
@@ -185,6 +187,7 @@ describe('WebClient', function () {
         assert.fail();
       } catch (error) {
         scope.done();
+        assert.notInstanceOf(error, AssertionError);
         assert.instanceOf(error, Error);
         assert.equal(error.code, ErrorCode.HTTPError);
         assert.equal(error.statusCode, 500);
@@ -201,6 +204,7 @@ describe('WebClient', function () {
         await client.apiCall('method');
         assert.fail();
       } catch (error) {
+        assert.notInstanceOf(error, AssertionError);
         assert.instanceOf(error, Error);
         assert.equal(error.code, ErrorCode.RequestError);
         assert.instanceOf(error.original, Error);
@@ -628,6 +632,7 @@ describe('WebClient', function () {
       } catch (error) {
         agent.addRequest.restore();
         agent.destroy();
+        assert.notInstanceOf(error, AssertionError);
         assert(spy.called);
       }
     });
@@ -737,6 +742,7 @@ describe('WebClient', function () {
           assert.fail();
         } catch (error) {
           scope.done();
+          assert.notInstanceOf(error, AssertionError);
           assert.instanceOf(error, Error);
           assert.equal(error.code, ErrorCode.RateLimitedError);
           assert.equal(error.retryAfter, retryAfter);
@@ -753,8 +759,9 @@ describe('WebClient', function () {
         try {
           await client.apiCall('method');
           assert.fail();
-        } catch (err) {
+        } catch (error) {
           scope.done();
+          assert.notInstanceOf(error, AssertionError);
           assert(spy.calledOnceWith(0))
         }
       });
@@ -818,8 +825,9 @@ describe('WebClient', function () {
       try {
         await client.apiCall('method');
         assert.fail();
-      } catch (err) {
+      } catch (error) {
         scope.done();
+        assert.notInstanceOf(error, AssertionError);
         assert(spy.calledOnceWith(0));
       }
     });
@@ -833,9 +841,10 @@ describe('WebClient', function () {
       try {
         await client.apiCall('method');
         assert.fail();
-      } catch (err) {
+      } catch (error) {
         scope.done();
-        assert.instanceOf(err, Error);
+        assert.notInstanceOf(error, AssertionError);
+        assert.instanceOf(error, Error);
       }
   });
 
@@ -847,9 +856,10 @@ describe('WebClient', function () {
       try {
         await client.apiCall('method');
         assert.fail();
-      } catch (err) {
+      } catch (error) {
         scope.done();
-        assert.instanceOf(err, Error);
+        assert.notInstanceOf(error, AssertionError);
+        assert.instanceOf(error, Error);
       }
   });
 

--- a/packages/webhook/src/IncomingWebhook.spec.js
+++ b/packages/webhook/src/IncomingWebhook.spec.js
@@ -97,9 +97,9 @@ describe('IncomingWebhook', function () {
         await webhook.send('Hello');
         assert.fail();
       } catch (error) {
-        assert(spy.called);
         agent.addRequest.restore();
         agent.destroy();
+        assert(spy.called);
       }
     });
   });


### PR DESCRIPTION
This cleans up tests a little on top of #808.

I noticed quite a few, if they failed, threw uncaught promises rather than ever reaching mocha so the errors weren't so useful.

Changing the async tests to use async/await instead of the `done` callback means uncaught promise exceptions will be handled by mocha. Makes it a bit cleaner to read too.

if you want to have a look at the diff, view the last commit by its self