### PR TITLE
Fix lerna bootstrap process: Update form-data to 2.5.0, removes @types/form-data

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -43,13 +43,12 @@
   "dependencies": {
     "@slack/logger": "^1.0.0",
     "@slack/types": "^1.0.0",
-    "@types/form-data": "^2.2.1",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=8.9.0",
     "@types/p-queue": "^2.3.2",
     "axios": "^0.18.0",
     "eventemitter3": "^3.1.0",
-    "form-data": "^2.3.3",
+    "form-data": "^2.5.0",
     "is-stream": "^1.1.0",
     "p-queue": "^2.4.2",
     "p-retry": "^4.0.0"


### PR DESCRIPTION
###  Summary

I noticed that the Travis CI build was failing due to a missing type
definition for form-data in the WebAPI package. It looks like the
current release of form-data includes its own type definitions, which
means that @types/form-data isn't necessary anymore.

Removing @types/form-data and updating form-data to 2.5.0 fixed the
lerna bootstrap command, which appears to be failing currently for Travis CI builds.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
