### PR TITLE
Adds support for the Remote Files API

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -145,7 +145,7 @@ export interface Datepicker extends Action {
  * Block Types
  */
 
-export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock | SectionBlock;
+export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock | SectionBlock | FileBlock;
 
 export interface Block {
   type: string;
@@ -178,6 +178,12 @@ export interface SectionBlock extends Block {
   text?: PlainTextElement | MrkdwnElement; // either this or fields must be defined
   fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
   accessory?: KnownAction | Action | ImageElement;
+}
+
+export interface FileBlock extends Block {
+  type: 'file';
+  source: string; // 'remote'
+  external_id: string;
 }
 
 export interface MessageAttachment {

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -397,6 +397,14 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     comments: {
       delete: (this.apiCall.bind(this, 'files.comments.delete')) as Method<methods.FilesCommentsDeleteArguments>,
     },
+    remote: {
+      info: (this.apiCall.bind(this, 'files.remote.info')) as Method<methods.FilesRemoteInfoArguments>,
+      list: (this.apiCall.bind(this, 'files.remote.list')) as Method<methods.FilesRemoteListArguments>,
+      add: (this.apiCall.bind(this, 'files.remote.add')) as Method<methods.FilesRemoteAddArguments>,
+      update: (this.apiCall.bind(this, 'files.remote.update')) as Method<methods.FilesRemoteUpdateArguments>,
+      remove: (this.apiCall.bind(this, 'files.remote.remove')) as Method<methods.FilesRemoteRemoveArguments>,
+      share: (this.apiCall.bind(this, 'files.remote.share')) as Method<methods.FilesRemoteShareArguments>,
+    },
   };
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -365,10 +365,13 @@ export interface FilesCommentsDeleteArguments extends WebAPICallOptions, TokenOv
 }
 
 // either file or external_id is required
-interface FilesRemoteInfoCommonArguments extends WebAPICallOptions, TokenOverridable { channel?: string; }
-type FilesRemoteInfoArgumentsFileRequired = FilesRemoteInfoCommonArguments & { file: string };
-type FilesRemoteInfoArgumentsExternalIdRequired = FilesRemoteInfoCommonArguments & { external_id: string };
-export type FilesRemoteInfoArguments = FilesRemoteInfoArgumentsFileRequired | FilesRemoteInfoArgumentsExternalIdRequired;
+export interface FilesRemoteInfoArguments extends WebAPICallOptions, TokenOverridable {
+  channel?: string;
+
+  // either one of the file or external_id arguments are required
+  file: string;
+  external_id: string;
+}
 
 export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable {
   ts_from?: string;
@@ -386,32 +389,35 @@ export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverrid
   filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
   preview_image?: Buffer | Stream;
   preview_file?: Buffer | Stream;
-  indexable_file_contents?: Buffer| Stream;
+  indexable_file_contents?: Buffer | Stream;
 }
 
-interface FilesRemoteUpdateCommonArguments extends WebAPICallOptions, TokenOverridable {
+export interface FilesRemoteUpdateArguments extends WebAPICallOptions, TokenOverridable {
   title: string;
   external_url: string;
   filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
   preview_image?: Buffer | Stream;
   preview_file?: Buffer | Stream;
-  indexable_file_contents?: Buffer| Stream;
+  indexable_file_contents?: Buffer | Stream;
+
+  // either one of the file or external_id arguments are required
+  file: string;
+  external_id: string;
 }
-type FilesRemoteUpdateArgumentsFileRequired = FilesRemoteUpdateCommonArguments & { file: string };
-type FilesRemoteUpdateArgumentsExternalIdRequired = FilesRemoteUpdateCommonArguments & { external_id: string };
-export type FilesRemoteUpdateArguments = FilesRemoteUpdateArgumentsFileRequired | FilesRemoteUpdateArgumentsExternalIdRequired;
 
-interface FilesRemoteRemoveCommonArguments extends WebAPICallOptions, TokenOverridable {}
-type FilesRemoteRemoveArgumentsFileRequired = FilesRemoteRemoveCommonArguments & { file: string };
-type FilesRemoteRemoveArgumentsExternalIdRequired = FilesRemoteRemoveCommonArguments & { external_id: string };
-export type FilesRemoteRemoveArguments = FilesRemoteRemoveArgumentsFileRequired | FilesRemoteRemoveArgumentsExternalIdRequired;
+export interface FilesRemoteRemoveArguments extends WebAPICallOptions, TokenOverridable {
+  // either one of the file or external_id arguments are required
+  file: string;
+  external_id: string;
+}
 
-interface FilesRemoteShareCommonArguments extends WebAPICallOptions, TokenOverridable {
+export interface FilesRemoteShareArguments extends WebAPICallOptions, TokenOverridable {
   channels: string; // comma-separated list of channel ids
+
+  // either one of the file or external_id arguments are required
+  file: string;
+  external_id: string;
 }
-type FilesRemoteShareArgumentsFileRequired = FilesRemoteShareCommonArguments & { file: string };
-type FilesRemoteShareArgumentsExternalIdRequired = FilesRemoteShareCommonArguments & { external_id: string };
-export type FilesRemoteShareArguments = FilesRemoteShareArgumentsFileRequired | FilesRemoteShareArgumentsExternalIdRequired;
 
   /*
    * `groups.*`

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -365,17 +365,14 @@ export interface FilesCommentsDeleteArguments extends WebAPICallOptions, TokenOv
 }
 // either file or external_id is required
 export interface FilesRemoteInfoArguments extends WebAPICallOptions, TokenOverridable {
-  channel?: string;
-
   // either one of the file or external_id arguments are required
-  file: string;
-  external_id: string;
+  file?: string;
+  external_id?: string;
 }
 export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   ts_from?: string;
   ts_to?: string;
   channel?: string;
-  types?: string;
 }
 cursorPaginationEnabledMethods.add('files.remote.list');
 export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverridable {
@@ -384,32 +381,30 @@ export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverrid
   external_id: string; // a unique identifier for the file in your system
   filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
   preview_image?: Buffer | Stream;
-  preview_file?: Buffer | Stream;
   indexable_file_contents?: Buffer | Stream;
 }
 export interface FilesRemoteUpdateArguments extends WebAPICallOptions, TokenOverridable {
-  title: string;
-  external_url: string;
-  filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
+  title?: string;
+  external_url?: string;
+  filetype?: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
   preview_image?: Buffer | Stream;
-  preview_file?: Buffer | Stream;
   indexable_file_contents?: Buffer | Stream;
 
   // either one of the file or external_id arguments are required
-  file: string;
-  external_id: string;
+  file?: string;
+  external_id?: string;
 }
 export interface FilesRemoteRemoveArguments extends WebAPICallOptions, TokenOverridable {
   // either one of the file or external_id arguments are required
-  file: string;
-  external_id: string;
+  file?: string;
+  external_id?: string;
 }
 export interface FilesRemoteShareArguments extends WebAPICallOptions, TokenOverridable {
   channels: string; // comma-separated list of channel ids
 
   // either one of the file or external_id arguments are required
-  file: string;
-  external_id: string;
+  file?: string;
+  external_id?: string;
 }
 
   /*

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -363,7 +363,6 @@ export interface FilesCommentsDeleteArguments extends WebAPICallOptions, TokenOv
   file: string; // file id
   id: string; // comment id
 }
-
 // either file or external_id is required
 export interface FilesRemoteInfoArguments extends WebAPICallOptions, TokenOverridable {
   channel?: string;
@@ -372,14 +371,13 @@ export interface FilesRemoteInfoArguments extends WebAPICallOptions, TokenOverri
   file: string;
   external_id: string;
 }
-
-export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable, TraditionalPagingEnabled {
+export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   ts_from?: string;
   ts_to?: string;
   channel?: string;
   types?: string;
 }
-
+cursorPaginationEnabledMethods.add('files.remote.list');
 export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverridable {
   title: string;
   external_url: string;
@@ -389,7 +387,6 @@ export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverrid
   preview_file?: Buffer | Stream;
   indexable_file_contents?: Buffer | Stream;
 }
-
 export interface FilesRemoteUpdateArguments extends WebAPICallOptions, TokenOverridable {
   title: string;
   external_url: string;
@@ -402,13 +399,11 @@ export interface FilesRemoteUpdateArguments extends WebAPICallOptions, TokenOver
   file: string;
   external_id: string;
 }
-
 export interface FilesRemoteRemoveArguments extends WebAPICallOptions, TokenOverridable {
   // either one of the file or external_id arguments are required
   file: string;
   external_id: string;
 }
-
 export interface FilesRemoteShareArguments extends WebAPICallOptions, TokenOverridable {
   channels: string; // comma-separated list of channel ids
 

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -373,11 +373,9 @@ export interface FilesRemoteInfoArguments extends WebAPICallOptions, TokenOverri
   external_id: string;
 }
 
-export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable {
+export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable, TraditionalPagingEnabled {
   ts_from?: string;
   ts_to?: string;
-  count?: number;
-  page?: number;
   channel?: string;
   types?: string;
 }

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -364,6 +364,55 @@ export interface FilesCommentsDeleteArguments extends WebAPICallOptions, TokenOv
   id: string; // comment id
 }
 
+// either file or external_id is required
+interface FilesRemoteInfoCommonArguments extends WebAPICallOptions, TokenOverridable { channel?: string; }
+type FilesRemoteInfoArgumentsFileRequired = FilesRemoteInfoCommonArguments & { file: string };
+type FilesRemoteInfoArgumentsExternalIdRequired = FilesRemoteInfoCommonArguments & { external_id: string };
+export type FilesRemoteInfoArguments = FilesRemoteInfoArgumentsFileRequired | FilesRemoteInfoArgumentsExternalIdRequired;
+
+export interface FilesRemoteListArguments extends WebAPICallOptions, TokenOverridable {
+  ts_from?: string;
+  ts_to?: string;
+  count?: number;
+  page?: number;
+  channel?: string;
+  types?: string;
+}
+
+export interface FilesRemoteAddArguments extends WebAPICallOptions, TokenOverridable {
+  title: string;
+  external_url: string;
+  external_id: string; // a unique identifier for the file in your system
+  filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
+  preview_image?: Buffer | Stream;
+  preview_file?: Buffer | Stream;
+  indexable_file_contents?: Buffer| Stream;
+}
+
+interface FilesRemoteUpdateCommonArguments extends WebAPICallOptions, TokenOverridable {
+  title: string;
+  external_url: string;
+  filetype: string; // possible values (except for 'auto'): https://api.slack.com/types/file#file_types
+  preview_image?: Buffer | Stream;
+  preview_file?: Buffer | Stream;
+  indexable_file_contents?: Buffer| Stream;
+}
+type FilesRemoteUpdateArgumentsFileRequired = FilesRemoteUpdateCommonArguments & { file: string };
+type FilesRemoteUpdateArgumentsExternalIdRequired = FilesRemoteUpdateCommonArguments & { external_id: string };
+export type FilesRemoteUpdateArguments = FilesRemoteUpdateArgumentsFileRequired | FilesRemoteUpdateArgumentsExternalIdRequired;
+
+interface FilesRemoteRemoveCommonArguments extends WebAPICallOptions, TokenOverridable {}
+type FilesRemoteRemoveArgumentsFileRequired = FilesRemoteRemoveCommonArguments & { file: string };
+type FilesRemoteRemoveArgumentsExternalIdRequired = FilesRemoteRemoveCommonArguments & { external_id: string };
+export type FilesRemoteRemoveArguments = FilesRemoteRemoveArgumentsFileRequired | FilesRemoteRemoveArgumentsExternalIdRequired;
+
+interface FilesRemoteShareCommonArguments extends WebAPICallOptions, TokenOverridable {
+  channels: string; // comma-separated list of channel ids
+}
+type FilesRemoteShareArgumentsFileRequired = FilesRemoteShareCommonArguments & { file: string };
+type FilesRemoteShareArgumentsExternalIdRequired = FilesRemoteShareCommonArguments & { external_id: string };
+export type FilesRemoteShareArguments = FilesRemoteShareArgumentsFileRequired | FilesRemoteShareArgumentsExternalIdRequired;
+
   /*
    * `groups.*`
    */


### PR DESCRIPTION
###  Summary

Adds methods and types related to Slack's new Remote Files API. Learn more: https://api.slack.com/messaging/files/remote

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
