### PR TITLE
Adds friendlier config error messages to Greet and React example app

### DIFF
--- a/examples/greet-and-react/.gitignore
+++ b/examples/greet-and-react/.gitignore
@@ -1,3 +1,4 @@
 # node / npm stuff
+.env
 /node_modules
 /package-lock.json

--- a/examples/greet-and-react/.gitignore
+++ b/examples/greet-and-react/.gitignore
@@ -2,3 +2,4 @@
 .env
 /node_modules
 /package-lock.json
+/storage

--- a/examples/greet-and-react/README.md
+++ b/examples/greet-and-react/README.md
@@ -17,12 +17,12 @@ changes
 	- Either clone this repo and run `npm install`
 	- Or visit [glitch.com/edit/#!/remix/slack-greet-and-react-example](https://glitch.com/edit/#!/remix/slack-greet-and-react-example)
 2. Set the following environment variables (all available on the *Basic Information* page) to `.env` (see `.env.sample` if you're developing locally)
-	- `SLACK_CLIENT_ID`: You app's _Client ID_
+	- `SLACK_CLIENT_ID`: Your app's _Client ID_
 	- `SLACK_CLIENT_SECRET`: Your app's _Client Secret_
 	- `SLACK_SIGNING_SECRET`: Your app's _Signing Secret_
 3. If you're running the app locally:
 	- Start the app (`node index.js`)
-	- In another window, start ngrok on the same port as your webserver (`ngrok http $PORT`)
+	- In another window, start [ngrok](https://ngrok.com/) on the same port as your webserver (`ngrok http $PORT`)
 
 ### Enable Events
 1. Go back to the app settings and click on `Event Subscriptions` on the left side navigation

--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -1,4 +1,4 @@
-// Load environment variables from `.env` file (optional)
+// Load environment variables from `.env` file.
 require('dotenv').config();
 
 const { createEventAdapter } = require('@slack/events-api');
@@ -9,10 +9,26 @@ const SlackStrategy = require('@aoberoi/passport-slack').default.Strategy;
 const http = require('http');
 const express = require('express');
 
+/**
+ * Logs a configuration error to console with given missing variable names.
+ * @param array envVarNames
+ */
+function logConfigurationError(envVarNames) {
+  const description = envVarNames.length > 1 ?
+    `${envVarNames.join(', ')} environment variables` :
+    `${envVarNames[0]} environment variable`;
+  console.log(`***\nCould not start up the application. Have you set your ${description}?\n\nSee https://github.com/slackapi/node-slack-sdk/blob/master/examples/greet-and-react/README.md#run-locally-or-\n`);
+}
+
+let slackEvents;
 // *** Initialize event adapter using signing secret from environment variables ***
-const slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET, {
-  includeBody: true
-});
+try {
+  slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET, {
+    includeBody: true
+  });
+} catch (error) {
+  return logConfigurationError(['SLACK_SIGNING_SECRET']);
+}
 
 // Initialize a Local Storage object to store authorization info
 // NOTE: This is an insecure method and thus for demo purposes only!
@@ -34,14 +50,20 @@ function getClientByTeamId(teamId) {
 }
 
 // Initialize Add to Slack (OAuth) helpers
-passport.use(new SlackStrategy({
-  clientID: process.env.SLACK_CLIENT_ID,
-  clientSecret: process.env.SLACK_CLIENT_SECRET,
-  skipUserProfile: true,
-}, (accessToken, scopes, team, extra, profiles, done) => {
-  botAuthorizationStorage.setItem(team.id, extra.bot.accessToken);
-  done(null, {});
-}));
+let strategy;
+try {
+  strategy = new SlackStrategy({
+    clientID: process.env.SLACK_CLIENT_ID,
+    clientSecret: process.env.SLACK_CLIENT_SECRET,
+    skipUserProfile: true,
+  }, (accessToken, scopes, team, extra, profiles, done) => {
+    botAuthorizationStorage.setItem(team.id, extra.bot.accessToken);
+    done(null, {});
+  });
+} catch (error) {
+  return logConfigurationError(['SLACK_CLIENT_ID', 'SLACK_CLIENT_SECRET']);
+}
+passport.use(strategy);
 
 // Initialize an Express application
 const app = express();

--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -11,7 +11,7 @@ const express = require('express');
 
 /**
  * Logs a configuration error to console with given missing variable names.
- * @param array envVarNames
+ * @param {Array} envVarNames
  */
 function logConfigurationError(envVarNames) {
   const description = envVarNames.length > 1 ?

--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -9,17 +9,6 @@ const SlackStrategy = require('@aoberoi/passport-slack').default.Strategy;
 const http = require('http');
 const express = require('express');
 
-/**
- * Logs a configuration error to console with given missing variable names.
- * @param {Array} envVarNames
- */
-function logConfigurationError(envVarNames) {
-  const description = envVarNames.length > 1 ?
-    `${envVarNames.join(', ')} environment variables` :
-    `${envVarNames[0]} environment variable`;
-  console.log(`***\nCould not start up the application. Have you set your ${description}?\n\nSee https://github.com/slackapi/node-slack-sdk/blob/master/examples/greet-and-react/README.md#run-locally-or-\n`);
-}
-
 let slackEvents;
 // *** Initialize event adapter using signing secret from environment variables ***
 try {
@@ -149,3 +138,14 @@ const port = process.env.PORT || 3000;
 http.createServer(app).listen(port, () => {
   console.log(`server listening on port ${port}`);
 });
+
+/**
+ * Logs a configuration error to console with given missing variable names.
+ * @param {Array} envVarNames
+ */
+function logConfigurationError(envVarNames) {
+  const description = envVarNames.length > 1 ?
+    `${envVarNames.join(', ')} environment variables` :
+    `${envVarNames[0]} environment variable`;
+  console.log(`***\nCould not start up the application. Have you set your ${description}?\n\nSee https://github.com/slackapi/node-slack-sdk/blob/master/examples/greet-and-react/README.md#run-locally-or-\n`);
+}


### PR DESCRIPTION
###  Summary

Outputs a readable error message instead of a stack trace per #818. Also adds a few minor cleanup tweaks:
* Fixes a typo in README
* Adds `.env`, `storage` dir, and EOL to .gitignore
* Adds link to `ngrok` in README

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
