### PR TITLE
Add pre-parsed requests support to `@slack/interactive-messages`

### DIFF
--- a/packages/events-api/src/http-handler.spec.js
+++ b/packages/events-api/src/http-handler.spec.js
@@ -106,17 +106,6 @@ describe('http-handler', function () {
       this.requestListener(req, res);
     });
 
-    it('should fail request signing verification when a request has body and no rawBody attribute', function (done) {
-      const res = this.res;
-      const req = createRequest('INVALID_SECRET', this.correctDate, correctRawBody);
-      getRawBodyStub.resolves(Buffer.from(correctRawBody));
-      res.end.callsFake(function () {
-        assert.equal(res.statusCode, 404);
-        done();
-      });
-      this.requestListener(req, res);
-    });
-
     it('should fail request signing verification with old timestamp', function (done) {
       const res = this.res;
       const sixMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 6);

--- a/packages/events-api/src/http-handler.ts
+++ b/packages/events-api/src/http-handler.ts
@@ -215,6 +215,12 @@ enum ResponseStatus {
   Failure = 500,
 }
 
+/**
+ * A RequestListener-compatible callback for creating response information from an incoming request.
+ *
+ * @remarks
+ * See RequestListener in the `http` module.
+ */
 type HTTPHandler = (req: IncomingMessage & { body?: any, rawBody?: Buffer }, res: ServerResponse) => void;
 
 /**

--- a/packages/interactive-messages/src/adapter.spec.js
+++ b/packages/interactive-messages/src/adapter.spec.js
@@ -119,17 +119,6 @@ describe('SlackMessageAdapter', function () {
       const middleware = this.adapter.expressMiddleware();
       assert.isFunction(middleware);
     });
-    it('should error when body parser is used', function (done) {
-      const middleware = this.adapter.expressMiddleware();
-      const req = { body: { } };
-      const res = this.res;
-      const next = this.next;
-      next.callsFake(function (err) {
-        assert.equal(err.code, errorCodes.BODY_PARSER_NOT_PERMITTED);
-        done();
-      });
-      middleware(req, res, next);
-    });
     it('should verify correctly signed request bodies', function (done) {
       const ts = Math.floor(Date.now() / 1000);
       const adapter = this.adapter;

--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -6,7 +6,7 @@ import isRegExp from 'lodash.isregexp';
 import isFunction from 'lodash.isfunction';
 import isPlainObject from 'lodash.isplainobject';
 import debugFactory from 'debug';
-import { ErrorCode, errorWithCode, CodedError } from './errors';
+import { ErrorCode, CodedError } from './errors';
 import { createHTTPHandler } from './http-handler';
 import { packageIdentifier, promiseTimeout, isFalsy } from './util';
 import { RequestHandler } from 'express'; // tslint:disable-line no-implicit-dependencies - only a type is imported
@@ -199,15 +199,7 @@ export class SlackMessageAdapter {
    */
   public expressMiddleware(): RequestHandler {
     const requestListener = this.requestListener();
-    return (req, res, next) => {
-      // If parser is being used, we can't verify request signature
-      if (!isFalsy(req.body)) {
-        next(errorWithCode(
-          new Error('Parsing request body prohibits request signature verification'),
-          ErrorCode.BodyParserNotPermitted,
-        ));
-        return;
-      }
+    return (req, res, _next) => {
       requestListener(req, res);
     };
   }

--- a/packages/interactive-messages/src/http-handler.ts
+++ b/packages/interactive-messages/src/http-handler.ts
@@ -165,6 +165,12 @@ export function createHTTPHandler(adapter: SlackMessageAdapter): HTTPHandler {
   };
 }
 
+/**
+ * A RequestListener-compatible callback for creating response information from an incoming request.
+ *
+ * @remarks
+ * See RequestListener in the `http` module.
+ */
 type HTTPHandler = (req: IncomingMessage & { body?: any, rawBody?: Buffer }, res: ServerResponse) => void;
 
 /**

--- a/packages/interactive-messages/test/helpers.js
+++ b/packages/interactive-messages/test/helpers.js
@@ -31,7 +31,26 @@ function createRequest(signingSecret, ts, rawBody) {
     'content-type': 'application/x-www-form-urlencoded'
   };
   return {
-    body: rawBody,
+    headers: headers
+  };
+}
+
+/**
+ * Creates request object with proper headers and a rawBody field payload
+ * @param {string} signingSecret - A Slack signing secret for request verification
+ * @param {Integer} ts - A timestamp for request verification and header
+ * @param {string} rawBody - String of raw body to be put in rawBody field
+ * @returns {Object} pseudo request object
+ */
+function createRawBodyRequest(signingSecret, ts, rawBody) {
+  const signature = createRequestSignature(signingSecret, ts, rawBody);
+  const headers = {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': ts,
+    'content-type': 'application/json'
+  };
+  return {
+    rawBody: Buffer.from(rawBody),
     headers: headers
   };
 }
@@ -89,6 +108,7 @@ function delayed(ms, value, rejectionReason) {
 }
 
 module.exports.createRequest = createRequest;
+module.exports.createRawBodyRequest = createRawBodyRequest;
 module.exports.createRequestSignature = createRequestSignature;
 module.exports.createStreamRequest = createStreamRequest;
 module.exports.delayed = delayed;


### PR DESCRIPTION
###  Summary

> Fixes #758. Updated version of #800.

Ports the work done in slackapi/node-slack-events-api#90 to `@slack/interactive-messages`. This enables serverless environments & other middleware to pre-parse a request's body so long as they populate the `rawBody` field of the request.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
