### PR TITLE
Fix Broken Local dev link in getting_started.md 

### DIFF
--- a/docs/_main/getting_started.md
+++ b/docs/_main/getting_started.md
@@ -140,7 +140,7 @@ look next:
 
 * Dive into the [`@slack/events-api`](https://slack.dev/node-slack-sdk/events_api) package to learn how your app can
   listen for events happening inside Slack. You'll need a URL where your app can receive events, and the [local
-  development tutorial](https://slack.dev/node-slack-sdk/local_development) can help you set one up.
+  development tutorial](https://slack.dev/node-slack-sdk/tutorials/local-development) can help you set one up.
 
 * This tutorial only used two of **over 130 Web API methods** available. [Look through
   them](https://api.slack.com/methods) to get ideas about what to build next!


### PR DESCRIPTION
Noticed this link was broken. Dug in and found the other links were fixed via https://github.com/slackapi/node-slack-sdk/pull/774 but this may have been missed

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
