### PR TITLE
Fix webhook httperror statuscode

### DIFF
--- a/packages/webhook/src/IncomingWebhook.spec.js
+++ b/packages/webhook/src/IncomingWebhook.spec.js
@@ -40,16 +40,18 @@ describe('IncomingWebhook', function () {
 
     describe('when the call fails', function () {
       beforeEach(function () {
+        this.statusCode = 500;
         this.scope = nock('https://hooks.slack.com')
           .post(/services/)
-          .reply(500);
+          .reply(this.statusCode);
       });
 
       it('should return a Promise which rejects on error', function () {
         const result = this.webhook.send('Hello');
-        result.catch((error) => {
+        return result.catch((error) => {
           assert.ok(error);
           assert.instanceOf(error, Error);
+          assert.match(error.message, new RegExp(this.statusCode));
           this.scope.done();
         });
       });

--- a/packages/webhook/src/errors.ts
+++ b/packages/webhook/src/errors.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 
 /**
  * All errors produced by this package adhere to this interface
@@ -54,9 +54,9 @@ export function requestErrorWithOriginal(original: AxiosError): IncomingWebhookR
  * A factory to create IncomingWebhookHTTPError objects
  * @param original The original error
  */
-export function httpErrorWithOriginal(original: AxiosError): IncomingWebhookHTTPError {
+export function httpErrorWithOriginal(original: AxiosError & { response: AxiosResponse }): IncomingWebhookHTTPError {
   const error = errorWithCode(
-    new Error(`An HTTP protocol error occurred: statusCode = ${original.code}`),
+    new Error(`An HTTP protocol error occurred: statusCode = ${original.response.status}`),
     ErrorCode.HTTPError,
   ) as Partial<IncomingWebhookHTTPError>;
   error.original = original;


### PR DESCRIPTION
###  Summary

When using the `IncomingWebhook#send()` method, if an HTTP error occurs (a response with a non-200 status code), the error's message should contain the status code. This was broken and was returning `undefined`. It was because the `error.code` property was not the same thing as `error.response.status` as previously assumed.

This PR addresses this and adds a test to verify this behavior. It also solves a problem where the test was not returning the Promise, so it likely wasn't verifying the error behavior at all before.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
