### PR TITLE
Make the text field in ChatUpdateArguments optional

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -216,7 +216,7 @@ export interface ChatUnfurlArguments extends WebAPICallOptions, TokenOverridable
 }
 export interface ChatUpdateArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  text: string;
+  text?: string;
   ts: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];


### PR DESCRIPTION
###  Summary
The `text` argument in the `chat.update` method [is not required](https://api.slack.com/methods/chat.update#arguments) when presenting `attachments`, so I've changed it to optional.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
