### PR TITLE
 Adds admin.users.session.reset method

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -271,6 +271,19 @@ export class WebClient extends EventEmitter<WebClientEvent> {
   }
 
   /**
+   * admin method family
+   */
+  public readonly admin = {
+    apps: {
+      approve: (this.apiCall.bind(this, 'admin.apps.approve')) as Method<methods.AdminAppsApproveArguments>,
+      requests: {
+        list: (this.apiCall.bind(this, 'admin.apps.requests.list')) as Method<methods.AdminAppsRequestsListArguments>,
+      },
+      restrict: (this.apiCall.bind(this, 'admin.apps.restrict')) as Method<methods.AdminAppsRestrictArguments>,
+    },
+  };
+
+  /**
    * api method family
    */
   public readonly api = {

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -281,6 +281,12 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       },
       restrict: (this.apiCall.bind(this, 'admin.apps.restrict')) as Method<methods.AdminAppsRestrictArguments>,
     },
+    users: {
+      session: {
+        reset:
+          (this.apiCall.bind(this, 'admin.users.session.reset')) as Method<methods.AdminUsersSessionResetArguments>,
+      },
+    },
   };
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -70,6 +70,11 @@ export interface AdminAppsRestrictArguments extends WebAPICallOptions, TokenOver
   request_id?: string;
   team_id: string;
 }
+export interface AdminUsersSessionResetArguments extends WebAPICallOptions, TokenOverridable {
+  user_id: string;
+  mobile_only?: boolean;
+  web_only?: boolean;
+}
 
   /*
    * `api.*`

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -55,6 +55,23 @@ export interface TraditionalPagingEnabled {
  */
 
   /*
+   * `admin.*`
+   */
+export interface AdminAppsApproveArguments extends WebAPICallOptions, TokenOverridable {
+  app_id?: string;
+  request_id?: string;
+  team_id: string;
+}
+export interface AdminAppsRequestsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+export interface AdminAppsRestrictArguments extends WebAPICallOptions, TokenOverridable {
+  app_id?: string;
+  request_id?: string;
+  team_id: string;
+}
+
+  /*
    * `api.*`
    */
 export interface APITestArguments extends WebAPICallOptions {}


### PR DESCRIPTION
###  Summary

Adds the [`admin.users.session.reset`](https://api.slack.com/methods/admin.users.session.reset) method.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
