### PR TITLE
Fix ChannelsListArguments type

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -131,8 +131,8 @@ export interface ChannelsLeaveArguments extends WebAPICallOptions, TokenOverrida
   channel: string;
 }
 export interface ChannelsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
-  exclude_archived: boolean;
-  exclude_members: boolean;
+  exclude_archived?: boolean;
+  exclude_members?: boolean;
 }
 cursorPaginationEnabledMethods.add('channels.list');
 export interface ChannelsMarkArguments extends WebAPICallOptions, TokenOverridable {


### PR DESCRIPTION
###  Summary
#861

The channels.list API has two optional parameters: exclude_archived, exclude_members.
but two parameter's TS type is not optional, so I make two parameters optional

https://api.slack.com/methods/channels.list

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
