### PR TITLE
Workaround for undocumented breaking change in TS3.6

### DIFF
--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -133,7 +133,7 @@ export class RTMClient extends EventEmitter {
 
                   let isRecoverable = true;
                   if (error.code === APICallErrorCode.PlatformError &&
-                      Object.values(UnrecoverableRTMStartError).includes(error.data.error)) {
+                      (Object.values(UnrecoverableRTMStartError) as string[]).includes(error.data.error)) {
                     isRecoverable = false;
                   } else if (error.code === APICallErrorCode.RequestError) {
                     isRecoverable = false;


### PR DESCRIPTION
###  Summary

This PR adds a cast to workaround a breaking change that occurred in TypeScript v3.6. We may later want to change the implementation to one that doesn't use a cast. At this moment it is critical to unblock all builds.

Fixes #863 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
