### PR TITLE
Extend check for action to include presence of view field

### DIFF
--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -387,8 +387,8 @@ export class SlackMessageAdapter {
 
       // if the action constraint is specified, only continue if it matches
       if (constraints.handlerType === StoredConstraintsType.Action) {
-        // a payload that represents an action either has actions, submission, or message defined
-        if (!(payload.actions || payload.submission || payload.message)) {
+        // a payload that represents an action either has actions, submission, message, or view defined
+        if (!(payload.actions || payload.submission || payload.message || payload.view)) {
           return false;
         }
 


### PR DESCRIPTION
###  Summary

`view_submission` type actions are currently not routable within the `@slack/interactive-messages` package, as there is a check inside the `matchCallback` function that checks the payload for the presence of an `actions`, `submission`, or `message` field. However the `view_submission` payload does not have any of those fields. It does however include a `view` field, so I have added that field to the list of other fields that are checked in order to allow the event to be routed correctly to the `ActionHandler`.

See https://github.com/slackapi/node-slack-sdk/issues/873 for more information.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
