### PR TITLE
Fix the args for views.update API

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1,5 +1,5 @@
 import { Stream } from 'stream';
-import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, PlainTextElement } from '@slack/types';
+import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls } from '@slack/types';
 import { WebAPICallOptions, WebAPICallResult } from './WebClient';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -805,11 +805,9 @@ export interface ViewsPushArguments extends WebAPICallOptions, TokenOverridable 
 
 export interface ViewsUpdateArguments extends WebAPICallOptions, TokenOverridable {
   view_id: string;
-  title: PlainTextElement;
-  blocks: (KnownBlock | Block)[];
-  close?: PlainTextElement;
-  submit?: PlainTextElement;
-  private_metadata?: string;
+  view: View;
+  external_id?: string;
+  hash?: string;
 }
 
 export * from '@slack/types';


### PR DESCRIPTION
###  Summary

The `views.update` arguments seem to be a bit incorrect. This pull request fixes them to be compatible with the document. https://api.slack.com/methods/views.update

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
