### PR TITLE
[fix] Update @slack/types codependency to 1.2.2

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@slack/logger": "^1.0.0",
-    "@slack/types": "^1.1.0",
+    "@slack/types": "^1.2.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=8.9.0",
     "@types/p-queue": "^2.3.2",


### PR DESCRIPTION
###  Summary

This PR updates the minor version of `@slack/types` from `1.1.0` to `1.2.0`, within the `@slack/web-api` package.

In the recent `@slack/web-api` update, the `@slack/web-api` now depends on the `View` interface, which is only available in `@slack/types 1.1.2`

https://github.com/slackapi/node-slack-sdk/compare/@slack/web-api@5.1.0...@slack/web-api@5.2.0#diff-104aaed728820f983dd962a1e332e447

When building my project downstream with `@slack/web-api 5.2.0` the following error is reported: 
```
./node_modules/@slack/web-api/dist/methods.d.ts(3,18): error TS2305: Module '"./node_modules/@slack/types/dist"' has no exported member 'View'.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
