### PR TITLE
Add views.publish method and types

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -381,6 +381,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
    */
   public readonly views = {
     open: (this.apiCall.bind(this, 'views.open')) as Method<methods.ViewsOpenArguments>,
+    publish: (this.apiCall.bind(this, 'views.publish')) as Method<methods.ViewsPublishArguments>,
     push: (this.apiCall.bind(this, 'views.push')) as Method<methods.ViewsPushArguments>,
     update: (this.apiCall.bind(this, 'views.update')) as Method<methods.ViewsUpdateArguments>,
   };

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -803,6 +803,12 @@ export interface ViewsPushArguments extends WebAPICallOptions, TokenOverridable 
   view: View;
 }
 
+export interface ViewsPublishArguments extends WebAPICallOptions, TokenOverridable {
+  user_id: string;
+  view: View;
+  hash?: string;
+}
+
 export interface ViewsUpdateArguments extends WebAPICallOptions, TokenOverridable {
   view_id: string;
   view: View;


### PR DESCRIPTION
###  Summary

Add support for `views.publish` - a new Web API method which is used for [the new App Home tab](https://api.slack.com/surfaces/tabs).

Thanks @shanedewael!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
