### PR TITLE
Add types for radio buttons

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -213,6 +213,7 @@ export interface RadioButtons extends Action {
   type: 'radio_buttons';
   initial_option?: Option;
   options: Option[];
+  confirm?: Confirm;
 }
 
 export interface PlainTextInput extends Action {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -209,6 +209,12 @@ export interface Datepicker extends Action {
   confirm?: Confirm;
 }
 
+export interface RadioButtons extends Action {
+  type: 'radio_buttons';
+  initial_option?: Option;
+  options: Option[];
+}
+
 export interface PlainTextInput extends Action {
   type: 'plain_text_input';
   placeholder?: PlainTextElement;
@@ -244,7 +250,7 @@ export interface ContextBlock extends Block {
 
 export interface ActionsBlock extends Block {
   type: 'actions';
-  elements: (Button | Overflow | Datepicker | Select | Action)[];
+  elements: (Button | Overflow | Datepicker | Select | RadioButtons | Action)[];
 }
 
 export interface DividerBlock extends Block {


### PR DESCRIPTION
###  Summary

Supports type information for radio buttons in App Home

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
