### PR TITLE
Add oauth.v2.access API support

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -414,6 +414,26 @@ describe('WebClient', function () {
         scope.done();
       });
     });
+
+    it('should remove client_id/client_secret arguments and set Authorization header', function () {
+      const client = new WebClient(undefined);
+
+      const scope = nock('https://slack.com', {
+        reqheaders: {
+          'Authorization': 'Basic MTIzLjQ1NjpyYW5kb20tc3RyaW5n',
+        }
+      })
+        .post(/api/, 'code=123&other=abc')
+        .reply(200, { ok: true });
+
+        const r = client.apiCall(
+        'method',
+        { client_id: '123.456', client_secret: 'random-string', code: 123, other: 'abc', }
+      );
+      return r.then(() => {
+        scope.done();
+      });
+    });
   });
 
   describe('apiCall() - when using static headers', function () {
@@ -895,48 +915,6 @@ describe('WebClient', function () {
           done();
         });
   });
-
-  /*
-  // npm i express --save-dev
-  // export SLACK_CLIENT_ID=123.456
-  // export SLACK_CLIENT_SECRET=abcabc
-  // export SLACK_REDIECT_URI=https://your-domain.ngrok.io/slack/oauth/callback
-  it('should request oauth.access using Basic Auth', function(done) {
-    const app = require('express')();
-    app.get('/slack/oauth/callback', (req, resp) => {
-      const client = new WebClient(null);
-      client.oauth.access({
-        client_id: process.env.SLACK_CLIENT_ID,
-        client_secret: process.env.SLACK_CLIENT_SECRET,
-        code: req.query.code,
-        redirect_uri: process.env.SLACK_REDIRECT_URI
-      })
-      .then(res => console.log(JSON.stringify(res)))
-      .catch(err => console.log(`error: ${err}`))
-    });
-    app.listen(3000, () => console.log(`Listening on port 3000!`));
-  });
-
-  // npm i express --save-dev
-  // export SLACK_CLIENT_ID=123.456
-  // export SLACK_CLIENT_SECRET=abcabc
-  // export SLACK_REDIECT_URI=https://your-domain.ngrok.io/slack/oauth/callback
-  it('should request oauth.v2.access using Basic Auth', function(done) {
-    const app = require('express')();
-    app.get('/slack/oauth/callback', (req, resp) => {
-      const client = new WebClient(null);
-      client.oauth.v2.access({
-        client_id: process.env.SLACK_CLIENT_ID,
-        client_secret: process.env.SLACK_CLIENT_SECRET,
-        code: req.query.code,
-        redirect_uri: process.env.SLACK_REDIRECT_URI
-      })
-      .then(res => console.log(JSON.stringify(res)))
-      .catch(err => console.log(`error: ${err}`))
-    });
-    app.listen(3000, () => console.log(`Listening on port 3000!`));
-  });
-  */
 
   afterEach(function () {
     nock.cleanAll();

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -896,6 +896,47 @@ describe('WebClient', function () {
         });
   });
 
+  /*
+  // npm i express --save-dev
+  // export SLACK_CLIENT_ID=123.456
+  // export SLACK_CLIENT_SECRET=abcabc
+  // export SLACK_REDIECT_URI=https://your-domain.ngrok.io/slack/oauth/callback
+  it('should request oauth.access using Basic Auth', function(done) {
+    const app = require('express')();
+    app.get('/slack/oauth/callback', (req, resp) => {
+      const client = new WebClient(null);
+      client.oauth.access({
+        client_id: process.env.SLACK_CLIENT_ID,
+        client_secret: process.env.SLACK_CLIENT_SECRET,
+        code: req.query.code,
+        redirect_uri: process.env.SLACK_REDIRECT_URI
+      })
+      .then(res => console.log(JSON.stringify(res)))
+      .catch(err => console.log(`error: ${err}`))
+    });
+    app.listen(3000, () => console.log(`Listening on port 3000!`));
+  });
+
+  // npm i express --save-dev
+  // export SLACK_CLIENT_ID=123.456
+  // export SLACK_CLIENT_SECRET=abcabc
+  // export SLACK_REDIECT_URI=https://your-domain.ngrok.io/slack/oauth/callback
+  it('should request oauth.v2.access using Basic Auth', function(done) {
+    const app = require('express')();
+    app.get('/slack/oauth/callback', (req, resp) => {
+      const client = new WebClient(null);
+      client.oauth.v2.access({
+        client_id: process.env.SLACK_CLIENT_ID,
+        client_secret: process.env.SLACK_CLIENT_SECRET,
+        code: req.query.code,
+        redirect_uri: process.env.SLACK_REDIRECT_URI
+      })
+      .then(res => console.log(JSON.stringify(res)))
+      .catch(err => console.log(`error: ${err}`))
+    });
+    app.listen(3000, () => console.log(`Listening on port 3000!`));
+  });
+  */
 
   afterEach(function () {
     nock.cleanAll();

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -146,16 +146,18 @@ export class WebClient extends EventEmitter<WebClientEvent> {
 
     // Sending an encrypted value in Authorization header instead of sending them in request body
     let headers = {};
-    if (options && typeof options.client_id !== 'undefined' && typeof options.client_secret !== 'undefined') {
+    if (typeof options !== 'undefined'
+      && typeof options.client_id !== 'undefined'
+      && typeof options.client_secret !== 'undefined') {
       const credentials = Buffer.from(`${options.client_id}:${options.client_secret}`).toString('base64');
-      headers = {'Authorization': `Basic ${credentials}`};
+      headers = { Authorization: `Basic ${credentials}` };
       delete options.client_id;
       delete options.client_secret;
     }
-    const response = await this.makeRequest(method, Object.assign(
-      { token: this.token },
-      options,
-    ), headers);
+    const response = await this.makeRequest(
+      method,
+      Object.assign({ token: this.token }, options),
+      headers);
     const result = this.buildResult(response);
 
     // log warnings in response metadata
@@ -519,7 +521,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     access: (this.apiCall.bind(this, 'oauth.access')) as Method<methods.OAuthAccessArguments>,
     v2: {
       access: (this.apiCall.bind(this, 'oauth.v2.access')) as Method<methods.OAuthV2AccessArguments>,
-    }
+    },
   };
 
   /**

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -144,10 +144,18 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
     }
 
+    // Sending an encrypted value in Authorization header instead of sending them in request body
+    let headers = {};
+    if (options && typeof options.client_id !== 'undefined' && typeof options.client_secret !== 'undefined') {
+      const credentials = Buffer.from(`${options.client_id}:${options.client_secret}`).toString('base64');
+      headers = {'Authorization': `Basic ${credentials}`};
+      delete options.client_id;
+      delete options.client_secret;
+    }
     const response = await this.makeRequest(method, Object.assign(
       { token: this.token },
       options,
-    ));
+    ), headers);
     const result = this.buildResult(response);
 
     // log warnings in response metadata

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -509,6 +509,9 @@ export class WebClient extends EventEmitter<WebClientEvent> {
    */
   public readonly oauth = {
     access: (this.apiCall.bind(this, 'oauth.access')) as Method<methods.OAuthAccessArguments>,
+    v2: {
+      access: (this.apiCall.bind(this, 'oauth.v2.access')) as Method<methods.OAuthV2AccessArguments>,
+    }
   };
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -606,6 +606,13 @@ export interface OAuthAccessArguments extends WebAPICallOptions {
   client_secret: string;
   code: string;
   redirect_uri?: string;
+  single_channel?: string;
+}
+export interface OAuthV2AccessArguments extends WebAPICallOptions {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  redirect_uri?: string;
 }
 
   /*


### PR DESCRIPTION
###  Summary

This pull request adds the support for `oauth.v2.access` endpoint introduced for Granular Permissions feature.

* https://api.slack.com/methods/oauth.v2.access
* https://api.slack.com/authentication/basics

Also, I noticed `oauth.access` has been missing an optional param named `single_channel`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
