### PR TITLE
Make title optional and support 'home' type for Views

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,8 +33,8 @@ export interface Dialog {
 }
 
 export interface View {
-  title: PlainTextElement;
-  type: 'modal';
+  title?: PlainTextElement;
+  type: 'home' | 'modal';
   blocks: (KnownBlock | Block)[];
   callback_id?: string;
   close?: PlainTextElement;


### PR DESCRIPTION
###  Summary

This PR adds a 'home' type to View interface, and allows the title
to be optional - both according to the View payload reference:

  https://api.slack.com/reference/surfaces/views

Without this change, I am unable to call `views.publish` for the new
App Home tabs feature from a typescript application.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
