### PR TITLE
Add oauth.v2.access method to WebClient

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -509,6 +509,9 @@ export class WebClient extends EventEmitter<WebClientEvent> {
    */
   public readonly oauth = {
     access: (this.apiCall.bind(this, 'oauth.access')) as Method<methods.OAuthAccessArguments>,
+    v2: {
+      access: (this.apiCall.bind(this, 'oauth.v2.access')) as Method<methods.OAuthV2AccessArguments>,
+    },
   };
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -606,8 +606,14 @@ export interface OAuthAccessArguments extends WebAPICallOptions {
   client_secret: string;
   code: string;
   redirect_uri?: string;
+  single_channel?: string;
 }
-
+export interface OAuthV2AccessArguments extends WebAPICallOptions {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  redirect_uri?: string;
+}
   /*
    * `pins.*`
    */


### PR DESCRIPTION
###  Summary

Add the `oauth.v2.access` method to the `WebClient` to support [Granular Bot Permissions and the new OAuth flow](https://api.slack.com/authentication/oauth-v2). Thanks to @seratch's PR #900 for the original work - this PR just cherry-picks the minimum necessary implementation from that.

Bonus: adds the missing `single_channel` argument for `oauth.access` - which was used for the since-deprecated Workspace Apps part of the Slack Platform.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
