### PR TITLE
Implement view submission and view closed handling on @slack/interactive-messages

### DIFF
--- a/docs/_packages/interactive_messages.md
+++ b/docs/_packages/interactive_messages.md
@@ -476,7 +476,7 @@ Constraints can be a simple string, a `RegExp`, or an object with a number of pr
 | `within` | `block_actions` or `interactive_message` or `dialog` | Match the source of options request | 🚫 | ✅ | 🚫 |
 | `unfurl` | `boolean` | Whether or not the `button`, `select`, or `block_action` occurred in an App Unfurl | ✅ | 🚫 | 🚫 |
 | `viewId` | `string` | Match the `view_id` for view submissions | 🚫 | 🚫 | ✅ |
-| `externalId` | `string` | Match the `external_id` for view submissions | 🚫 | 🚫 | ✅ |
+| `externalId` | `string` or `RegExp` | Match the `external_id` for view submissions | 🚫 | 🚫 | ✅ |
 
 All of the properties are optional, its just a matter of how specific you want to the handler's behavior to be. A
 `string` or `RegExp` is a shorthand for only specifying the `callbackId` constraint. Here are some examples:

--- a/docs/_packages/interactive_messages.md
+++ b/docs/_packages/interactive_messages.md
@@ -348,6 +348,117 @@ slackInteractions.options({ within: 'dialog' }, (payload) => {
 
 ---
 
+### Handling view submission and view closed interactions
+
+View submissions are generated when a user clicks on the submission button of a
+[Modal](https://api.slack.com/surfaces/modals). View closed interactions are generated when a user clicks on the cancel
+button of a Modal, or dismisses the modal using the `×` in the corner.
+
+Apps register functions, called **handlers**, to be triggered when a submissions are received by the adapter using the
+`.viewSubmission(constraints, handler)` method or when closed interactions are received using the
+`.viewClosed(constraints, handler)` method. When registering a handler, you describe which submissions and closed
+interactions you'd like the handler to match using **constraints**. Constraints are [described in detail](#constraints)
+below. The adapter will call the handler whose constraints match the interaction best.
+
+These handlers receive a single `payload` argument. The `payload` describes the
+[view submission](https://api.slack.com/reference/interaction-payloads/views#view_submission) or
+[view closed](https://api.slack.com/reference/interaction-payloads/views#view_closed)
+interaction that occurred.
+
+For view submissions, handlers can return an object, or a `Promise` for a object which must resolve within the
+`syncResponseTimeout` (default: 2500ms). The contents of the object depend on what you'd like to happen to the view.
+Your app can update the view, push a new view into the stack, close the view, or display validation errors to the user.
+In the documentation, the shape of the objects for each of those possible outcomes, which the handler would return, are
+described as `response_action`s. If the handler returns no value, or a Promise that resolves to no value, the view will
+simply be dismissed on submission.
+
+View closed interactions only occur if the view was opened with the `notify_on_close` property set to `true`. For these
+interactions the handler should not return a value.
+
+```javascript
+const { createMessageAdapter } = require('@slack/interactive-messages');
+const slackSigningSecret = process.env.SLACK_SIGNING_SECRET;
+const slackInteractions = createMessageAdapter(slackSigningSecret);
+const port = process.env.PORT || 3000;
+
+// Example of handling a simple view submission
+slackInteractions.viewSubmission('simple_modal_callback_id', (payload) => {
+  // Log the input elements from the view submission.
+  console.log(payload.view.state);
+
+  // The previous value is an object keyed by block_id, which contains objects keyed by action_id,
+  // which contains value properties that contain the input data. Let's log one specific value.
+  console.log(payload.view.state.my_block_id.my_action_id.value);
+
+  // Validate the inputs (errors is of the shape in https://api.slack.com/surfaces/modals/using#displaying_errors)
+  const errors = validate(payload.view.state);
+
+  // Return validation errors if there were errors in the inputs
+  if (errors) {
+    return errors;
+  }
+
+  // Process the submission
+  doWork();
+});
+
+// Example of handling a view submission which pushes another view onto the stack
+slackInteractions.viewSubmission('first_step_callback_id', () => {
+  const errors = validate(payload.view.state);
+
+  if (errors) {
+    return errors;
+  }
+
+  // Process the submission (needs to complete under 2.5 seconds)
+  return doWork()
+    .then(() => {
+      return {
+        response_action: 'push',
+        view: {
+          type: 'modal',
+          callback_id: 'second_step_callback_id',
+          title: {
+            type: 'plain_text',
+            text: 'Second step',
+          },
+          blocks: [
+            {
+              type: 'input',
+              block_id: 'last_thing',
+              element: {
+                type: 'plain_text_input',
+                action_id: 'text',
+              },
+              label: {
+                type: 'plain_text',
+                text: 'One last thing...',
+              },
+            },
+          ],
+        },
+      };
+    })
+    .catch((error) => {
+      // Log the error. In your app, inform the user of a failure using a DM or some other area in Slack.
+      console.log(error);
+    });
+});
+
+// Example of handling view closed
+slackInteractions.viewClosed('my_modal_callback_id', (payload) => {
+  // If you accumulated partial state using block actions, now is a good time to clear it
+  clearPartialState();
+});
+
+(async () => {
+  const server = await slackInteractions.start(port);
+  console.log(`Listening for events on ${server.address().port}`);
+})();
+```
+
+---
+
 ### Constraints
 
 Constraints allow you to describe when a handler should be called. In simpler apps, you can use very simple constraints
@@ -356,14 +467,16 @@ conditions, and express a more nuanced structure of your app.
 
 Constraints can be a simple string, a `RegExp`, or an object with a number of properties.
 
-| Property name | Type | Description | Used with `.actions()` | Used with `.options()` |
-|---------------|------|-------------|------------------------|------------------------|
-| `callbackId` | `string` or `RegExp` | Match the `callback_id` for attachment or dialog | ✅ | ✅ |
-| `blockId` | `string` or `RegExp` | Match the `block_id` for a block action | ✅ | ✅ |
-| `actionId` | `string` or `RegExp` | Match the `action_id` for a block action | ✅ | ✅ |
-| `type` | any block action element type or `message_actions` or `dialog_submission` or `button` or `select` | Match the kind of interaction | ✅ | 🚫 |
-| `within` | `block_actions` or `interactive_message` or `dialog` | Match the source of options request | 🚫 | ✅ |
-| `unfurl` | `boolean` | Whether or not the `button`, `select`, or `block_action` occurred in an App Unfurl |  ✅ | 🚫 |
+| Property name | Type | Description | Used with `.action()` | Used with `.options()` | Used with `.viewSubmission()` and `.viewClosed()` |
+|---------------|------|-------------|-----------------------|------------------------|---------------------------------------------------|
+| `callbackId` | `string` or `RegExp` | Match the `callback_id` for attachment or dialog | ✅ | ✅ | ✅ |
+| `blockId` | `string` or `RegExp` | Match the `block_id` for a block action | ✅ | ✅ | 🚫 |
+| `actionId` | `string` or `RegExp` | Match the `action_id` for a block action | ✅ | ✅ | 🚫 |
+| `type` | any block action element type or `message_actions` or `dialog_submission` or `button` or `select` | Match the kind of interaction | ✅ | 🚫 | 🚫 |
+| `within` | `block_actions` or `interactive_message` or `dialog` | Match the source of options request | 🚫 | ✅ | 🚫 |
+| `unfurl` | `boolean` | Whether or not the `button`, `select`, or `block_action` occurred in an App Unfurl | ✅ | 🚫 | 🚫 |
+| `viewId` | `string` | Match the `view_id` for view submissions | 🚫 | 🚫 | ✅ |
+| `externalId` | `string` | Match the `external_id` for view submissions | 🚫 | 🚫 | ✅ |
 
 All of the properties are optional, its just a matter of how specific you want to the handler's behavior to be. A
 `string` or `RegExp` is a shorthand for only specifying the `callbackId` constraint. Here are some examples:

--- a/packages/interactive-messages/README.md
+++ b/packages/interactive-messages/README.md
@@ -485,7 +485,7 @@ Constraints can be a simple string, a `RegExp`, or an object with a number of pr
 | `within` | `block_actions` or `interactive_message` or `dialog` | Match the source of options request | 🚫 | ✅ | 🚫 |
 | `unfurl` | `boolean` | Whether or not the `button`, `select`, or `block_action` occurred in an App Unfurl | ✅ | 🚫 | 🚫 |
 | `viewId` | `string` | Match the `view_id` for view submissions | 🚫 | 🚫 | ✅ |
-| `externalId` | `string` | Match the `external_id` for view submissions | 🚫 | 🚫 | ✅ |
+| `externalId` | `string` or `RegExp` | Match the `external_id` for view submissions | 🚫 | 🚫 | ✅ |
 
 All of the properties are optional, its just a matter of how specific you want to the handler's behavior to be. A
 `string` or `RegExp` is a shorthand for only specifying the `callbackId` constraint. Here are some examples:

--- a/packages/interactive-messages/src/adapter.spec.js
+++ b/packages/interactive-messages/src/adapter.spec.js
@@ -394,6 +394,10 @@ describe('SlackMessageAdapter', function () {
         this.adapter[methodName]({ externalId: 'my_external_id' }, this.handler);
         assertHandlerRegistered(this.adapter, this.handler);
       });
+      it('a RegExp external_id registers successfully', function () {
+        this.adapter[methodName]({ externalId: /w+_external_id/ }, this.handler);
+        assertHandlerRegistered(this.adapter, this.handler);
+      });
       it('invalid external_id types throw on registration', function () {
         const handler = this.handler;
         const adapter = this.adapter;
@@ -408,9 +412,6 @@ describe('SlackMessageAdapter', function () {
         }, TypeError);
         assert.throws(function () {
           adapter[methodName]({ externalId: null }, handler);
-        }, TypeError);
-        assert.throws(function () {
-          adapter[methodName]({ externalId: /\w+_external_id/ }, handler);
         }, TypeError);
       });
       it('a string view_id registers successfully', function () {
@@ -1317,6 +1318,20 @@ describe('SlackMessageAdapter', function () {
             this.adapter.dispatch(this.payload);
             assert(this.callback.called);
           });
+
+          it('should return undefined with a RegExp mismatch', function () {
+            let response;
+            this.adapter.viewSubmission({ externalId: /g/ }, this.callback);
+            response = this.adapter.dispatch(this.payload);
+            assert(this.callback.notCalled);
+            assert.isUndefined(response);
+          });
+
+          it('should match with matching RegExp externalId', function () {
+            this.adapter.viewSubmission({ externalId: /a/ }, this.callback);
+            this.adapter.dispatch(this.payload);
+            assert(this.callback.called);
+          });
         });
         describe('on view closed', function () {
           beforeEach(function () {
@@ -1333,6 +1348,20 @@ describe('SlackMessageAdapter', function () {
 
           it('should match with matching viewId', function () {
             this.adapter.viewClosed({ externalId: 'abcdef' }, this.callback);
+            this.adapter.dispatch(this.payload);
+            assert(this.callback.called);
+          });
+
+          it('should return undefined with a RegExp mismatch', function () {
+            let response;
+            this.adapter.viewClosed({ externalId: /g/ }, this.callback);
+            response = this.adapter.dispatch(this.payload);
+            assert(this.callback.notCalled);
+            assert.isUndefined(response);
+          });
+
+          it('should match with matching RegExp externalId', function () {
+            this.adapter.viewClosed({ externalId: /a/ }, this.callback);
             this.adapter.dispatch(this.payload);
             assert(this.callback.called);
           });

--- a/packages/interactive-messages/src/adapter.spec.js
+++ b/packages/interactive-messages/src/adapter.spec.js
@@ -986,12 +986,14 @@ describe('SlackMessageAdapter', function () {
         this.viewSubmissionPayload = {
           type: 'view_submission',
           view: {
+            callback_id: 'id',
             id: 'V12345'
           },
         };
         this.viewSubmissionWithExternalIdPayload = {
           type: 'view_submission',
           view: {
+            callback_id: 'id',
             id: 'V12345',
             external_id: 'abcdef',
           },
@@ -999,32 +1001,31 @@ describe('SlackMessageAdapter', function () {
         this.viewClosedPayload = {
           type: 'view_closed',
           view: {
+            callback_id: 'id',
             id: 'V12345'
           },
         };
         this.viewClosedWithExternalIdPayload = {
           type: 'view_closed',
           view: {
+            callback_id: 'id',
             id: 'V12345',
             external_id: 'abcdef',
           },
         };
         this.callback = sinon.spy();
       });
+
       it('should return undefined when there are no callbacks registered', function () {
         const response = this.adapter.dispatch({});
         assert.isUndefined(response);
       });
 
-      describe('callback ID based matching', function () {
-        beforeEach(function () {
-          this.payload = this.buttonPayload;
-        });
-
+      function shouldMatchBasedOnCallbackId(payload) {
         it('should return undefined with a string mismatch', function () {
           let response;
           this.adapter.action('b', this.callback);
-          response = this.adapter.dispatch(this.payload);
+          response = this.adapter.dispatch(payload);
           assert(this.callback.notCalled);
           assert.isUndefined(response);
         });
@@ -1032,13 +1033,19 @@ describe('SlackMessageAdapter', function () {
         it('should return undefined with a RegExp mismatch', function () {
           let response;
           this.adapter.action(/b/, this.callback);
-          response = this.adapter.dispatch(this.payload);
+          response = this.adapter.dispatch(payload);
           assert(this.callback.notCalled);
           assert.isUndefined(response);
         });
 
         // TODO: successful match on string, successful match on regexp, matches when registered
         // as an options handler instead
+      }
+
+      describe('callback ID based matching', function () {
+        shouldMatchBasedOnCallbackId('interactive message action', this.buttonPayload);
+        shouldMatchBasedOnCallbackId('view submission', this.viewSubmissionPayload);
+        shouldMatchBasedOnCallbackId('view closed', this.viewClosedPayload);
       });
 
       describe('block ID based matching', function () {

--- a/packages/interactive-messages/src/adapter.spec.js
+++ b/packages/interactive-messages/src/adapter.spec.js
@@ -213,7 +213,7 @@ describe('SlackMessageAdapter', function () {
           adapter[methodName](undefined, handler);
         }, TypeError);
       });
-      it('non-function callbacks throw on registration', function () {
+      it('non-function handlers throw on registration', function () {
         const adapter = this.adapter;
         assert.throws(function () {
           adapter[methodName]('my_callback', 5);
@@ -275,6 +275,7 @@ describe('SlackMessageAdapter', function () {
         assert.throws(function () {
           adapter.action({ blockId: [] }, handler);
         }, TypeError);
+        // TODO: do the following two tests even work?
         assert.throws(function () {
           adapter.action({ blockId: null }, handler);
         }, TypeError);
@@ -299,6 +300,7 @@ describe('SlackMessageAdapter', function () {
         assert.throws(function () {
           adapter.action({ actionId: [] }, handler);
         }, TypeError);
+        // TODO: do the following two tests even work?
         assert.throws(function () {
           adapter.action({ actionId: null }, handler);
         }, TypeError);
@@ -382,10 +384,95 @@ describe('SlackMessageAdapter', function () {
     });
   });
 
+  // shared view constraints tests
+  function shouldRegisterWithViewConstraints(methodName) {
+    describe('when registering with a complex set of constraints', function () {
+      beforeEach(function () {
+        this.handler = function () { };
+      });
+      it('a string external_id registers successfully', function () {
+        this.adapter[methodName]({ externalId: 'my_external_id' }, this.handler);
+        assertHandlerRegistered(this.adapter, this.handler);
+      });
+      it('invalid external_id types throw on registration', function () {
+        const handler = this.handler;
+        const adapter = this.adapter;
+        assert.throws(function () {
+          adapter[methodName]({ externalId: 5 }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ externalId: true }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ externalId: [] }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ externalId: null }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ externalId: /\w+_external_id/ }, handler);
+        }, TypeError);
+      });
+      it('a string view_id registers successfully', function () {
+        this.adapter[methodName]({ viewId: 'my_view_id' }, this.handler);
+        assertHandlerRegistered(this.adapter, this.handler);
+      });
+      it('invalid view_id types throw on registration', function () {
+        const handler = this.handler;
+        const adapter = this.adapter;
+        assert.throws(function () {
+          adapter[methodName]({ viewId: 5 }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ viewId: true }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ viewId: [] }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ viewId: null }, handler);
+        }, TypeError);
+        assert.throws(function () {
+          adapter[methodName]({ viewId: /\w+_view_id/ }, handler);
+        }, TypeError);
+      });
+    });
+  }
+
+  describe('#viewSubmission()', function () {
+    beforeEach(function () {
+      this.adapter = new SlackMessageAdapter(workingSigningSecret);
+    });
+    it('should fail view submission registration without handler', function () {
+      assert.throws(function () {
+        this.adapter.viewSubmission('my_callback');
+      }, TypeError);
+    });
+
+    // execute shared tests
+    shouldRegisterWithCallbackId('viewSubmission');
+    shouldRegisterWithViewConstraints('viewSubmission');
+  });
+
+  describe('#viewClosed()', function () {
+    beforeEach(function () {
+      this.adapter = new SlackMessageAdapter(workingSigningSecret);
+    });
+    it('should fail view closed registration without handler', function () {
+      assert.throws(function () {
+        this.adapter.viewClosed('my_callback');
+      }, TypeError);
+    });
+
+    // execute shared tests
+    shouldRegisterWithCallbackId('viewClosed');
+    shouldRegisterWithViewConstraints('viewSubmission');
+  });
+
   describe('#dispatch()', function () {
     beforeEach(function () {
       this.adapter = new SlackMessageAdapter(workingSigningSecret, {
-        // using a short timout to make tests finish faster
+        // using a short timeout to make tests finish faster
         syncResponseTimeout: 50
       });
     });
@@ -510,7 +597,7 @@ describe('SlackMessageAdapter', function () {
         ]);
       });
       it('should handle the callback returning a promise that fails after the timeout with a ' +
-         'sychronous response', function () {
+         'synchronous response', function () {
         let dispatchResponse;
         const requestPayload = this.requestPayload;
         const timeout = this.adapter.syncResponseTimeout;
@@ -522,7 +609,7 @@ describe('SlackMessageAdapter', function () {
         return assertResponseStatusAndMessage(dispatchResponse, 200);
       });
       it('should handle the callback returning a promise that fails before the timeout with a ' +
-         'sychronous response', function () {
+         'synchronous response', function () {
         let dispatchResponse;
         const requestPayload = this.requestPayload;
         const timeout = this.adapter.syncResponseTimeout;
@@ -636,7 +723,7 @@ describe('SlackMessageAdapter', function () {
           return assertResponseStatusAndMessage(dispatchResponse, 200, replacement);
         });
         it('should handle the callback returning a promise that fails after the timeout with a ' +
-           'sychronous response', function () {
+           'synchronous response', function () {
           let dispatchResponse;
           const requestPayload = this.requestPayload;
           const timeout = this.adapter.syncResponseTimeout;

--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -789,7 +789,7 @@ type ViewSubmissionHandler = (payload: any) => any | Promise<any> | undefined;
  *
  * TODO: describe the payload and return values more specifically?
  */
-type ViewClosedHandler = (payload: any) => any | Promise<any> | undefined;
+type ViewClosedHandler = (payload: any) => void;
 
 type Callback = ActionHandler | OptionsHandler | ViewSubmissionHandler | ViewClosedHandler;
 

--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -452,10 +452,15 @@ export class SlackMessageAdapter {
     return this.callbacks.find(([constraints]) => {
       // if the callback ID constraint is specified, only continue if it matches
       if (!isFalsy(constraints.callbackId)) {
-        if (isString(constraints.callbackId) && payload.callback_id !== constraints.callbackId) {
+        // The callback ID is located at a different path in the payload for view submission and view closed
+        const callbackId = (
+          constraints.handlerType === StoredConstraintsType.ViewSubmission ||
+          constraints.handlerType === StoredConstraintsType.ViewClosed
+        ) ? payload.view.callback_id : payload.callback_id;
+        if (isString(constraints.callbackId) && callbackId !== constraints.callbackId) {
           return false;
         }
-        if (isRegExp(constraints.callbackId) && !(constraints.callbackId as RegExp).test(payload.callback_id)) {
+        if (isRegExp(constraints.callbackId) && !(constraints.callbackId as RegExp).test(callbackId)) {
           return false;
         }
       }

--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -80,7 +80,7 @@ function validateOptionsConstraints(optionsConstraints: OptionsConstraints): Err
 }
 
 /**
- * Validates properties fo a matching constraints object specific to registering a view submission or view closed
+ * Validates properties of a matching constraints object specific to registering a view submission or view closed
  * request
  * @param viewConstraints - object describing the constraints on a view submission or view closed handler
  * @returns `false` represents successful validation, an error represents failure and describes why validation failed.
@@ -308,7 +308,19 @@ export class SlackMessageAdapter {
   }
 
   /**
-   * Add a handler for a view submission
+   * Add a handler for view submission.
+   *
+   * The value returned from the `callback` determines the response sent back to Slack. The handler can return a plain
+   * object with a `response_action` property to dismiss the modal, push a view into the modal, display validation
+   * errors, or update the view. Alternatively, the handler can return a Promise for this kind of object, which resolves
+   * before `syncResponseTimeout` or `lateResponseFallbackEnabled: false`, to perform the same response actions. If the
+   * Promise resolves afterwards or `lateResponseFallbackEnabled: true` then the modal will be dismissed. If the handler
+   * returns `undefined` the modal will be dismissed.
+   *
+   * @param matchingConstraints - the callback ID (as a string or RegExp) or an object describing the constraints to
+   *   match view submissions for the handler.
+   * @param callback - the function to run when an view submission is matched
+   * @returns this instance (for chaining)
    */
   public viewSubmission(matchingConstraints: string | RegExp | ViewConstraints, callback: ViewSubmissionHandler): this {
     const viewConstraints = formatMatchingConstraints(matchingConstraints);
@@ -325,7 +337,12 @@ export class SlackMessageAdapter {
   }
 
   /**
-   * Add a handler for a view submission
+   * Add a handler for view closed interaction. The handler should not return a value.
+   *
+   * @param matchingConstraints - the callback ID (as a string or RegExp) or an object describing the constraints to
+   *   match view closed interactions for the handler.
+   * @param callback - the function to run when an view closed interaction is matched
+   * @returns this instance (for chaining)
    */
   public viewClosed(matchingConstraints: string | RegExp | ViewConstraints, callback: ViewClosedHandler): this {
     const viewConstraints = formatMatchingConstraints(matchingConstraints);
@@ -680,8 +697,19 @@ export interface OptionsConstraints {
  * Constraints on when to call a view submission or view closed handler.
  */
 export interface ViewConstraints {
+  /**
+   * A string or RegExp to match against the `callback_id`
+   */
   callbackId?: string | RegExp;
+
+  /**
+   * A string to match against the `external_id`
+   */
   externalId?: string;
+
+  /**
+   * A string to match against the `view_id`
+   */
   viewId?: string;
 }
 


### PR DESCRIPTION
###  Summary

Implements view submission handling as described in #288 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
