### PR TITLE
Add admin.inviteRequests.* APIs

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -896,6 +896,63 @@ describe('WebClient', function () {
         });
   });
 
+  describe('has all admin.inviteRequests.* APIs', function () {
+    function verify(runApiCall, methodName, expectedBody, done) {
+      const scope = nock('https://slack.com')
+        .post(`/api/${methodName}`)
+        .reply(200, function (_uri, body) {
+          return { ok: true, body: body };
+        });
+      runApiCall
+        .then((res) => {
+          assert.equal(res.body, expectedBody);
+          scope.done();
+          done();
+        });
+    }
+    const client = new WebClient(token);
+
+    it('can call admin.inviteRequests.approve', function (done) {
+      verify(
+        client.admin.inviteRequests.approve({ team_id: 'T123', invite_request_id: 'I123' }),
+        'admin.inviteRequests.approve',
+        'token=xoxb-faketoken&team_id=T123&invite_request_id=I123',
+        done,
+      );
+    });
+    it('can call admin.inviteRequests.deny', function (done) {
+      verify(
+        client.admin.inviteRequests.deny({ team_id: 'T123', invite_request_id: 'I123' }),
+        'admin.inviteRequests.deny',
+        'token=xoxb-faketoken&team_id=T123&invite_request_id=I123',
+        done
+      );
+    });
+    it('can call admin.inviteRequests.list', function (done) {
+      verify(
+        client.admin.inviteRequests.list({ team_id: 'T123', limit: 10, cursor: 'position' }),
+        'admin.inviteRequests.list',
+        'token=xoxb-faketoken&team_id=T123&limit=10&cursor=position',
+        done
+      );
+    });
+    it('can call admin.inviteRequests.approved.list', function (done) {
+      verify(
+        client.admin.inviteRequests.approved.list({ team_id: 'T123', limit: 10, cursor: 'position' }),
+        'admin.inviteRequests.approved.list',
+        'token=xoxb-faketoken&team_id=T123&limit=10&cursor=position',
+        done
+      );
+    });
+    it('can call admin.inviteRequests.denied.list', function (done) {
+      verify(
+        client.admin.inviteRequests.denied.list({ team_id: 'T123', limit: 10, cursor: 'position' }),
+        'admin.inviteRequests.denied.list',
+        'token=xoxb-faketoken&team_id=T123&limit=10&cursor=position',
+        done
+      );
+    });
+  });
 
   afterEach(function () {
     nock.cleanAll();

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -281,6 +281,22 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       },
       restrict: (this.apiCall.bind(this, 'admin.apps.restrict')) as Method<methods.AdminAppsRestrictArguments>,
     },
+    inviteRequests: {
+      approve: (this.apiCall.bind(
+        this, 'admin.inviteRequests.approve')) as Method<methods.AdminInviteRequestsApproveArguments>,
+      deny: (this.apiCall.bind(
+        this, 'admin.inviteRequests.deny')) as Method<methods.AdminInviteRequestsDenyArguments>,
+      list: (this.apiCall.bind(
+        this, 'admin.inviteRequests.list')) as Method<methods.AdminInviteRequestsListArguments>,
+      approved: {
+        list: (this.apiCall.bind(
+          this, 'admin.inviteRequests.approved.list')) as Method<methods.AdminInviteRequestsApprovedListArguments>,
+      },
+      denied: {
+        list: (this.apiCall.bind(
+          this, 'admin.inviteRequests.denied.list')) as Method<methods.AdminInviteRequestsDeniedListArguments>,
+      },
+    },
     teams: {
       admins: {
         list: (this.apiCall.bind(this, 'admin.teams.admins.list')) as Method<methods.AdminTeamsAdminsListArguments>,

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -70,6 +70,28 @@ export interface AdminAppsRestrictArguments extends WebAPICallOptions, TokenOver
   request_id?: string;
   team_id?: string;
 }
+export interface AdminInviteRequestsApproveArguments
+  extends WebAPICallOptions, TokenOverridable {
+  invite_request_id: string;
+  team_id: string;
+}
+export interface AdminInviteRequestsDenyArguments
+  extends WebAPICallOptions, TokenOverridable {
+  invite_request_id: string;
+  team_id: string;
+}
+export interface AdminInviteRequestsListArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+export interface AdminInviteRequestsApprovedListArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+export interface AdminInviteRequestsDeniedListArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
 export interface AdminTeamsAdminsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
 }


### PR DESCRIPTION
###  Summary

This pull request adds the following APIs to the SDK. These endpoints are recently added.

* https://api.slack.com/methods/admin.inviteRequests.approve
* https://api.slack.com/methods/admin.inviteRequests.deny
* https://api.slack.com/methods/admin.inviteRequests.list
* https://api.slack.com/methods/admin.inviteRequests.approved.list
* https://api.slack.com/methods/admin.inviteRequests.denied.list

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
