### PR TITLE
Fix failing typecheck when esModuleInterop is false

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,7 +10,11 @@
     "test:mocha": "mocha proxy-test.js"
   },
   "dependencies": {
+    "@slack/events-api": "^2.3.0",
+    "@slack/interactive-messages": "^1.4.0",
+    "@slack/rtm-api": "^5.0.3",
     "@slack/web-api": "^5.0.0",
+    "@slack/webhook": "^5.0.2",
     "@types/node": "^8.10.43"
   },
   "devDependencies": {

--- a/integration-tests/types/import-all.ts
+++ b/integration-tests/types/import-all.ts
@@ -1,0 +1,11 @@
+import { WebClient } from '@slack/web-api';
+import { RTMClient } from '@slack/rtm-api';
+import { IncomingWebhook } from '@slack/webhook';
+import { createEventAdapter } from '@slack/events-api';
+import { createMessageAdapter } from '@slack/interactive-messages';
+
+new WebClient();
+new RTMClient('xoxb-dummy-token');
+new IncomingWebhook('https://example.com');
+createEventAdapter('dummy-signing-secret');
+createMessageAdapter('dummy-signing-secret');


### PR DESCRIPTION
###  Summary

This is a draft PR that is a starting point for fixing issue #872. I've added a test to the integration tests which imports all the user-facing packages of the SDK under a `tsconfig.json` which does not set `esModuleInterop` to true (so it's `false`). This test is currently failing with the following message:

```
Error: Errors in typescript@next for external dependencies:
../../packages/events-api/dist/adapter.d.ts(2,8): error TS1192: Module '"events"' has no default export.
../../packages/events-api/dist/adapter.d.ts(3,8): error TS1192: Module '"http"' has no default export.
../../packages/events-api/dist/adapter.d.ts(3,16): error TS2305: Module '"http"' has no exported member 'RequestListener'.
../../packages/interactive-messages/dist/adapter.d.ts(2,8): error TS1192: Module '"http"' has no default export.
../../packages/interactive-messages/dist/adapter.d.ts(2,16): error TS2305: Module '"http"' has no exported member 'RequestListener'.

    at /Users/ankur/Developer/node-slack-sdk/integration-tests/node_modules/dtslint/bin/index.js:189:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/ankur/Developer/node-slack-sdk/integration-tests/node_modules/dtslint/bin/index.js:5:58)
```

Once the issue is fixed, these tests should pass.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
