### PR TITLE
Add horizontal rule before web_api's Logging section docs for readability

### DIFF
--- a/docs/_packages/web_api.md
+++ b/docs/_packages/web_api.md
@@ -334,6 +334,8 @@ const vid = 'YOUR_VIEW_ID';
 ```
 </details>
 
+---
+
 ### Logging
 
 The `WebClient` will log interesting information to the console by default. You can use the `logLevel` to decide how


### PR DESCRIPTION
###  Summary

This PR simply adds a horizontal rule between Opening modals and Logging section under web_api docs. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
