### PR TITLE
Fix #916 Logger given to WebClient is destructively modified

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -65,6 +65,11 @@ describe('WebClient', function () {
       const capturedOutput = this.capture.getCapturedText();
       assert.isEmpty(capturedOutput);
     });
+    it('never modifies the original logger', function () {
+      new WebClient(token, { logger: this.logger });
+      // Calling #setName of the given logger is destructive
+      assert.isFalse(this.logger.setName.called);
+    });
     afterEach(function () {
       this.capture.stopCapture();
     });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -104,7 +104,14 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     this.rejectRateLimitedCalls = rejectRateLimitedCalls;
 
     // Logging
-    this.logger = getLogger(WebClient.loggerName, logLevel, logger);
+    if (typeof logger !== 'undefined') {
+      this.logger = logger;
+      if (typeof logLevel !== 'undefined') {
+        this.logger.debug('The logLevel given to WebClient was ignored as you also gave logger');
+      }
+    } else {
+      this.logger = getLogger(WebClient.loggerName, logLevel, logger);
+    }
 
     this.axios = axios.create({
       baseURL: slackApiUrl,


### PR DESCRIPTION
###  Summary

This pull request fixes #916. Refer to the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
