### PR TITLE
Add `types` field to `package.json`

### DIFF
--- a/packages/events-api/package.json
+++ b/packages/events-api/package.json
@@ -17,6 +17,7 @@
     "event-emitter"
   ],
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "slack-verify": "dist/verify.js"
   },


### PR DESCRIPTION
###  Summary

This allows TypeScript & IDEs to find types easier, and understand how to structure imports (currently, WebStorm will autoimport from `@slack/events-api/dist`)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
