### PR TITLE
Add `types` field to `package.json`

### DIFF
--- a/packages/interactive-messages/package.json
+++ b/packages/interactive-messages/package.json
@@ -24,6 +24,7 @@
     "request-signing"
   ],
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*"
   ],


### PR DESCRIPTION
###  Summary

This allows TypeScript & IDEs to find types easier, and understand how to structure imports (currently, WebStorm will autoimport from `@slack/interactive-messages/dist`)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
