### PR TITLE
Fix wrong type import in interactive-message

### DIFF
--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -1,5 +1,5 @@
 /* tslint:disable import-name */
-import http, { RequestListener } from 'http';
+import http, { IncomingMessage, ServerResponse } from 'http';
 import axios, { AxiosInstance } from 'axios';
 import isString from 'lodash.isstring';
 import isRegExp from 'lodash.isregexp';
@@ -230,7 +230,7 @@ export class SlackMessageAdapter {
   /**
    * Create a request listener function that handles HTTP requests, verifies requests and dispatches responses
    */
-  public requestListener(): RequestListener {
+  public requestListener(): (req: IncomingMessage, res: ServerResponse) => void {
     return createHTTPHandler(this);
   }
 


### PR DESCRIPTION
###  Summary

There is an imported type from 'http' that doesn't exist. The changes will remove the non-existing import and replaces with the proper types.
Fixes https://github.com/slackapi/node-slack-sdk/issues/872

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).