### PR TITLE
Fix a code error in events-api documentation

### DIFF
--- a/docs/_packages/events_api.md
+++ b/docs/_packages/events_api.md
@@ -366,7 +366,7 @@ slackEvents.on('reaction_added', (event, respond) => {
   console.log('Reaction event received');
   // Normal success
   respond();
-})
+});
 
 (async () => {
   const server = await slackEvents.start(port);


### PR DESCRIPTION
###  Summary

This pull request fixes a code sample error in `@slack/events-api` documentation.

```
(async () => {
^

TypeError: slackEvents.on(...) is not a function
```

Just in case, I assigned @aoberoi as he is the original author. But I believe this one is safe enough. I may merge this within a few days.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
