### PR TITLE
added missing admin apis. Issue #941

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -283,10 +283,21 @@ export class WebClient extends EventEmitter<WebClientEvent> {
   public readonly admin = {
     apps: {
       approve: (this.apiCall.bind(this, 'admin.apps.approve')) as Method<methods.AdminAppsApproveArguments>,
+      approved: {
+        list: (this.apiCall.bind(this, 'admin.apps.approved.list')) as Method<methods.AdminAppsApprovedListArguments>,
+      },
       requests: {
         list: (this.apiCall.bind(this, 'admin.apps.requests.list')) as Method<methods.AdminAppsRequestsListArguments>,
       },
       restrict: (this.apiCall.bind(this, 'admin.apps.restrict')) as Method<methods.AdminAppsRestrictArguments>,
+      restricted: {
+        list:
+          (this.apiCall.bind(this, 'admin.apps.restricted.list')) as Method<methods.AdminAppsRestrictedListArguments>,
+      },
+    },
+    conversations: {
+      setTeams: (this.apiCall.bind(
+          this, 'admin.conversations.setTeams')) as Method<methods.AdminConversationsSetTeamsArguments>,
     },
     inviteRequests: {
       approve: (this.apiCall.bind(
@@ -308,10 +319,24 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       admins: {
         list: (this.apiCall.bind(this, 'admin.teams.admins.list')) as Method<methods.AdminTeamsAdminsListArguments>,
       },
+      create: (this.apiCall.bind(this, 'admin.teams.create')) as Method<methods.AdminTeamsCreateArguments>,
+      list: (this.apiCall.bind(this, 'admin.teams.list')) as Method<methods.AdminTeamsListArguments>,
       owners: {
         list: (this.apiCall.bind(this, 'admin.teams.owners.list')) as Method<methods.AdminTeamsOwnersListArguments>,
       },
-      create: (this.apiCall.bind(this, 'admin.teams.create')) as Method<methods.AdminTeamsCreateArguments>,
+      settings: {
+        info: (this.apiCall.bind(this, 'admin.teams.settings.info')) as Method<methods.AdminTeamsSettingsInfoArguments>,
+        setDefaultChannels: (this.apiCall.bind(this, 'admin.teams.settings.setDefaultChannels')
+          ) as Method<methods.AdminTeamsSettingsSetDefaultChannelsArguments>,
+        setDescription: (this.apiCall.bind(
+          this, 'admin.teams.settings.setDescription')) as Method<methods.AdminTeamsSettingsSetDescriptionArguments>,
+        setDiscoverability: (this.apiCall.bind(this, 'admin.teams.settings.setDiscoverability')
+          ) as Method<methods.AdminTeamsSettingsSetDiscoverabilityArguments>,
+        setIcon: (this.apiCall.bind(
+          this, 'admin.teams.settings.setIcon')) as Method<methods.AdminTeamsSettingseSetIconArguments>,
+        setName: (this.apiCall.bind(
+          this, 'admin.teams.settings.setName')) as Method<methods.AdminTeamsSettingsSetNameArguments>,
+      },
     },
     users: {
       session: {
@@ -320,8 +345,11 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       },
       assign: (this.apiCall.bind(this, 'admin.users.assign')) as Method<methods.AdminUsersAssignArguments>,
       invite: (this.apiCall.bind(this, 'admin.users.invite')) as Method<methods.AdminUsersInviteArguments>,
+      list: (this.apiCall.bind(this, 'admin.users.list')) as Method<methods.AdminUsersListArguments>,
       remove: (this.apiCall.bind(this, 'admin.users.remove')) as Method<methods.AdminUsersRemoveArguments>,
       setAdmin: (this.apiCall.bind(this, 'admin.users.setAdmin')) as Method<methods.AdminUsersSetAdminArguments>,
+      setExpiration:
+        (this.apiCall.bind(this, 'admin.users.setExpiration')) as Method<methods.AdminUsersSetExpirationArguments>,
       setOwner: (this.apiCall.bind(this, 'admin.users.setOwner')) as Method<methods.AdminUsersSetOwnerArguments>,
       setRegular: (this.apiCall.bind(this, 'admin.users.setRegular')) as Method<methods.AdminUsersSetRegularArguments>,
     },

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -62,47 +62,94 @@ export interface AdminAppsApproveArguments extends WebAPICallOptions, TokenOverr
   request_id?: string;
   team_id?: string;
 }
+export interface AdminAppsApprovedListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id?: string;
+  enterprise_id?: string;
+}
+cursorPaginationEnabledMethods.add('admin.apps.approved.list');
 export interface AdminAppsRequestsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id?: string;
 }
+cursorPaginationEnabledMethods.add('admin.apps.requests.list');
 export interface AdminAppsRestrictArguments extends WebAPICallOptions, TokenOverridable {
   app_id?: string;
   request_id?: string;
   team_id?: string;
+}
+export interface AdminAppsRestrictedListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id?: string;
+  enterprise_id?: string;
+}
+cursorPaginationEnabledMethods.add('admin.apps.restricted.list');
+export interface AdminConversationsSetTeamsArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  team_id?: string;
+  target_team_ids?: string[];
+  org_channel?: boolean;
 }
 export interface AdminInviteRequestsApproveArguments
   extends WebAPICallOptions, TokenOverridable {
   invite_request_id: string;
   team_id: string;
 }
+export interface AdminInviteRequestsApprovedListArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+cursorPaginationEnabledMethods.add('admin.inviteRequests.approved.list');
 export interface AdminInviteRequestsDenyArguments
   extends WebAPICallOptions, TokenOverridable {
   invite_request_id: string;
-  team_id: string;
-}
-export interface AdminInviteRequestsListArguments
-  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
-  team_id: string;
-}
-export interface AdminInviteRequestsApprovedListArguments
-  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
 }
 export interface AdminInviteRequestsDeniedListArguments
   extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
 }
+cursorPaginationEnabledMethods.add('admin.inviteRequests.denied.list');
+export interface AdminInviteRequestsListArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+cursorPaginationEnabledMethods.add('admin.inviteRequests.list');
 export interface AdminTeamsAdminsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
 }
+cursorPaginationEnabledMethods.add('admin.teams.admins.list');
 export interface AdminTeamsCreateArguments extends WebAPICallOptions, TokenOverridable {
   team_domain: string;
   team_name: string;
   team_description?: string;
   team_discoverability?: string;
 }
+export interface AdminTeamsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {}
+cursorPaginationEnabledMethods.add('admin.teams.list');
 export interface AdminTeamsOwnersListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
+}
+cursorPaginationEnabledMethods.add('admin.teams.owners.list');
+export interface AdminTeamsSettingsInfoArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+}
+export interface AdminTeamsSettingsSetDefaultChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  channel_ids: string[];
+}
+export interface AdminTeamsSettingsSetDescriptionArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  description: string;
+}
+export interface AdminTeamsSettingsSetDiscoverabilityArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  discoverability: 'open' | 'invite_only' | 'closed' | 'unlisted';
+}
+export interface AdminTeamsSettingseSetIconArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  image_url: string;
+}
+export interface AdminTeamsSettingsSetNameArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  name: string;
 }
 export interface AdminUsersAssignArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
@@ -121,6 +168,10 @@ export interface AdminUsersInviteArguments extends WebAPICallOptions, TokenOverr
   real_name?: string;
   resend?: boolean;
 }
+export interface AdminUsersListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  team_id: string;
+}
+cursorPaginationEnabledMethods.add('admin.users.list');
 export interface AdminUsersRemoveArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
   user_id: string;
@@ -128,6 +179,11 @@ export interface AdminUsersRemoveArguments extends WebAPICallOptions, TokenOverr
 export interface AdminUsersSetAdminArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
   user_id: string;
+}
+export interface AdminUsersSetExpirationArguments extends WebAPICallOptions, TokenOverridable {
+  team_id: string;
+  user_id: string;
+  expiration_ts: number;
 }
 export interface AdminUsersSetOwnerArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
@@ -295,6 +351,7 @@ export interface ChatScheduledMessagesListArguments extends WebAPICallOptions, T
   latest: number;
   oldest: number;
 }
+cursorPaginationEnabledMethods.add('chat.scheduledMessages.list');
 export interface ChatUnfurlArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
   ts: string;


### PR DESCRIPTION
###  Summary

This pull request fixes #941 by adding  the following apis:
* `admin.apps.approved.list`
* `admin.apps.restricted.list`
*  `admin.conversations.setTeams`
* `admin.teams.create`
* `admin.teams.list`
* `admin.teams.settings.info`
*  `admin.teams.settings.setDefaultChannels`
* `admin.teams.settings.setDescription`
* `admin.teams.settings.setDiscoverability`
* `admin.teams.settings.setIcon`
* `admin.teams.settings.setName`
* `admin.users.list`
* `admin.users.setExpiration`

Also added `cursorPaginationEnabledMethods.add` for a few methods that were missing it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
