### PR TITLE
Updated documentation for Granular Bot Permissions

### DIFF
--- a/docs/_main/getting_started.md
+++ b/docs/_main/getting_started.md
@@ -10,7 +10,7 @@ never used the Slack APIs before, you're in the right place. Welcome, and let's 
 
 ## Create a Slack app
 
-The first step is to [register a new app](https://api.slack.com/apps/new) with Slack at the API website. Give your app a
+The first step is to [create a new app](https://api.slack.com/apps?new_granular_bot_app=1) with Slack at the API website. Give your app a
 fun name and choose a Development Slack Workspace. We recommend using a workspace where you aren't going to disrupt real
 work getting done -- you can create a new one for free. After you create an app, you'll be greeted with some basic information.
 
@@ -21,20 +21,20 @@ status. Before we can call any methods, we need to configure our new app with th
 
 ## Getting a token to use the Web API
 
-Navigate to "OAuth & Permissions" and scroll down to the section for scopes. Slack describes the various permissions
+Navigate to **OAuth & Permissions** and scroll down to the section for scopes. Slack describes the various permissions
 your app could obtain from an installing bot as **scopes**. There are [over 80 scopes](https://api.slack.com/scopes)!
 Some are broad and authorize your app to access lots of data, while others are very specific and let your app touch just
 a tiny sliver. Your users (and their IT admins) will have opinions about which data your app should access, and only
 agree to install the app if the data permissions seem reasonable, so we recommend finding the scope(s) with the least
 amount of privilege for your app's needs. In this guide we will use the Web API to post a message. The scope required
-for this is called `chat:write`. Use the dropdown or start typing its name to select and add the scope, then click
+for this is called [`chat:write`](https://api.slack.com/scopes/chat:write). Use the dropdown under the "Bot Token Scopes" header and add the scope, then click
 "Save Changes".
 
-Now our app has described which scope it desires in the workspace, but we haven't added it to your workspace yet. To do so, we first need to create a bot user. Scroll down to Bot Users and click "Add a Bot User". Add a display name and username for your bot. Next, scroll up to Install App and click "Install App to Workspace". You'll be taken to the app installation page. This page is where you grant the bot user permission to install the app in your development workspace with specific capabilities.
+Now our app has described which scope it desires in the workspace, but we haven't added it to your workspace yet. To install your app, scroll up to the top of the page and click the green **Install App to Workspace** button. You'll be taken to the app installation page. This page is where you grant the bot user permission to install the app in your development workspace with specific capabilities.
 
 Go ahead and click "Allow". This will install the app on the workspace and generate the token we'll need.
 
-When you return to the "OAuth & Permissions" page copy the "Bot User OAuth Access Token" (it should begin with `xoxb`). Treat
+When you return to the **OAuth & Permissions** page copy the **Bot User OAuth Access Token** (it should begin with `xoxb`). Treat
 this value like a password and keep it safe. The Web API uses tokens to to authenticate the requests your app makes. In
 a later step, you'll be asked to use this token in your code.
 
@@ -114,8 +114,8 @@ const currentTime = new Date().toTimeString();
 })();
 ```
 
-This code creates an instance of the `WebClient`, which uses an access token to call Web API methods. The program reads
-the app's access token from an environment variable. Then this program will post a message in the `#general` channel,
+This code creates an instance of the `WebClient`, which uses an access token to call Web API methods. The app reads
+the access token from an environment variable. Then this app will post a message in the `#general` channel,
 assuming you have invited your bot to that channel.
 
 Run the program. The output should look like the following:

--- a/docs/_packages/rtm_api.md
+++ b/docs/_packages/rtm_api.md
@@ -12,7 +12,7 @@ order: 4
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://api.slack.com/rtm). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
-**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](#TODO). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
+**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](https://api.slack.com/apps?new_classic_app=1). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
 
 ## Installation
 

--- a/docs/_packages/rtm_api.md
+++ b/docs/_packages/rtm_api.md
@@ -12,6 +12,8 @@ order: 4
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://api.slack.com/rtm). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
+**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](#TODO). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
+
 ## Installation
 
 ```shell

--- a/docs/_packages/web_api.md
+++ b/docs/_packages/web_api.md
@@ -651,8 +651,8 @@ const web = new WebClient(token, options);
 ### Exchange an OAuth grant for a token
 
 There's one method in the Slack Web API that doesn't requires a token, because its the method that gets a token! This
-method is called [`oauth.access`](https://api.slack.com/methods/oauth.access). It's used as part of the [OAuth
-2.0](https://api.slack.com/docs/oauth) process that users initiate when installing your app into a workspace. In the
+method is called [`oauth.v2.access`](https://api.slack.com/methods/oauth.v2.access). It's used as part of the [OAuth
+2.0](https://api.slack.com/authentication/oauth-v2) process that users initiate when installing your app into a workspace. In the
 last step of this process, your app has received an authorization grant called `code` which it needs to exchange for
 an access token (`token`). You can use an instance of the `WebClient` that has no token to easily complete this
 exchange.
@@ -667,7 +667,7 @@ const clientSecret = process.env.SLACK_CLIENT_SECRET;
 // Not shown: received an authorization grant called `code`.
 (async () => {
   // Create a client instance just to make this single call, and use it for the exchange
-  const result = await (new WebClient()).oauth.access({
+  const result = await (new WebClient()).oauth.v2.access({
     client_id: clientId,
     client_secret: clientSecret,
     code

--- a/docs/_packages/webhook.md
+++ b/docs/_packages/webhook.md
@@ -30,7 +30,7 @@ $ npm install @slack/webhook
 The package exports a `IncomingWebhook` class. You'll need to initialize it with the URL you received from Slack.
 
 The URL can come from installation in your development workspace, which is shown right in the app configuration pages.
-Or, the URL could be in the response from [`oauth.access`](https://api.slack.com/methods/oauth.access) when the app is
+Or, the URL could be in the response from [`oauth.v2.access`](https://api.slack.com/methods/oauth.v2.access) when the app is
 distributed and installed into another workspace.
 
 ```javascript

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -9,6 +9,8 @@
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://api.slack.com/rtm). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
+**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](#TODO). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
+
 ## Installation
 
 ```shell

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -9,7 +9,7 @@
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://api.slack.com/rtm). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
-**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](#TODO). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
+**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](https://api.slack.com/apps?new_classic_app=1). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
 
 ## Installation
 

--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -28,7 +28,7 @@ $ npm install @slack/webhook
 The package exports a `IncomingWebhook` class. You'll need to initialize it with the URL you received from Slack.
 
 The URL can come from installation in your development workspace, which is shown right in the app configuration pages.
-Or, the URL could be in the response from [`oauth.access`](https://api.slack.com/methods/oauth.access) when the app is
+Or, the URL could be in the response from [`oauth.v2.access`](https://api.slack.com/methods/oauth.v2.access) when the app is
 distributed and installed into another workspace.
 
 ```javascript


### PR DESCRIPTION
###  Summary

Updating the documentation in preparation for granular bot permissions. Also added a warning for RTM users not to update. 

Related to #938 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
