### PR TITLE
surface up error message from platform api calls

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -86,7 +86,11 @@ describe('WebClient', function () {
           .post(/api/)
           .reply(200, { ok: true,
             response_metadata: {
-              warnings: ['testWarning1', 'testWarning2']
+              warnings: ['testWarning1', 'testWarning2'],
+              messages: [
+                "[ERROR] unsupported type: sections [json-pointer:/blocks/0/type]", 
+                "[WARN] A Content-Type HTTP header was presented but did not declare a charset, such as a 'utf-8'"
+              ]
             }
           });
       });
@@ -99,7 +103,7 @@ describe('WebClient', function () {
         });
       });
 
-      it('should send warnings to logs', function() {
+      it('should send warnings to logs from both response_metadata.warnings & response_metadata.messages', function() {
         const logger = {
           debug: sinon.spy(),
           info: sinon.spy(),
@@ -111,7 +115,23 @@ describe('WebClient', function () {
         const warnClient = new WebClient(token, { logLevel: LogLevel.WARN, logger });
         return warnClient.apiCall('method')
           .then(() => {
-            assert.isTrue(logger.warn.calledTwice);
+            assert.isTrue(logger.warn.calledThrice);
+          });
+      });
+
+      it('should send response_metadata.messages errors to logs', function() {
+        const logger = {
+          debug: sinon.spy(),
+          info: sinon.spy(),
+          warn: sinon.spy(),
+          error: sinon.spy(),
+          setLevel: sinon.spy(),
+          setName: sinon.spy(),
+        };
+        const errorClient = new WebClient(token, { logLevel: LogLevel.ERROR, logger });
+        return errorClient.apiCall('method')
+          .then(() => {
+            assert.isTrue(logger.error.calledOnce);
           });
       });
     });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -162,6 +162,26 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       result.response_metadata.warnings.forEach(this.logger.warn.bind(this.logger));
     }
 
+    // log warnings and errors in response metadata messages
+    // related to https://api.slack.com/changelog/2016-09-28-response-metadata-is-on-the-way
+    if (result.response_metadata !== undefined && result.response_metadata.messages !== undefined) {
+      result.response_metadata.messages.forEach((msg) => {
+        const errReg: RegExp = /\[ERROR\](.*)/;
+        const warnReg: RegExp = /\[WARN\](.*)/;
+        if (errReg.test(msg)) {
+          const errMatch = msg.match(errReg);
+          if (errMatch != null) {
+            this.logger.error(errMatch[1].trim());
+          }
+        } else if (warnReg.test(msg)) {
+          const warnMatch = msg.match(warnReg);
+          if (warnMatch != null) {
+            this.logger.warn(warnMatch[1].trim());
+          }
+        }
+      });
+    }
+
     if (!result.ok) {
       throw platformErrorFromResult(result as (WebAPICallResult & { error: string; }));
     }


### PR DESCRIPTION
###  Summary

Issue number: #945 

On failed platform api calls which contain blocks, we don't properly surface up the error message from the api. This PR solves that. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
