### PR TITLE
Fix #951 TypeScript build failure related to EventEmitter types

### DIFF
--- a/packages/events-api/package.json
+++ b/packages/events-api/package.json
@@ -46,7 +46,7 @@
     "@types/debug": "^4.1.4",
     "@types/express": "^4.17.0",
     "@types/lodash.isstring": "^4.0.6",
-    "@types/node": ">=4.2.0",
+    "@types/node": ">=4.2.0 < 13",
     "@types/yargs": "^13.0.0",
     "debug": "^2.6.1",
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
###  Summary

This pull request fixes #951 that causes the CI build failures with the `master` branch and all pull requests. Refer to the link @aoberoi shared https://github.com/slackapi/node-slack-sdk/issues/951#issuecomment-580001914 to know the cause.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
