### PR TITLE
Fix type error with `for await (... of paginate)`

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -189,7 +189,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
    * @param shouldStop a predicate that is called with each page, and should return true when pagination can end.
    * @param reduce a callback that can be used to accumulate a value that the return promise is resolved to
    */
-  public paginate(method: string, options?: WebAPICallOptions): AsyncIterator<WebAPICallResult>;
+  public paginate(method: string, options?: WebAPICallOptions): AsyncIterableIterator<WebAPICallResult>;
   public paginate(
     method: string,
     options: WebAPICallOptions,
@@ -206,7 +206,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     options?: WebAPICallOptions,
     shouldStop?: PaginatePredicate,
     reduce?: PageReducer<A>,
-  ): (Promise<A> | AsyncIterator<WebAPICallResult>) {
+  ): (Promise<A> | AsyncIterableIterator<WebAPICallResult>) {
 
     if (!methods.cursorPaginationEnabledMethods.has(method)) {
       this.logger.warn(`paginate() called with method ${method}, which is not known to be cursor pagination enabled.`);


### PR DESCRIPTION
###  Summary

Writing `for await (const page of client.paginate("conversations.history", args)) {` produces below error:

```
Type 'AsyncIterator<WebAPICallResult, any, undefined>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.ts(2504)
```
In the function body (not the return type) AsyncIterableIterator is used and it has `[Symbol.asyncIterator]()`, this PR changes return type to it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
