### PR TITLE
Fix #964 Add types for checkboxes

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -211,6 +211,13 @@ export interface RadioButtons extends Action {
   confirm?: Confirm;
 }
 
+export interface Checkboxes extends Action {
+  type: 'checkboxes';
+  initial_options?: Option[];
+  options: Option[];
+  confirm?: Confirm;
+}
+
 export interface PlainTextInput extends Action {
   type: 'plain_text_input';
   placeholder?: PlainTextElement;
@@ -246,7 +253,7 @@ export interface ContextBlock extends Block {
 
 export interface ActionsBlock extends Block {
   type: 'actions';
-  elements: (Button | Overflow | Datepicker | Select | RadioButtons | Action)[];
+  elements: (Button | Overflow | Datepicker | Select | RadioButtons | Checkboxes | Action)[];
 }
 
 export interface DividerBlock extends Block {


### PR DESCRIPTION
###  Summary

This pull request fixes #964 by adding a type for the `checkboxes` type block element. The `radion_buttons` one already exists.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
