### PR TITLE
📝 add MrkdwnElement to text on Option

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,7 +67,7 @@ export interface MrkdwnElement {
 }
 
 export interface Option {
-  text: PlainTextElement;
+  text: PlainTextElement | MrkdwnElement;
   value?: string;
   url?: string;
   description?: PlainTextElement;


### PR DESCRIPTION
#  Summary

Resolves #973

Just adds MrkdwnElement as an option for text field in Option block, to match docs/behavior to enable mrkdwn for checkboxes and radio buttons.

https://api.slack.com/reference/block-kit/composition-objects#option 

> Overflow, select, and multi-select menus can only use plain_text objects, while radio buttons and checkboxes can use mrkdwn text objects.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
