### PR TITLE
Option text parameter now allows Markdown Element Type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,7 +67,7 @@ export interface MrkdwnElement {
 }
 
 export interface Option {
-  text: PlainTextElement;
+  text: PlainTextElement | MrkdwnElement ;
   value?: string;
   url?: string;
   description?: PlainTextElement;


### PR DESCRIPTION
###  Summary

Fixes #973.

Option text parameter supports markdown as well as plain text.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
