### PR TITLE
Fix #979 Support radio_buttons block element in input block for TypeScript users

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -275,7 +275,7 @@ export interface SectionBlock extends Block {
   type: 'section';
   text?: PlainTextElement | MrkdwnElement; // either this or fields must be defined
   fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
-  accessory?: Button | Overflow | Datepicker | Select | MultiSelect | Action | ImageElement;
+  accessory?: Button | Overflow | Datepicker | Select | MultiSelect | Action | ImageElement | RadioButtons;
 }
 
 export interface FileBlock extends Block {
@@ -289,7 +289,7 @@ export interface InputBlock extends Block {
   label: PlainTextElement;
   hint?: PlainTextElement;
   optional?: boolean;
-  element: Select | MultiSelect | Datepicker | PlainTextInput;
+  element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons;
 }
 
 export interface MessageAttachment {


### PR DESCRIPTION
###  Summary

This pull request fixes #979 by updating type definitions for Block Kit. The original report of this issue mentioned only input blocks but I also noticed the `radion_buttons` element is not available for section blocks yet.

To be clear, this issue affects only TypeScript users. It hasn't been a blocker for JavaScript users.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
