### PR TITLE
Fix #986 Missing code sample in interactive-messages docs

### DIFF
--- a/docs/_packages/interactive_messages.md
+++ b/docs/_packages/interactive_messages.md
@@ -620,9 +620,9 @@ const { createMessageAdapter } = require('@slack/interactive-messages');
 const slackSigningSecret = process.env.SLACK_SIGNING_SECRET;
 const port = process.env.PORT || 3000;
 
-// Turn late response fallback off
+// Adjust the timeout millis from 2500 (default) to 2800
 const slackInteractions = createMessageAdapter(slackSigningSecret, {
-  lateResponseFallbackEnabled: false,
+  syncResponseTimeout: 2800,
 });
 
 (async () => {


### PR DESCRIPTION
###  Summary

This pull request fixes #986 where a code snippet in the `interactive-message` package document is not demonstrating a good example.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
