### PR TITLE
Fix #993 Support checkboxes block element in input block for TypeScript users.

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -275,7 +275,7 @@ export interface SectionBlock extends Block {
   type: 'section';
   text?: PlainTextElement | MrkdwnElement; // either this or fields must be defined
   fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
-  accessory?: Button | Overflow | Datepicker | Select | MultiSelect | Action | ImageElement | RadioButtons;
+  accessory?: Button | Overflow | Datepicker | Select | MultiSelect | Action | ImageElement | RadioButtons | Checkboxes;
 }
 
 export interface FileBlock extends Block {
@@ -289,7 +289,7 @@ export interface InputBlock extends Block {
   label: PlainTextElement;
   hint?: PlainTextElement;
   optional?: boolean;
-  element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons;
+  element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons | Checkboxes;
 }
 
 export interface MessageAttachment {


### PR DESCRIPTION
###  Summary

This pull request fixes #993 by updating type definitions for Block Kit like #979. For instance, the checkboxes block element should be supported in input block. In addition, it should also be supported in section block. This provides additional definitions to support them.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
