### PR TITLE
Divided ViewUpdateArguments into 2 types

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -471,7 +471,8 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     open: (this.apiCall.bind(this, 'views.open')) as Method<methods.ViewsOpenArguments>,
     publish: (this.apiCall.bind(this, 'views.publish')) as Method<methods.ViewsPublishArguments>,
     push: (this.apiCall.bind(this, 'views.push')) as Method<methods.ViewsPushArguments>,
-    update: (this.apiCall.bind(this, 'views.update')) as Method<methods.ViewsUpdateArgumentsWithViewId | methods.ViewsUpdateArgumentsWithExternalId>,
+    update: (this.apiCall.bind(this, 'views.update')) as
+      Method<methods.ViewsUpdateArgumentsWithViewId | methods.ViewsUpdateArgumentsWithExternalId>,
   };
 
   /**

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -471,7 +471,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     open: (this.apiCall.bind(this, 'views.open')) as Method<methods.ViewsOpenArguments>,
     publish: (this.apiCall.bind(this, 'views.publish')) as Method<methods.ViewsPublishArguments>,
     push: (this.apiCall.bind(this, 'views.push')) as Method<methods.ViewsPushArguments>,
-    update: (this.apiCall.bind(this, 'views.update')) as Method<methods.ViewsUpdateArguments>,
+    update: (this.apiCall.bind(this, 'views.update')) as Method<methods.ViewsUpdateArgumentsWithViewId | methods.ViewsUpdateArgumentsWithExternalId>,
   };
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -940,10 +940,16 @@ export interface ViewsPublishArguments extends WebAPICallOptions, TokenOverridab
 }
 
 export interface ViewsUpdateArguments extends WebAPICallOptions, TokenOverridable {
-  view_id: string;
   view: View;
-  external_id?: string;
   hash?: string;
+}
+
+export interface ViewsUpdateArgumentsWithViewId extends ViewsUpdateArguments {
+  view_id: string;
+}
+
+export interface ViewsUpdateArgumentsWithExternalId extends ViewsUpdateArguments {
+  external_id: string;
 }
 
 export * from '@slack/types';


### PR DESCRIPTION
###  Summary

Divided ViewUpdateArguments into 2 types ViewsUpdateArgumentsWithViewId | ViewsUpdateArgumentsWithExternalId. This is a fix for #1002 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

# Challenges
I was not able to test this code yet. Lerna tests was giving me some error, If someone can help me with it?