### PR TITLE
Update OAuth examples

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -317,8 +317,8 @@ const installer = new InstallProvider({
 
 ### Examples
 
-*  [OAuth Express app](https://github.com/slackapi/node-slack-sdk/tree/master/examples/oauth-v1). This example uses [Keyv](https://github.com/lukechilds/keyv) library as an installation store.
-*  [classic Slack App](https://github.com/slackapi/node-slack-sdk/tree/master/examples/oauth-v2). This example uses the built-in installation store
+*  [OAuth Express app](https://github.com/slackapi/node-slack-sdk/tree/master/examples/oauth-v2). This example uses [Keyv](https://github.com/lukechilds/keyv) library as an installation store.
+*  [OAuth Express app for Classic Slack apps](https://github.com/slackapi/node-slack-sdk/tree/master/examples/oauth-v1). This example uses the built-in installation store.
 
 ---
 

--- a/examples/oauth-v1/README.md
+++ b/examples/oauth-v1/README.md
@@ -1,6 +1,6 @@
 # OAuth v1 Example
 
-This repo contains a sample app for doing OAuth with Slack for [Classic Slack apps](https://api.slack.com/authentication/quickstart). Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library. 
+This repo contains a sample app for doing OAuth with Slack for [Classic Slack apps](https://api.slack.com/bot-users). Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library. 
 
 Local development requires a public URL where Slack can send requests. In this guide, we'll be using [`ngrok`](https://ngrok.com/download). Checkout [this guide](https://api.slack.com/tutorials/tunneling-with-ngrok) for setting it up.
 


### PR DESCRIPTION
###  Summary

This PR...
- fixes the links in the OAuth package's examples at the bottom of the Jekyll page to link to the correct examples
- updates the link in the v1 example to go to a page specifically about Classic Slack apps

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
