### PR TITLE
improved oauth success user experience flow

### DIFF
--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -140,11 +140,15 @@ If you decide you need custom success or failure behaviors (ex: wanting to show 
 const callbackOptions = {
   success: (installation, metadata, req, res) => {
     // Do custom success logic here
-    res.send('successful!');
+    // tip: you can add javascript and css in the htmlResponse using the <script> and <style> tags
+    const htmlResponse = `<html><body>Success!</body></html>`
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(htmlResponse);
   }, 
   failure: (error, installOptions , req, res) => {
     // Do custom failure logic here
-    res.send('failure');
+    res.writeHead(500, { 'Content-Type': 'text/html' });
+    res.end('<html><body><h1>Oops, Something Went Wrong! Please Try Again or Contact the App Owner</h1></body></html>');
   }
 }
 app.get('/slack/oauth_redirect', (req, res) => {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -179,7 +179,7 @@ export class InstallProvider {
         parsedUrl = parseUrl(req.url, true);
         code = parsedUrl.query.code as string;
         state = parsedUrl.query.state as string;
-        if (state === undefined || code === undefined) {
+        if (state === undefined || state === '' || code === undefined) {
           throw new MissingStateError('redirect url is missing state or code query parameters');
         }
       } else {
@@ -507,8 +507,14 @@ function callbackSuccess(
     // redirect back to slack
     // Open in native app
     const redirectUrl = `slack://app?team=${installation.team.id}&id=${installation.appId}`;
-    res.writeHead(302, { Location: redirectUrl });
-    res.end();
+    const htmlResponse = `<html>
+    <meta http-equiv="refresh" content="0; URL=${redirectUrl}">
+    <body>
+      <h1>Success! Redirecting to the Slack App...</h1>
+      <button onClick="window.location = '${redirectUrl}'">Click here to redirect</button>
+    </body></html>`;
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(htmlResponse);
   } else {
     // Send a generic success page
     // TODO: make this page pretty?


### PR DESCRIPTION
###  Summary

Fix for issue #1010.

It will now show a generic success page which will automatically launch the redirect to the slack app. It also includes a button to launch the slack app incase users have javascript turned off or this click no during the original popup window. 

This is an improved flow vs the allow permissions tab staying open with a spinning button

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

<img width="613" alt="Screen Shot 2020-05-06 at 4 25 06 PM" src="https://user-images.githubusercontent.com/169536/81238163-30934880-8fb6-11ea-949e-4bb279d0e3e8.png">
