### PR TITLE
Add admin.usergroups.* APIs for Grid org admins

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -979,6 +979,66 @@ describe('WebClient', function () {
     });
   });
 
+  describe('has all admin.usergroups.* APIs', function () {
+    function verify(runApiCall, methodName, expectedBody, done) {
+      const scope = nock('https://slack.com')
+        .post(`/api/${methodName}`)
+        .reply(200, function (_uri, body) {
+          return { ok: true, body: body };
+        });
+
+      runApiCall
+        .then((res) => {
+          assert.equal(res.body, expectedBody);
+          scope.done();
+          done();
+        });
+    }
+    const client = new WebClient(token);
+
+    it('can call admin.usergroups.addChannels with a string "channe_ids"', function (done) {
+      verify(
+        client.admin.usergroups.addChannels({ team_id: 'T123', usergroup_id: 'S123', channel_ids: 'C123,C234' }),
+        'admin.usergroups.addChannels',
+        'token=xoxb-faketoken&team_id=T123&usergroup_id=S123&channel_ids=C123%2CC234',
+        done,
+      );
+    });
+
+    it('can call admin.usergroups.addChannels', function (done) {
+      verify(
+        client.admin.usergroups.addChannels({ team_id: 'T123', usergroup_id: 'S123', channel_ids: ['C123','C234'] }),
+        'admin.usergroups.addChannels',
+        'token=xoxb-faketoken&team_id=T123&usergroup_id=S123&channel_ids=%5B%22C123%22%2C%22C234%22%5D', // URL encoded "['C123','C234']"
+        done,
+      );
+    });
+    it('can call admin.usergroups.listChannels', function (done) {
+      verify(
+        client.admin.usergroups.listChannels({ team_id: 'T123', include_num_members: true, usergroup_id: 'S123' }),
+        'admin.usergroups.listChannels',
+        'token=xoxb-faketoken&team_id=T123&include_num_members=true&usergroup_id=S123',
+        done
+      );
+    });
+    it('can call admin.usergroups.removeChannels with a string "channe_ids"', function (done) {
+      verify(
+        client.admin.usergroups.removeChannels({ usergroup_id: 'S123', channel_ids: 'C123,C234' }),
+        'admin.usergroups.removeChannels',
+        'token=xoxb-faketoken&usergroup_id=S123&channel_ids=C123%2CC234',
+        done,
+      );
+    });
+
+    it('can call admin.usergroups.removeChannels', function (done) {
+      verify(
+        client.admin.usergroups.removeChannels({ usergroup_id: 'S123', channel_ids: ['C123','C234'] }),
+        'admin.usergroups.removeChannels',
+        'token=xoxb-faketoken&usergroup_id=S123&channel_ids=%5B%22C123%22%2C%22C234%22%5D', // URL encoded "['C123','C234']"
+        done,
+      );
+    });
+  });
   afterEach(function () {
     nock.cleanAll();
   });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -319,7 +319,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     },
     conversations: {
       setTeams: (this.apiCall.bind(
-          this, 'admin.conversations.setTeams')) as Method<methods.AdminConversationsSetTeamsArguments>,
+        this, 'admin.conversations.setTeams')) as Method<methods.AdminConversationsSetTeamsArguments>,
     },
     inviteRequests: {
       approve: (this.apiCall.bind(
@@ -348,17 +348,25 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       },
       settings: {
         info: (this.apiCall.bind(this, 'admin.teams.settings.info')) as Method<methods.AdminTeamsSettingsInfoArguments>,
-        setDefaultChannels: (this.apiCall.bind(this, 'admin.teams.settings.setDefaultChannels')
-          ) as Method<methods.AdminTeamsSettingsSetDefaultChannelsArguments>,
+        setDefaultChannels: (this.apiCall.bind(this, 'admin.teams.settings.setDefaultChannels')) as
+          Method<methods.AdminTeamsSettingsSetDefaultChannelsArguments>,
         setDescription: (this.apiCall.bind(
           this, 'admin.teams.settings.setDescription')) as Method<methods.AdminTeamsSettingsSetDescriptionArguments>,
-        setDiscoverability: (this.apiCall.bind(this, 'admin.teams.settings.setDiscoverability')
-          ) as Method<methods.AdminTeamsSettingsSetDiscoverabilityArguments>,
+        setDiscoverability: (this.apiCall.bind(this, 'admin.teams.settings.setDiscoverability')) as
+          Method<methods.AdminTeamsSettingsSetDiscoverabilityArguments>,
         setIcon: (this.apiCall.bind(
           this, 'admin.teams.settings.setIcon')) as Method<methods.AdminTeamsSettingseSetIconArguments>,
         setName: (this.apiCall.bind(
           this, 'admin.teams.settings.setName')) as Method<methods.AdminTeamsSettingsSetNameArguments>,
       },
+    },
+    usergroups: {
+      addChannels: (this.apiCall.bind(this, 'admin.usergroups.addChannels')) as
+        Method<methods.AdminUsergroupsAddChannelsArguments>,
+      listChannels: (this.apiCall.bind(this, 'admin.usergroups.listChannels')) as
+        Method<methods.AdminUsergroupsListChannelsArguments>,
+      removeChannels: (this.apiCall.bind(this, 'admin.usergroups.removeChannels')) as
+        Method<methods.AdminUsergroupsRemoveChannelsArguments>,
     },
     users: {
       session: {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -151,6 +151,20 @@ export interface AdminTeamsSettingsSetNameArguments extends WebAPICallOptions, T
   team_id: string;
   name: string;
 }
+export interface AdminUsergroupsAddChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  team_id: string;
+  channel_ids: string | string[];
+}
+export interface AdminUsergroupsListChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  include_num_members?: boolean;
+  team_id?: string;
+}
+export interface AdminUsergroupsRemoveChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  channel_ids: string | string[];
+}
 export interface AdminUsersAssignArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
   user_id: string;


### PR DESCRIPTION
###  Summary

This pull request adds admin.usergroups.* APIs for Grid org admins.

* admin.usergroups.addChannels
* admin.usergroups.listChannels
* admin.usergroups.removeChannels

Refer to https://api.slack.com/enterprise/managing#defaultchannels for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
