### PR TITLE
added org app support

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -165,15 +165,34 @@ const installer = new InstallProvider({
     // returns nothing
     storeInstallation: (installation) => {
       // replace myDB.set with your own database or OEM setter
-      myDB.set(installation.team.id, installation);
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+        // enterprise app, org wide installation
+        myDB.set(installation.enterprise.id, installation);
+      } else if (installation.team.id !== undefined) {
+        // non enterprise org app installation
+        myDB.set(installation.team.id, installation);
+      } else {
+        throw new Error('Failed saving installation data to installationStore');
+      }
       return;
     },
     // takes in an installQuery as an argument
     // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
     // returns installation object from database
-    fetchInstallation: (installQuery) => {
+    fetchInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      return myDB.get(installQuery.teamId);
+      let result = undefined;
+      // enterprise org app installation lookup
+      if (InstallQuery.enterpriseId !== undefined) {
+        result = await myDB.get(installQuery.enterpriseId);
+      }
+
+      // non enterprise org app lookup
+      if (result === undefined && InstallQuery.teamId !== undefined) {
+        result = await myDB.get(installQuery.teamId);
+      }
+
+      return result;
     },
   },
 });

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -92,7 +92,7 @@ installer.generateInstallUrl({
 
 ### Handling the OAuth redirect
 
-After the user approves the request to install your app (and grants access to the required permissions), Slack will redirect the user to your specified **redirect url**. You can either set the redirect url in the app’s **OAuth and Permissions** page or pass a `redirectUri` when calling `installProvider.generateInstallUrl`. Your HTTP server should handle requests to the redirect URL by calling the `installProvider.handleCallback()` method. The first two arguments (`req`, `res`) to `installProvider.handleCallback` are required. By default, if the installation is successful the user will be redirected back to your App Home in Slack (or shown a generic success page for classic Slack apps). If the installation is not successful the user will be shown an error page.
+After the user approves the request to install your app (and grants access to the required permissions), Slack will redirect the user to your specified **redirect url**. You can either set the redirect url in the app’s **OAuth and Permissions** page or pass a `redirectUri` when calling `installProvider.generateInstallUrl`. Your HTTP server should handle requests to the redirect URL by calling the `installProvider.handleCallback()` method. The first two arguments (`req`, `res`) to `installProvider.handleCallback` are required. By default, if the installation is successful the user will be redirected back to your App Home in Slack (or redirected back to the last open workspace in your slack app for classic Slack apps). If the installation is not successful the user will be shown an error page.
 
 ```javascript
 const { createServer } = require('http');
@@ -209,7 +209,7 @@ The `installer.authorize()` method only returns a subset of the installation dat
 // installer.installationStore.fetchInstallation takes in an installQuery as an argument
 // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
 // returns an installation object
-const result = installer.installationStore.fetchInstallation({teamId:'my-Team-ID'});
+const result = installer.installationStore.fetchInstallation({teamId:'my-Team-ID', enterpriseId:'my-enterprise-ID'});
 ```
 </details>
 

--- a/examples/oauth-v1/app.js
+++ b/examples/oauth-v1/app.js
@@ -59,7 +59,7 @@ app.get('/slack/oauth_redirect', async (req, res) => {
 slackEvents.on('app_home_opened', async (event, body) => {
   try {
     if (event.tab === 'home') {
-      const DBInstallData = await installer.authorize({teamId:body.team_id});
+      const DBInstallData = await installer.authorize({teamId:body.team_id, enterpriseId: body.enterprise_id});
       const web = new WebClient(DBInstallData.botToken);
       await web.views.publish({
         user_id: event.user,

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -34,11 +34,8 @@ const installer = new InstallProvider({
       if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // enterprise app, org wide installation
         keyv.set(installation.enterprise.id, installation);
-      } else if (installation.enterprise !== undefined) {
-        // enterprise app, single workspace installation
-        keyv.set(`${installation.enterprise.id}-${installation.team.id}`, installation);
       } else if (installation.team.id !== undefined) {
-        // non enterprise installation
+        // non enterprise org app installation
         keyv.set(installation.team.id, installation);
       } else {
         throw new Error('Failed saving installation data to installationStore');
@@ -53,12 +50,7 @@ const installer = new InstallProvider({
         result = await keyv.get(InstallQuery.enterpriseId);
       }
 
-      // non org app installation but still in enterprise lookup
-      if (result === undefined && InstallQuery.enterpriseId !== undefined && InstallQuery.teamId !== undefined) {
-        result = await keyv.get(`${InstallQuery.enterpriseId}-${InstallQuery.teamId}`);
-      }
-
-      // non enterprise lookup
+      // non org app lookup
       if (result === undefined && InstallQuery.teamId !== undefined) {
         result = await keyv.get(InstallQuery.teamId);
       }

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -33,15 +33,13 @@ const installer = new InstallProvider({
     storeInstallation: (installation) => {
       if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // enterprise app, org wide installation
-        keyv.set(installation.enterprise.id, installation);
+        return await keyv.set(installation.enterprise.id, installation);
       } else if (installation.team.id !== undefined) {
         // non enterprise org app installation
-        keyv.set(installation.team.id, installation);
+        return await keyv.set(installation.team.id, installation);
       } else {
         throw new Error('Failed saving installation data to installationStore');
       }
-
-      return
     },
     fetchInstallation: async (InstallQuery) => {
       let result = undefined;

--- a/packages/events-api/package.json
+++ b/packages/events-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/events-api",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -99,7 +99,7 @@ installer.generateInstallUrl({
 
 ### Handling the OAuth redirect
 
-After the user approves the request to install your app (and grants access to the required permissions), Slack will redirect the user to your specified **redirect url**. You can either set the redirect url in the app’s **OAuth and Permissions** page or pass a `redirectUri` when calling `installProvider.generateInstallUrl`. Your HTTP server should handle requests to the redirect URL by calling the `installProvider.handleCallback()` method. The first two arguments (`req`, `res`) to `installProvider.handleCallback` are required. By default, if the installation is successful the user will be redirected back to your App Home in Slack (or shown a generic success page for classic Slack apps). If the installation is not successful the user will be shown an error page.
+After the user approves the request to install your app (and grants access to the required permissions), Slack will redirect the user to your specified **redirect url**. You can either set the redirect url in the app’s **OAuth and Permissions** page or pass a `redirectUri` when calling `installProvider.generateInstallUrl`. Your HTTP server should handle requests to the redirect URL by calling the `installProvider.handleCallback()` method. The first two arguments (`req`, `res`) to `installProvider.handleCallback` are required. By default, if the installation is successful the user will be redirected back to your App Home in Slack (or redirected back to the last open workspace in your slack app for classic Slack apps). If the installation is not successful the user will be shown an error page.
 
 ```javascript
 const { createServer } = require('http');
@@ -198,7 +198,7 @@ You can use the the `installationProvider.authorize()` function to fetch data th
 ```javascript
 // installer.authorize takes in an installQuery as an argument
 // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
-const result = installer.authorize({teamId:'my-Team-ID'});
+const result = installer.installationStore.fetchInstallation({teamId:'my-team-ID', enterpriseId:'my-enterprise-ID'});
 /*
 result = {
   botToken: '',

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -31,7 +31,7 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "tslint --project .",
-    "test": "nyc mocha --config .mocharc.json src/*.spec.js test/integration/*.js",
+    "test": "nyc mocha --config .mocharc.json src/*.spec.js",
     "coverage": "codecov -F oauthhelper --root=$PWD"
   },
   "dependencies": {

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -38,7 +38,8 @@ rewiremock(() => require('@slack/web-api')).with({
           bot_user_id: 'botUserId',
           scope: 'chat:write,chat:read',
           appId: 'fakeAppId',
-          token_type: 'bot'
+          token_type: 'bot',
+          enterprise: null,
         })
       }
     }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -448,13 +448,13 @@ class MemoryInstallationStore implements InstallationStore {
     // db write
     if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
       this.devDB[installation.enterprise.id] = installation;
-    } else if (installation.team.id !== undefined) {
+    } else if (installation.team !== null && installation.team.id !== undefined) {
       this.devDB[installation.team.id] = installation;
     } else {
       throw new Error('Failed saving installation data to installationStore');
     }
 
-    return;
+    return Promise.resolve();
   }
 
   public async fetchInstallation(query: InstallationQuery, logger?: Logger): Promise<Installation> {
@@ -481,9 +481,9 @@ class MemoryInstallationStore implements InstallationStore {
 // result. This is a normalized shape.
 export interface Installation {
   team: {
-    id?: string;
-    name?: string;
-  };
+    id: string;
+    name: string;
+  } | null;
   enterprise?: {
     id: string;
     name?: string;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -354,7 +354,7 @@ interface OAuthV2Response {
   token_type: string;
   access_token: string;
   bot_user_id: string;
-  team: { id: string, name: string };
+  team: { id: string, name: string } | null;
   enterprise: { name: string, id: string } | null;
   is_enterprise_install: boolean;
   error?: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -142,6 +142,7 @@ export interface ConversationsSelect extends Action {
   placeholder?: PlainTextElement;
   confirm?: Confirm;
   response_url_enabled?: boolean;
+  default_to_current_conversation?: boolean;
   filter?: {
     include?: ('im' | 'mpim' | 'private' | 'public')[];
     exclude_external_shared_channels?: boolean;
@@ -155,6 +156,7 @@ export interface MultiConversationsSelect extends Action {
   placeholder?: PlainTextElement;
   max_selected_items?: number;
   confirm?: Confirm;
+  default_to_current_conversation?: boolean;
   filter?: {
     include?: ('im' | 'mpim' | 'private' | 'public')[];
     exclude_external_shared_channels?: boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,7 @@ export interface Confirm {
   text: PlainTextElement | MrkdwnElement;
   confirm?: PlainTextElement;
   deny?: PlainTextElement;
+  style?: 'primary' | 'danger';
 }
 
 /*

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -979,6 +979,66 @@ describe('WebClient', function () {
     });
   });
 
+  describe('has all admin.usergroups.* APIs', function () {
+    function verify(runApiCall, methodName, expectedBody, done) {
+      const scope = nock('https://slack.com')
+        .post(`/api/${methodName}`)
+        .reply(200, function (_uri, body) {
+          return { ok: true, body: body };
+        });
+
+      runApiCall
+        .then((res) => {
+          assert.equal(res.body, expectedBody);
+          scope.done();
+          done();
+        });
+    }
+    const client = new WebClient(token);
+
+    it('can call admin.usergroups.addChannels with a string "channe_ids"', function (done) {
+      verify(
+        client.admin.usergroups.addChannels({ team_id: 'T123', usergroup_id: 'S123', channel_ids: 'C123,C234' }),
+        'admin.usergroups.addChannels',
+        'token=xoxb-faketoken&team_id=T123&usergroup_id=S123&channel_ids=C123%2CC234',
+        done,
+      );
+    });
+
+    it('can call admin.usergroups.addChannels', function (done) {
+      verify(
+        client.admin.usergroups.addChannels({ team_id: 'T123', usergroup_id: 'S123', channel_ids: ['C123','C234'] }),
+        'admin.usergroups.addChannels',
+        'token=xoxb-faketoken&team_id=T123&usergroup_id=S123&channel_ids=%5B%22C123%22%2C%22C234%22%5D', // URL encoded "['C123','C234']"
+        done,
+      );
+    });
+    it('can call admin.usergroups.listChannels', function (done) {
+      verify(
+        client.admin.usergroups.listChannels({ team_id: 'T123', include_num_members: true, usergroup_id: 'S123' }),
+        'admin.usergroups.listChannels',
+        'token=xoxb-faketoken&team_id=T123&include_num_members=true&usergroup_id=S123',
+        done
+      );
+    });
+    it('can call admin.usergroups.removeChannels with a string "channe_ids"', function (done) {
+      verify(
+        client.admin.usergroups.removeChannels({ usergroup_id: 'S123', channel_ids: 'C123,C234' }),
+        'admin.usergroups.removeChannels',
+        'token=xoxb-faketoken&usergroup_id=S123&channel_ids=C123%2CC234',
+        done,
+      );
+    });
+
+    it('can call admin.usergroups.removeChannels', function (done) {
+      verify(
+        client.admin.usergroups.removeChannels({ usergroup_id: 'S123', channel_ids: ['C123','C234'] }),
+        'admin.usergroups.removeChannels',
+        'token=xoxb-faketoken&usergroup_id=S123&channel_ids=%5B%22C123%22%2C%22C234%22%5D', // URL encoded "['C123','C234']"
+        done,
+      );
+    });
+  });
   afterEach(function () {
     nock.cleanAll();
   });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -319,7 +319,7 @@ export class WebClient extends EventEmitter<WebClientEvent> {
     },
     conversations: {
       setTeams: (this.apiCall.bind(
-          this, 'admin.conversations.setTeams')) as Method<methods.AdminConversationsSetTeamsArguments>,
+        this, 'admin.conversations.setTeams')) as Method<methods.AdminConversationsSetTeamsArguments>,
     },
     inviteRequests: {
       approve: (this.apiCall.bind(
@@ -348,17 +348,25 @@ export class WebClient extends EventEmitter<WebClientEvent> {
       },
       settings: {
         info: (this.apiCall.bind(this, 'admin.teams.settings.info')) as Method<methods.AdminTeamsSettingsInfoArguments>,
-        setDefaultChannels: (this.apiCall.bind(this, 'admin.teams.settings.setDefaultChannels')
-          ) as Method<methods.AdminTeamsSettingsSetDefaultChannelsArguments>,
+        setDefaultChannels: (this.apiCall.bind(this, 'admin.teams.settings.setDefaultChannels')) as
+          Method<methods.AdminTeamsSettingsSetDefaultChannelsArguments>,
         setDescription: (this.apiCall.bind(
           this, 'admin.teams.settings.setDescription')) as Method<methods.AdminTeamsSettingsSetDescriptionArguments>,
-        setDiscoverability: (this.apiCall.bind(this, 'admin.teams.settings.setDiscoverability')
-          ) as Method<methods.AdminTeamsSettingsSetDiscoverabilityArguments>,
+        setDiscoverability: (this.apiCall.bind(this, 'admin.teams.settings.setDiscoverability')) as
+          Method<methods.AdminTeamsSettingsSetDiscoverabilityArguments>,
         setIcon: (this.apiCall.bind(
           this, 'admin.teams.settings.setIcon')) as Method<methods.AdminTeamsSettingseSetIconArguments>,
         setName: (this.apiCall.bind(
           this, 'admin.teams.settings.setName')) as Method<methods.AdminTeamsSettingsSetNameArguments>,
       },
+    },
+    usergroups: {
+      addChannels: (this.apiCall.bind(this, 'admin.usergroups.addChannels')) as
+        Method<methods.AdminUsergroupsAddChannelsArguments>,
+      listChannels: (this.apiCall.bind(this, 'admin.usergroups.listChannels')) as
+        Method<methods.AdminUsergroupsListChannelsArguments>,
+      removeChannels: (this.apiCall.bind(this, 'admin.usergroups.removeChannels')) as
+        Method<methods.AdminUsergroupsRemoveChannelsArguments>,
     },
     users: {
       session: {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -151,6 +151,20 @@ export interface AdminTeamsSettingsSetNameArguments extends WebAPICallOptions, T
   team_id: string;
   name: string;
 }
+export interface AdminUsergroupsAddChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  team_id: string;
+  channel_ids: string | string[];
+}
+export interface AdminUsergroupsListChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  include_num_members?: boolean;
+  team_id?: string;
+}
+export interface AdminUsergroupsRemoveChannelsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  channel_ids: string | string[];
+}
 export interface AdminUsersAssignArguments extends WebAPICallOptions, TokenOverridable {
   team_id: string;
   user_id: string;

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -28,6 +28,7 @@ export interface Searchable {
   highlight?: boolean;
   sort: 'score' | 'timestamp';
   sort_dir: 'asc' | 'desc';
+  team_id?: string;
 }
 
 // A set of method names is initialized here and added to each time an argument type extends the CursorPaginationEnabled
@@ -231,6 +232,7 @@ export interface AuthTestArguments extends WebAPICallOptions, TokenOverridable {
    */
 export interface BotsInfoArguments extends WebAPICallOptions, TokenOverridable  {
   bot?: string;
+  team_id?: string;
 }
 
   /*
@@ -243,6 +245,7 @@ export interface ChannelsArchiveArguments extends WebAPICallOptions, TokenOverri
 export interface ChannelsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   validate?: boolean;
+  team_id?: string;
 }
 export interface ChannelsHistoryArguments extends WebAPICallOptions, TokenOverridable, TimelinePaginationEnabled {
   channel: string;
@@ -270,6 +273,7 @@ export interface ChannelsLeaveArguments extends WebAPICallOptions, TokenOverrida
 export interface ChannelsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   exclude_members?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('channels.list');
 export interface ChannelsMarkArguments extends WebAPICallOptions, TokenOverridable {
@@ -358,6 +362,7 @@ export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOv
   thread_ts?: string;
   unfurl_links?: boolean;
   unfurl_media?: boolean;
+  team_id?: string;
 }
 export interface ChatScheduledMessagesListArguments extends WebAPICallOptions, TokenOverridable,
   CursorPaginationEnabled {
@@ -397,6 +402,7 @@ export interface ConversationsCloseArguments extends WebAPICallOptions, TokenOve
 export interface ConversationsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   is_private?: boolean;
+  team_id?: string;
 }
 export interface ConversationsHistoryArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled,
   TimelinePaginationEnabled {
@@ -423,6 +429,7 @@ export interface ConversationsLeaveArguments extends WebAPICallOptions, TokenOve
 export interface ConversationsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   types?: string; // comma-separated list of conversation types
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('conversations.list');
 export interface ConversationsMembersArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
@@ -502,6 +509,7 @@ export interface FilesListArguments extends WebAPICallOptions, TokenOverridable,
   ts_from?: string;
   ts_to?: string;
   types?: string; // comma-separated list of file types
+  team_id?: string;
 }
 export interface FilesRevokePublicURLArguments extends WebAPICallOptions, TokenOverridable {
   file: string; // file id
@@ -576,6 +584,7 @@ export interface GroupsArchiveArguments extends WebAPICallOptions, TokenOverrida
 export interface GroupsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   validate?: boolean;
+  team_id?: string;
 }
 export interface GroupsCreateChildArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
@@ -602,6 +611,7 @@ export interface GroupsLeaveArguments extends WebAPICallOptions, TokenOverridabl
 export interface GroupsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   exclude_members?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('groups.list');
 export interface GroupsMarkArguments extends WebAPICallOptions, TokenOverridable {
@@ -664,6 +674,7 @@ export interface IMRepliesArguments extends WebAPICallOptions, TokenOverridable 
 export interface MigrationExchangeArguments extends WebAPICallOptions, TokenOverridable {
   users: string; // comma-separated list of users
   to_old?: boolean;
+  team_id?: string;
 }
 
   /*
@@ -751,6 +762,7 @@ export interface ReactionsListArguments extends WebAPICallOptions, TokenOverrida
   CursorPaginationEnabled {
   user?: string;
   full?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('reactions.list');
 export interface ReactionsRemoveArguments extends WebAPICallOptions, TokenOverridable {
@@ -835,9 +847,11 @@ export interface TeamAccessLogsArguments extends WebAPICallOptions, TokenOverrid
   before?: number;
   count?: number;
   page?: number;
+  team_id?: string;
 }
 export interface TeamBillableInfoArguments extends WebAPICallOptions, TokenOverridable {
   user?: string;
+  team_id?: string;
 }
 export interface TeamInfoArguments extends WebAPICallOptions, TokenOverridable {}
 export interface TeamIntegrationLogsArguments extends WebAPICallOptions, TokenOverridable {
@@ -847,9 +861,11 @@ export interface TeamIntegrationLogsArguments extends WebAPICallOptions, TokenOv
   page?: number;
   service_id?: string;
   user?: string;
+  team_id?: string;
 }
 export interface TeamProfileGetArguments extends WebAPICallOptions, TokenOverridable {
   visibility?: 'all' | 'visible' | 'hidden';
+  team_id?: string;
 }
 
   /*
@@ -900,6 +916,7 @@ export interface UsersConversationsArguments extends WebAPICallOptions, TokenOve
   exclude_archived?: boolean;
   types?: string; // comma-separated list of conversation types
   user?: string;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('users.conversations');
 export interface UsersDeletePhotoArguments extends WebAPICallOptions, TokenOverridable {}
@@ -912,6 +929,7 @@ export interface UsersInfoArguments extends WebAPICallOptions, TokenOverridable,
 }
 export interface UsersListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled, LocaleAware {
   presence?: boolean; // deprecated, defaults to false
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('users.list');
 export interface UsersLookupByEmailArguments extends WebAPICallOptions, TokenOverridable {


### PR DESCRIPTION
###  Summary

This PR adds support for Org Apps to the OAuth library.

Updates include:
- improved logic for saving and retrieving data from `MemoryInstallationStore` to handle org wide enterprise installations. 
- added new `isEnterpriseInstall` parameter to `Installation` object. This is mapped directly from `is_enterprise_install` from the `oauth.v2.access` response. If true, it indicates it is an org wide installation
- added `team_id` to web-api methods that require it for org-apps
- updated examples

Todo: 
- [ ] Add tests


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
