### PR TITLE
Fix #1022 by adding confirm.style (Block Kit composition object)

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,7 @@ export interface Confirm {
   text: PlainTextElement | MrkdwnElement;
   confirm?: PlainTextElement;
   deny?: PlainTextElement;
+  style?: 'primary' | 'danger';
 }
 
 /*


### PR DESCRIPTION
###  Summary

This pull request fixes #1022 by adding `style` field to `confirm` objects. 

Note: the lack of this definition has been affecting only TypeScript users.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
