### PR TITLE
added calls Api support

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -358,3 +358,15 @@ export interface SelectOption {
   label: string; // shown to user
   value: string; // sent to app
 }
+
+export type CallUser = CallUserSlack | CallUserExternal;
+
+export interface CallUserSlack {
+  slack_id: string;
+}
+
+export interface CallUserExternal {
+  external_id: string;
+  display_name: string;
+  avatar_url: string;
+}

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -408,6 +408,19 @@ export class WebClient extends EventEmitter<WebClientEvent> {
   };
 
   /**
+   * calls method family
+   */
+  public readonly calls = {
+    add: (this.apiCall.bind(this, 'calls.add')) as Method<methods.CallsAddArguments>,
+    end: (this.apiCall.bind(this, 'calls.end')) as Method<methods.CallsEndArguments>,
+    info: (this.apiCall.bind(this, 'calls.info')) as Method<methods.CallsInfoArguments>,
+    update: (this.apiCall.bind(this, 'calls.update')) as Method<methods.CallsUpdateArguments>,
+    participants: {
+      add: (this.apiCall.bind(this, 'calls.participants.add')) as Method<methods.CallsParticipantsAddArguments>,
+    },
+  };
+
+  /**
    * channels method family
    */
   public readonly channels = {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1,5 +1,5 @@
 import { Stream } from 'stream';
-import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls } from '@slack/types';
+import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser } from '@slack/types';
 import { WebAPICallOptions, WebAPICallResult } from './WebClient';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -231,6 +231,41 @@ export interface AuthTestArguments extends WebAPICallOptions, TokenOverridable {
    */
 export interface BotsInfoArguments extends WebAPICallOptions, TokenOverridable  {
   bot?: string;
+}
+
+  /*
+  * `calls.*`
+  */
+export interface CallsAddArguments extends WebAPICallOptions, TokenOverridable {
+  external_unique_id: string;
+  join_url: string;
+  created_by?: string;
+  date_start?: number;
+  desktop_app_join_url?: string;
+  external_display_id?: string;
+  title?: string;
+  users?: CallUser[];
+}
+
+export interface CallsEndArguments extends WebAPICallOptions, TokenOverridable {
+  id: string;
+  duration?: number;
+}
+
+export interface CallsInfoArguments extends WebAPICallOptions, TokenOverridable {
+  id: string;
+}
+
+export interface CallsUpdateArguments extends WebAPICallOptions, TokenOverridable {
+  id: string;
+  join_url?: string;
+  desktop_app_join_url?: string;
+  title?: string;
+}
+
+export interface CallsParticipantsAddArguments extends WebAPICallOptions, TokenOverridable {
+  id: string;
+  users: CallUser[];
 }
 
   /*


### PR DESCRIPTION
###  Summary

Issue: https://github.com/slackapi/node-slack-sdk/issues/1021

Added support for the calls Api

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
