### PR TITLE
Change `paginate` return type to `AsyncIterable`

### DIFF
--- a/integration-tests/types/webclient-paginate-types.ts
+++ b/integration-tests/types/webclient-paginate-types.ts
@@ -1,73 +1,17 @@
+/// <reference lib="esnext.asynciterable" />
+
 // tslint:disable:no-unused-expression
-import { WebClient, WebAPICallResult } from '@slack/web-api';
+import { WebClient } from '@slack/web-api';
 
 const web = new WebClient();
 
 /* Testing the return type of WebClient#paginate() */
 
-/**
- * SO. For all intents and purposes, this thing below is just an AsyncIterator. That's what it's meant to be. "So why
- * not just put `AsyncIterator`," you ask. Good question. Let me tell you a tale:
- *
- * In the year 2019, all was happy, all was cheerful. These integration tests $ExpectedType AsyncIterator and this
- * redundant interface was naught. Birds chirped with glee. Children played in the fields. Not a thing in the world
- * could possibly go wrong.
- *
- * Then something went wrong. From each cardinal direction a storm approached. Its winds ripped trees from their roots
- * and separated hatchlings from their mothers. Mercilessly, the storm tore apart the meadow and everything it
- * supported.
- *
- * This storm has not been forgotten. We keep its bittersweet memory in our hearts. Some cower at the foul beast's name:
- * `typescript@3.6.0-dev.20190703`.
- *
- * For, you see, this was not your average storm. No, this storm approached instead as something to be celebrated. It
- * boasted updated generator types and it advertised comfortable iterator ergonomics. Alas, in hindsight this was but a
- * mirage--a trojan horse, even--masquerading the terror that followed. It knocked with its weapon upfront: no longer
- * was it `AsyncIterator<T>`, but rather `AsyncIterator<T, TReturn = any, TNext = undefined>`.
- *
- * It struck right at the edge: the integration tests. For, you see, their foundation is dtslint, which (at the time of
- * the storm) tests against each minor release of TypeScript from 2.0 all the way to `typescript@next`. Whilst usage
- * remain unaffected, the same could not be said of our types integration tests. These tests now failed, for their
- * single generic argument was unequal to the three dtslint expected.
- *
- * Our most trustworthy guard, Travis (CI), attempted to warn us of the dangerous storm, but by the time the message
- * reached us the damage was done. Builds were failing. PRs reported failures. Builds were a sea of red ✗'s (read: a sea
- * of blood).
- *
- * This is why we've enacted this memorial: the __DangerouslyOutmodedAsyncIteratorSignatureWrapper. Its purpose is not
- * only to remember the sorrows of past maintiners, but to also appease the storm by wrapping `AsyncIterator` in a new
- * type that is fully equivalent, yet named different under `$ExpectType` (that is, the same across TypeScript
- * versions).
- *
- *  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
- *
- * Just as there is a calm before the storm, there must also be one after.
- *
- * We dream of a day where dtslint only runs a specific range of supported versions. We dream of a day where dtslint can
- * see the equality of an expected type without explicit defaults and the type with its defaults filled in[1]. We dream
- * of a future after the storm.
- *
- * Once we reach that future, this memorial will have served its purpose[2]. It will be safe to remove in that future we
- * dream of.
- *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- *
- * [1]: That is, `AsyncIterator<T>` is equal to `AsyncIterator<T, any, undefined>` because the defaults cause them to
- *      become equal.
- * [2]: This interface is no longer needed once TypeScript 3.6 or higher is the supported range, or once dtslint can
- *      better compare type assertions.
- *
- * For more information, search the history books for PR #836.
- */
-interface __DangerouslyOutmodedAsyncIteratorSignatureWrapper<T> extends AsyncIterator<T> {
-  // same as AsyncIterator<T>.
-}
+// $ExpectType AsyncIterable<WebAPICallResult>
+web.paginate('conversations.list');
 
-// $ExpectType __DangerouslyOutmodedAsyncIteratorSignatureWrapper<WebAPICallResult>
-web.paginate('conversations.list') as __DangerouslyOutmodedAsyncIteratorSignatureWrapper<WebAPICallResult>;
-
-// $ExpectType __DangerouslyOutmodedAsyncIteratorSignatureWrapper<WebAPICallResult>
-web.paginate('conversations.list', {}) as __DangerouslyOutmodedAsyncIteratorSignatureWrapper<WebAPICallResult>;
+// $ExpectType AsyncIterable<WebAPICallResult>
+web.paginate('conversations.list', {});
 
 // $ExpectType Promise<void>
 web.paginate('conversations.list', {}, () => false);
@@ -79,9 +23,20 @@ web.paginate('conversations.list', {}, () => 7);
 web.paginate('conversations.list', {}, () => false, () => 5);
 
 // When there's no shouldStop predicate given but there is a reducer, the behavior is undefined.
-// (However in the current implementation, the return value is AsyncIterator<WebAPICallResult>)
+// (However in the current implementation, the return value is `AsyncIteratable<WebAPICallResult>`.)
 // $ExpectError
 web.paginate('conversations.list', {}, undefined, () => 5);
+
+// Ensure that it works in a for-await-of loop.
+async () => {
+  for await (const page of web.paginate('conversations.list')) {
+    // $ExpectType WebAPICallResult
+    page;
+  }
+
+  // (async functions expect a return statement, or at least that's what the error told me when I didn't have one.)
+  return;
+};
 
 /* Testing the arguments of the shouldStop param */
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -211,7 +211,7 @@ export class WebClient extends Methods {
    * @param shouldStop a predicate that is called with each page, and should return true when pagination can end.
    * @param reduce a callback that can be used to accumulate a value that the return promise is resolved to
    */
-  public paginate(method: string, options?: WebAPICallOptions): AsyncIterator<WebAPICallResult>;
+  public paginate(method: string, options?: WebAPICallOptions): AsyncIterable<WebAPICallResult>;
   public paginate(
     method: string,
     options: WebAPICallOptions,
@@ -228,7 +228,7 @@ export class WebClient extends Methods {
     options?: WebAPICallOptions,
     shouldStop?: PaginatePredicate,
     reduce?: PageReducer<A>,
-  ): (Promise<A> | AsyncIterator<WebAPICallResult>) {
+  ): (Promise<A> | AsyncIterable<WebAPICallResult>) {
 
     if (!cursorPaginationEnabledMethods.has(method)) {
       this.logger.warn(`paginate() called with method ${method}, which is not known to be cursor pagination enabled.`);


### PR DESCRIPTION
##  Summary

Fixes #779. Changes the return type of `WebClient`'s `paginate` method to be `AsyncIterable` instead of `AsyncIterator` (the former can be used in for-await-of loops, whereas the latter can't).

As a side effect, this cleans up some previous collateral in the integration test for the `paginate` method.

(RIP the comment from my best commit ever.)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
