### PR TITLE
Add error to WebClient's `Methods` superclass

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -2,7 +2,7 @@ require('mocha');
 const fs = require('fs');
 const path = require('path');
 const { Agent } = require('https');
-const { assert, expect } = require('chai');
+const { assert } = require('chai');
 const { WebClient } = require('./WebClient');
 const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
@@ -34,25 +34,25 @@ describe('WebClient', function () {
 
   describe('Methods superclass', function () {
     it('should fail to construct classes that don\'t extend WebClient', function () {
-      expect(function () {
+      assert.throws(function () {
         class X extends Methods {
           apiCall() {}
         }
         new X();
-      }).to.throw();
+      });
     });
 
     it('should succeed when constructing WebClient', function () {
-      expect(function () {
+      assert.doesNotThrow(function () {
         new WebClient();
-      }).to.not.throw();
+      });
     });
 
     it('should succeed when constructing a class that extends WebClient', function () {
-      expect(function () {
+      assert.doesNotThrow(function () {
         class X extends WebClient {}
         new X();
-      }).to.not.throw();
+      });
     });
   });
 

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -2,12 +2,13 @@ require('mocha');
 const fs = require('fs');
 const path = require('path');
 const { Agent } = require('https');
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 const { WebClient } = require('./WebClient');
 const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
 const { addAppMetadata } = require('./instrument');
 const { rapidRetryPolicy } = require('./retry-policies');
+const { Methods } = require('./methods');
 const { CaptureConsole } = require('@aoberoi/capture-console');
 const nock = require('nock');
 const Busboy = require('busboy');
@@ -28,6 +29,30 @@ describe('WebClient', function () {
     it('should build a client without a token', function () {
       const client = new WebClient();
       assert.instanceOf(client, WebClient);
+    });
+  });
+
+  describe('Methods superclass', function () {
+    it('should fail to construct classes that don\'t extend WebClient', function () {
+      expect(function () {
+        class X extends Methods {
+          apiCall() {}
+        }
+        new X();
+      }).to.throw();
+    });
+
+    it('should succeed when constructing WebClient', function () {
+      expect(function () {
+        new WebClient();
+      }).to.not.throw();
+    });
+
+    it('should succeed when constructing a class that extends WebClient', function () {
+      expect(function () {
+        class X extends WebClient {}
+        new X();
+      }).to.not.throw();
     });
   });
 

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1,6 +1,6 @@
 import { Stream } from 'stream';
 import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser } from '@slack/types';
-import { WebAPICallOptions, WebAPICallResult, WebClientEvent } from './WebClient';
+import { WebAPICallOptions, WebAPICallResult, WebClient, WebClientEvent } from './WebClient';
 import { EventEmitter } from 'eventemitter3';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -28,6 +28,15 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
   // so I'm just making this class extend EventEmitter.
   //
   // It shouldn't be here, indeed. Nothing here uses it, indeed. But it must be here for the sake of sanity.
+
+  protected constructor() {
+    super();
+
+    // Check that the class being created extends from `WebClient` rather than this class
+    if (new.target !== WebClient && !(new.target.prototype instanceof WebClient)) {
+      throw new Error('Attempt to inherit from WebClient methods without inheriting from WebClient');
+    }
+  }
 
   public abstract async apiCall(method: string, options?: WebAPICallOptions): Promise<WebAPICallResult>;
 


### PR DESCRIPTION
###  Summary

As an tag-on to #1036, this PR aims to prevent package consumers from using the new `Methods` abstract class as it is currently meant to only serve `WebClient` specifically.

If someone attempts to create a class that `extends Methods` then it should error when being created with `new`, unless that class `extends WebClient`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
