### PR TITLE
Add two methods endpoints

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -90,6 +90,8 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     usergroups: {
       addChannels: bindApiCall<AdminUsergroupsAddChannelsArguments, WebAPICallResult>(
         this, 'admin.usergroups.addChannels'),
+      addTeams: bindApiCall<AdminUsergroupsAddTeamsArguments, WebAPICallResult>(
+        this, 'admin.usergroups.addTeams'),
       listChannels: bindApiCall<AdminUsergroupsListChannelsArguments, WebAPICallResult>(
         this, 'admin.usergroups.listChannels'),
       removeChannels: bindApiCall<AdminUsergroupsRemoveChannelsArguments, WebAPICallResult>(
@@ -132,6 +134,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     update: bindApiCall<CallsUpdateArguments, WebAPICallResult>(this, 'calls.update'),
     participants: {
       add: bindApiCall<CallsParticipantsAddArguments, WebAPICallResult>(this, 'calls.participants.add'),
+      remove: bindApiCall<CallsParticipantsRemoveArguments, WebAPICallResult>(this, 'calls.participants.remove'),
     },
   };
 
@@ -512,8 +515,13 @@ export interface AdminTeamsSettingsSetNameArguments extends WebAPICallOptions, T
 }
 export interface AdminUsergroupsAddChannelsArguments extends WebAPICallOptions, TokenOverridable {
   usergroup_id: string;
-  team_id: string;
+  team_id?: string;
   channel_ids: string | string[];
+}
+export interface AdminUsergroupsAddTeamsArguments extends WebAPICallOptions, TokenOverridable {
+  usergroup_id: string;
+  team_ids: string | string[];
+  auto_provision?: boolean;
 }
 export interface AdminUsergroupsListChannelsArguments extends WebAPICallOptions, TokenOverridable {
   usergroup_id: string;
@@ -623,6 +631,11 @@ export interface CallsUpdateArguments extends WebAPICallOptions, TokenOverridabl
 }
 
 export interface CallsParticipantsAddArguments extends WebAPICallOptions, TokenOverridable {
+  id: string;
+  users: CallUser[];
+}
+
+export interface CallsParticipantsRemoveArguments extends WebAPICallOptions, TokenOverridable {
   id: string;
   users: CallUser[];
 }


### PR DESCRIPTION
###  Summary

Adds arguments types and method bindings for two Web API methods:

- [`calls.participants.remove`](https://api.slack.com/methods/calls.participants.remove)
- [`admin.usergroups.addTeams`](https://api.slack.com/methods/admin.usergroups.addTeams)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
