### PR TITLE
added four new web-api methods

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -58,6 +58,14 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     conversations: {
       setTeams:
         bindApiCall<AdminConversationsSetTeamsArguments, WebAPICallResult>(this, 'admin.conversations.setTeams'),
+      restrictAccess: {
+        addGroup:
+          bindApiCall<AdminConversationsRestrictAccessAddGroupArguments, WebAPICallResult>(this, 'admin.conversations.restrictAccess.addGroup'),
+        listGroups:
+          bindApiCall<AdminConversationsRestrictAccessListGroupsArguments, WebAPICallResult>(this, 'admin.conversations.restrictAccess.listGroups'),
+        removeGroup:
+          bindApiCall<AdminConversationsRestrictAccessRemoveGroupArguments, WebAPICallResult>(this, 'admin.conversations.restrictAccess.removeGroup'),
+      },
     },
     inviteRequests: {
       approve: bindApiCall<AdminInviteRequestsApproveArguments, WebAPICallResult>(
@@ -193,6 +201,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     kick: bindApiCall<ConversationsKickArguments, WebAPICallResult>(this, 'conversations.kick'),
     leave: bindApiCall<ConversationsLeaveArguments, WebAPICallResult>(this, 'conversations.leave'),
     list: bindApiCall<ConversationsListArguments, WebAPICallResult>(this, 'conversations.list'),
+    mark: bindApiCall<ConversationsMarkArguments, WebAPICallResult>(this, 'conversations.mark'),
     members: bindApiCall<ConversationsMembersArguments, WebAPICallResult>(this, 'conversations.members'),
     open: bindApiCall<ConversationsOpenArguments, WebAPICallResult>(this, 'conversations.open'),
     rename: bindApiCall<ConversationsRenameArguments, WebAPICallResult>(this, 'conversations.rename'),
@@ -452,6 +461,24 @@ export interface AdminAppsRestrictedListArguments extends WebAPICallOptions, Tok
   enterprise_id?: string;
 }
 cursorPaginationEnabledMethods.add('admin.apps.restricted.list');
+
+export interface AdminConversationsRestrictAccessAddGroupArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  group_id: string;
+  team_id?: string;
+}
+
+export interface AdminConversationsRestrictAccessListGroupsArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  team_id?: string;
+}
+
+export interface AdminConversationsRestrictAccessRemoveGroupArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  group_id: string;
+  team_id: string;
+}
+
 export interface AdminConversationsSetTeamsArguments extends WebAPICallOptions, TokenOverridable {
   channel_id: string;
   team_id?: string;
@@ -841,6 +868,10 @@ export interface ConversationsListArguments extends WebAPICallOptions, TokenOver
   types?: string; // comma-separated list of conversation types
 }
 cursorPaginationEnabledMethods.add('conversations.list');
+export interface ConversationsMarkArguments extends WebAPICallOptions, TokenOverridable {
+  channel: string;
+  ts: string;
+}
 export interface ConversationsMembersArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   channel: string;
 }


### PR DESCRIPTION
###  Summary

Added four methods to web-api:

- admin.conversations.restrictAccess.addGroup
- admin.conversations.restrictAccess.listGroups
- admin.conversations.restrictAccess.removeGroup
- conversations.mark

Linked issue: #1047 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
