### PR TITLE
added whitelist depr. + generic deprecation method

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -582,14 +582,23 @@ function parseRetryHeaders(response: AxiosResponse): number | undefined {
  * @param logger instance of web clients logger
  */
 function warnDeprecations(method: string, logger: Logger): void {
-  const deprecatedMethods = ['channels.', 'groups.', 'im.', 'mpim.'];
+  const deprecatedConversationsMethods = ['channels.', 'groups.', 'im.', 'mpim.'];
+
+  const deprecatedMethods = ['admin.conversations.whitelist.'];
+
+  const isDeprecatedConversations = deprecatedConversationsMethods.some((depMethod) => {
+    const re = new RegExp(`^${depMethod}`);
+    return re.test(method);
+  });
 
   const isDeprecated = deprecatedMethods.some((depMethod) => {
     const re = new RegExp(`^${depMethod}`);
     return re.test(method);
   });
 
-  if (isDeprecated) {
+  if (isDeprecatedConversations) {
     logger.warn(`${method} is deprecated. Please use the Conversations API instead. For more info, go to https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api`);
+  } else if (isDeprecated) {
+    logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
   }
 }


### PR DESCRIPTION
###  Summary

I changed the warnDeprecations method to be a generic deprecation notice rather than one specific to the Conversations API. The method still logs the old conversations API deprecation notice for those particular methods as it did before. The original PR for warnDeprecations is #992.

I modified warnDeprecations to show the deprecation notice for the `admin.conversations.whitelist` methods as specified in issue: #1048.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
