### PR TITLE
added agent as a top level option to pass in

### DIFF
--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -1,5 +1,5 @@
 /* tslint:disable import-name */
-import http, { RequestListener } from 'http';
+import http, { RequestListener, Agent } from 'http';
 import axios, { AxiosInstance } from 'axios';
 import isString from 'lodash.isstring';
 import isRegExp from 'lodash.isregexp';
@@ -137,6 +137,7 @@ export class SlackMessageAdapter {
   constructor(signingSecret: string, {
     syncResponseTimeout = 2500,
     lateResponseFallbackEnabled = true,
+    agent = undefined,
   }: MessageAdapterOptions = {}) {
     if (!isString(signingSecret)) {
       throw new TypeError('SlackMessageAdapter needs a signing secret');
@@ -154,6 +155,13 @@ export class SlackMessageAdapter {
       headers: {
         'User-Agent': packageIdentifier(),
       },
+      httpAgent: agent,
+      httpsAgent: agent,
+      // disabling axios' automatic proxy support:
+      // axios would read from envvars to configure a proxy automatically, but it doesn't support TLS destinations.
+      // for compatibility with https://api.slack.com, and for a larger set of possible proxies (SOCKS or other
+      // protocols), users of this package should use the `agent` option to configure a proxy.
+      proxy: false,
     });
 
     debug('instantiated');
@@ -654,6 +662,7 @@ interface DispatchResult {
 export interface MessageAdapterOptions {
   syncResponseTimeout?: number;
   lateResponseFallbackEnabled?: boolean;
+  agent?: Agent;
 }
 
 /**


### PR DESCRIPTION
###  Summary

Fixes issue: #823. Allows developers to pass in an `agent` so they can configure a proxy when doing axios.post request for `response_url`.

Still want to add tests but figured I should get eyes on this since it is a priority fix

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
