### PR TITLE
Added three workflows.* methods for upcoming Workflow Steps feature

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1420,11 +1420,11 @@ export interface WorkflowsStepCompletedArguments extends WebAPICallOptions, Toke
   workflow_step_execute_id: string;
   outputs?: object;
 }
- 
+
 export interface WorkflowsStepFailedArguments extends WebAPICallOptions, TokenOverridable {
   workflow_step_execute_id: string;
   error: {
-      message: string;
+    message: string;
   };
 }
 

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -380,6 +380,12 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       set: bindApiCall<UsersProfileSetArguments, WebAPICallResult>(this, 'users.profile.set'),
     },
   };
+
+  public readonly workflows = {
+    stepCompleted: bindApiCall<WorkflowsStepCompletedArguments, WebAPICallResult>(this, 'workflows.stepCompleted'),
+    stepFailed: bindApiCall<WorkflowsStepFailedArguments, WebAPICallResult>(this, 'workflows.stepFailed'),
+    updateStep: bindApiCall<WorkflowsUpdateStepArguments, WebAPICallResult>(this, 'workflows.updateStep'),
+  };
 }
 
 /**
@@ -1405,6 +1411,31 @@ export interface ViewsUpdateArguments extends WebAPICallOptions, TokenOverridabl
   view: View;
   external_id?: string;
   hash?: string;
+}
+
+  /*
+   * `workflows.*`
+   */
+export interface WorkflowsStepCompletedArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_execute_id: string;
+  outputs?: object;
+}
+ 
+export interface WorkflowsStepFailedArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_execute_id: string;
+  error: {
+      message: string;
+  };
+}
+
+export interface WorkflowsUpdateStepArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_edit_id: string;
+  inputs?: object;
+  outputs?: {
+    type: string;
+    name: string;
+    label: string;
+  }[];
 }
 
 export * from '@slack/types';


### PR DESCRIPTION
###  Summary

Added three `workflows` methods to web-api:

`workflows.stepCompleted`
`workflows.stepFailed`
`workflows.updateStep`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
