### PR TITLE
Fix required parameters in chat.update method

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -819,13 +819,13 @@ export interface ChatUnfurlArguments extends WebAPICallOptions, TokenOverridable
 }
 export interface ChatUpdateArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  text: string;
   ts: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];
   link_names?: boolean;
   parse?: 'full' | 'none';
+  text?: string;
 }
 
   /*


### PR DESCRIPTION
###  Summary

Closes #1061 

Alternatively, it can use a union type (make text required if blocks/attachments are not there), but I don't want to break from the existing pattern since union types aren't used anywhere else. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
