### PR TITLE
[Closes #1054] Add OAuth to the homepage and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ walk you through building your first Slack app using Node.js.
 | Web API      | Send data to or query data from Slack using any of [over 130 methods](https://api.slack.com/methods). | [`@slack/web-api`](https://slack.dev/node-slack-sdk/web-api) |
 | Events API   | Listen for incoming messages and [many other events](https://api.slack.com/events) happening in Slack, using a URL. | [`@slack/events-api`](https://slack.dev/node-slack-sdk/events-api) |
 | Interactive Messages | Respond to button clicks, dialogs, and other interactions with messages. | [`@slack/interactive-messages`](https://slack.dev/node-slack-sdk/interactive-messages) |
+| OAuth        | Setup the authentication flow using OAuth 2.0 for Slack apps and OAuth 1.0 for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
 | RTM API      | Listen for incoming messages and a limited set of events happening in Slack, using websockets. | [`@slack/rtm-api`](https://slack.dev/node-slack-sdk/rtm-api) |
 | Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](https://slack.dev/node-slack-sdk/webhook) |
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ walk you through building your first Slack app using Node.js.
 | Web API      | Send data to or query data from Slack using any of [over 130 methods](https://api.slack.com/methods). | [`@slack/web-api`](https://slack.dev/node-slack-sdk/web-api) |
 | Events API   | Listen for incoming messages and [many other events](https://api.slack.com/events) happening in Slack, using a URL. | [`@slack/events-api`](https://slack.dev/node-slack-sdk/events-api) |
 | Interactive Messages | Respond to button clicks, dialogs, and other interactions with messages. | [`@slack/interactive-messages`](https://slack.dev/node-slack-sdk/interactive-messages) |
-| OAuth        | Setup the authentication flow using OAuth 2.0 for Slack apps and OAuth 1.0 for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
+| OAuth        | Setup the authentication flow using V2 OAuth for Slack apps as well as V1 OAuth for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
 | RTM API      | Listen for incoming messages and a limited set of events happening in Slack, using websockets. | [`@slack/rtm-api`](https://slack.dev/node-slack-sdk/rtm-api) |
 | Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](https://slack.dev/node-slack-sdk/webhook) |
 

--- a/docs/_main/index.md
+++ b/docs/_main/index.md
@@ -22,6 +22,7 @@ walk you through building your first Slack app using Node.js.
 | Web API      | Send data to or query data from Slack using any of [over 130 methods](https://api.slack.com/methods). | [`@slack/web-api`](https://slack.dev/node-slack-sdk/web-api) |
 | Events API   | Listen for incoming messages and [many other events](https://api.slack.com/events) happening in Slack, using a URL. | [`@slack/events-api`](https://slack.dev/node-slack-sdk/events-api) |
 | Interactive Messages | Respond to button clicks, dialogs, and other interactions with messages. | [`@slack/interactive-messages`](https://slack.dev/node-slack-sdk/interactive-messages) |
+| OAuth        | Setup the authentication flow using OAuth 2.0 for Slack apps and OAuth 1.0 for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
 | RTM API      | Listen for incoming messages and a limited set of events happening in Slack, using websockets. | [`@slack/rtm-api`](https://slack.dev/node-slack-sdk/rtm-api) |
 | Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](https://slack.dev/node-slack-sdk/webhook) |
 

--- a/docs/_main/index.md
+++ b/docs/_main/index.md
@@ -22,7 +22,7 @@ walk you through building your first Slack app using Node.js.
 | Web API      | Send data to or query data from Slack using any of [over 130 methods](https://api.slack.com/methods). | [`@slack/web-api`](https://slack.dev/node-slack-sdk/web-api) |
 | Events API   | Listen for incoming messages and [many other events](https://api.slack.com/events) happening in Slack, using a URL. | [`@slack/events-api`](https://slack.dev/node-slack-sdk/events-api) |
 | Interactive Messages | Respond to button clicks, dialogs, and other interactions with messages. | [`@slack/interactive-messages`](https://slack.dev/node-slack-sdk/interactive-messages) |
-| OAuth        | Setup the authentication flow using OAuth 2.0 for Slack apps and OAuth 1.0 for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
+| OAuth        | Setup the authentication flow using V2 OAuth for Slack apps as well as V1 OAuth for classic Slack apps. | [`@slack/oauth`](https://slack.dev/node-slack-sdk/oauth) |
 | RTM API      | Listen for incoming messages and a limited set of events happening in Slack, using websockets. | [`@slack/rtm-api`](https://slack.dev/node-slack-sdk/rtm-api) |
 | Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](https://slack.dev/node-slack-sdk/webhook) |
 


### PR DESCRIPTION
###  Summary

This pull request closes issue #1054 by adding OAuth (`@slack/oauth`) to the tables on the [homepage](https://slack.dev/node-slack-sdk/) and [README.md](https://github.com/slackapi/node-slack-sdk/blob/main/README.md).

- Updated the table on the homepage
- Updated the table on `README.md`
- Matched the OAuth row position with its position in side bar menu
- OAuth description is paraphrased from the OAuth page
- OAuth description length same as other rows

Tested:

- Locally using `bundle exec jekyll serve`

### Review & feedback

🙏🏻 Since this is my first pull request to [slackapi](https://github.com/slackapi/) organization, I'd appreciate extra 👀 :

- Double-check that I've signed the CLA properly
- Double-check that my changes are correct and complete
- Double-check that the base branch should be `main` (not `master`)
- Feedback on the commit and PR formatting

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
