### PR TITLE
Add header block to types

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -246,7 +246,7 @@ export interface PlainTextInput extends Action {
  */
 
 export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock |
-  SectionBlock | InputBlock | FileBlock;
+  SectionBlock | InputBlock | FileBlock | HeaderBlock;
 
 export interface Block {
   type: string;
@@ -285,6 +285,11 @@ export interface FileBlock extends Block {
   type: 'file';
   source: string; // 'remote'
   external_id: string;
+}
+
+export interface HeaderBlock extends Block {
+  type: 'header';
+  text: PlainTextElement;
 }
 
 export interface InputBlock extends Block {


### PR DESCRIPTION
###  Summary

Adds the new [header block](https://api.slack.com/reference/block-kit/blocks#header) to type definitions. Closes #1066.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
