### PR TITLE
check that headers are present before calling verifySignature

### DIFF
--- a/packages/events-api/src/http-handler.spec.js
+++ b/packages/events-api/src/http-handler.spec.js
@@ -2,7 +2,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 
-const { createRequest, createRawBodyRequest } = require('../test/helpers');
+const { createRequest, createRawBodyRequest, createRequestWithoutRequiredHeaders } = require('../test/helpers');
 
 const getRawBodyStub = sinon.stub();
 const { createHTTPHandler, verifyRequestSignature } = proxyquire('./http-handler', { 'raw-body': getRawBodyStub });
@@ -117,6 +117,17 @@ describe('http-handler', function () {
       });
       this.requestListener(req, res);
     });
+
+    it('should fail request signing verification if signature and timestamp headers are not present', function (done) {
+      const res = this.res;
+      const req = createRequestWithoutRequiredHeaders();
+      getRawBodyStub.resolves(Buffer.from(correctRawBody));
+      res.end.callsFake(function () {
+        assert.equal(res.statusCode, 404);
+        done();
+      });
+      this.requestListener(req, res);
+    })
 
     it('should handle unexpected error', function (done) {
       const res = this.res;

--- a/packages/events-api/src/http-handler.ts
+++ b/packages/events-api/src/http-handler.ts
@@ -139,6 +139,17 @@ export function createHTTPHandler(adapter: SlackEventAdapter): HTTPHandler {
     // Bind a response function to this request's respond object.
     const respond = sendResponse(res);
 
+    if (isFalsy(req.headers['x-slack-signature']) || isFalsy(req.headers['x-slack-request-timestamp'])) {
+      handleError(
+        errorWithCode(
+          new Error('Slack request signing verification failed'),
+          ErrorCode.SignatureVerificationFailure
+        ),
+        respond,
+      )
+      return;
+    }
+
     // If parser is being used and we don't receive the raw payload via `rawBody`,
     // we can't verify request signature
     if (!isFalsy(req.body) && isFalsy(req.rawBody)) {

--- a/packages/events-api/src/http-handler.ts
+++ b/packages/events-api/src/http-handler.ts
@@ -143,10 +143,10 @@ export function createHTTPHandler(adapter: SlackEventAdapter): HTTPHandler {
       handleError(
         errorWithCode(
           new Error('Slack request signing verification failed'),
-          ErrorCode.SignatureVerificationFailure
+          ErrorCode.SignatureVerificationFailure,
         ),
         respond,
-      )
+      );
       return;
     }
 

--- a/packages/events-api/test/helpers.js
+++ b/packages/events-api/test/helpers.js
@@ -36,6 +36,19 @@ function createRequest(signingSecret, ts, rawBody) {
 }
 
 /**
+ * Create request object with missing headers
+ * @returns {Object} pseudo request object
+ */
+function createRequestWithoutRequiredHeaders() {
+  const headers = {
+    'content-type': 'application/json'
+  };
+  return {
+    headers: headers
+  };
+}
+
+/**
  * Creates request object with proper headers and a rawBody field payload
  * @param {string} signingSecret - A Slack signing secret for request verification
  * @param {Integer} ts - A timestamp for request verification and header
@@ -101,4 +114,5 @@ module.exports.createRequest = createRequest;
 module.exports.createRawBodyRequest = createRawBodyRequest;
 module.exports.createRequestSignature = createRequestSignature;
 module.exports.createStreamRequest = createStreamRequest;
+module.exports.createRequestWithoutRequiredHeaders = createRequestWithoutRequiredHeaders;
 exports.completionAggregator = completionAggregator;


### PR DESCRIPTION
###  Summary

Fixes Issue https://github.com/slackapi/node-slack-sdk/issues/1069

We check that the required headers, (x-slack-signature, x-slack-request-timestamp) are present and exit early if not.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
