### PR TITLE
oauth docs: correct nodejs `.url` usage

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -99,7 +99,7 @@ const { createServer } = require('http');
 
 const server = createServer((req, res) =>  {
   // our redirect_uri is /slack/oauth_redirect
-  if (req.url === '/slack/oauth_redirect') {
+  if (req.url.startsWith('/slack/oauth_redirect')) {
     // call installer.handleCallback to wrap up the install flow
     installer.handleCallback(req, res);
   }


### PR DESCRIPTION
###  Summary

this is an [IncomingMessage](https://nodejs.org/docs/latest-v12.x/api/http.html#http_class_http_incomingmessage) object which gives the full URL for `.url`. We either want to switch to getting path, or check that we match the start of the URL. I just put what worked for me in dev/testing.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
