### PR TITLE
Update what versions of Node are tested on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - "8"
-  - "9"
   - "10"
   - "11"
+  - "12"
+  - "13"
+  - "14"
 env:
   - PACKAGE=@slack/web-api
   - PACKAGE=@slack/rtm-api


### PR DESCRIPTION
###  Summary

> ⚠️ **Note**: this only applies to what versions we automatically test in CI. Even though some versions were removed from testing, they are still technically supported by the current versions of SDK modules until the next opportunity to bump the minimum supported Node version.

- Dropped Node.js v8 & v9
- Added v12, v13, and v14

(This should unblock the failing tests in #1065.)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
