### PR TITLE
added clientOptions and authorizationUrl

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -33,7 +33,8 @@
     "lint": "tslint --project .",
     "test": "nyc mocha --config .mocharc.json src/*.spec.js",
     "coverage": "codecov -F oauthhelper --root=$PWD",
-    "ref-docs:model": "api-extractor run"
+    "ref-docs:model": "api-extractor run",
+    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
     "@slack/logger": "^2.0.0",

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -218,6 +218,43 @@ describe('OAuth', async () => {
               assert.fail(error.message);
           }
       });
+      it('should return a generated url when passed a custom authorizationUrl', async () => {
+        const fakeStateStore = {
+          generateStateParam: sinon.fake.resolves('fakeState'),
+          verifyStateParam: sinon.fake.resolves({})
+        }
+        const authorizationUrl = 'https://dev.slack.com/oauth/v2/authorize';
+        const installer = new InstallProvider({ clientId, clientSecret, stateStore: fakeStateStore, authorizationUrl });
+        const scopes = ['channels:read'];
+        const teamId = '1234Team';
+        const redirectUri = 'https://mysite.com/slack/redirect';
+        const userScopes = ['chat:write:user']
+        const installUrlOptions = {
+          scopes,
+          metadata: 'some_metadata',
+          teamId,
+          redirectUri,
+          userScopes,
+        }
+        try {
+            const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
+            assert.exists(generatedUrl);
+            assert.equal(fakeStateStore.generateStateParam.callCount, 1);
+            assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
+            assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
+
+            const parsedUrl = url.parse(generatedUrl, true);
+            assert.equal(parsedUrl.query.state, 'fakeState');
+            assert.equal(parsedUrl.pathname, '/oauth/v2/authorize');
+            assert.equal(parsedUrl.host, 'dev.slack.com')
+            assert.equal(scopes.join(','), parsedUrl.query.scope);
+            assert.equal(redirectUri, parsedUrl.query.redirect_uri);
+            assert.equal(teamId, parsedUrl.query.team);
+            assert.equal(userScopes.join(','), parsedUrl.query.user_scope);
+        } catch (error) {
+            assert.fail(error.message);
+        }
+    });
       it('should return a generated v1 url', async () => {
           const fakeStateStore = {
             generateStateParam: sinon.fake.resolves('fakeState'),

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -5,12 +5,14 @@ const url = require('url');
 const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 const { ErrorCode } = require('./errors');
+const { LogLevel } = require('./logger');
 
 // Stub WebClient api calls that the OAuth package makes
 rewiremock(() => require('@slack/web-api')).with({
   WebClient: class {
-    constructor(token, _options) {
+    constructor(token, options) {
       this.token = token;
+      this.options = options;
     };
     auth = {
       test: sinon.fake.resolves({ bot_id: '' }),

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -41,7 +41,8 @@
     "test:mocha": "nyc mocha --config .mocharc.json src/*.spec.js",
     "test:types": "tsd",
     "coverage": "codecov -F webapi --root=$PWD",
-    "ref-docs:model": "api-extractor run"
+    "ref-docs:model": "api-extractor run",
+    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",


### PR DESCRIPTION
###  Summary

Added `clientOptions` and `authorizationUrl` as options that `@slack/oauth` accepts. `clientOptions` is passed along to `@slack/web-api`. `authorizationUrl` is used to override the authorization endpoint this library uses (default is `https://slack.com/oauth/v2/authorize`

Also added support for a `npm run watch` command that uses `nodemon` to watch for changes and rebuild the source. Great for developing on the package itself. 

Issue: #1055 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
