### PR TITLE
Append original stack when WebClient#apiCall throws

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -213,6 +213,7 @@ describe('WebClient', function () {
         r.catch((error) => {
           assert.instanceOf(error, Error);
           this.scope.done();
+          assert.match(error.stack, /Error: thrown by\n\s+at WebClient.apiCall/);
           done();
         });
       });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -145,50 +145,57 @@ export class WebClient extends Methods {
    * @param options - options
    */
   public async apiCall(method: string, options?: WebAPICallOptions): Promise<WebAPICallResult> {
-    this.logger.debug(`apiCall('${method}') start`);
+    const {stack: originalStack} = new Error('thrown by');
 
-    warnDeprecations(method, this.logger);
+    try {
+      this.logger.debug(`apiCall('${method}') start`);
 
-    if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
-      throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
-    }
+      warnDeprecations(method, this.logger);
 
-    const response = await this.makeRequest(method, Object.assign(
-      { token: this.token },
-      options,
-    ));
-    const result = this.buildResult(response);
+      if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
+        throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
+      }
 
-    // log warnings in response metadata
-    if (result.response_metadata !== undefined && result.response_metadata.warnings !== undefined) {
-      result.response_metadata.warnings.forEach(this.logger.warn.bind(this.logger));
-    }
+      const response = await this.makeRequest(method, Object.assign(
+        { token: this.token },
+        options,
+      ));
+      const result = this.buildResult(response);
 
-    // log warnings and errors in response metadata messages
-    // related to https://api.slack.com/changelog/2016-09-28-response-metadata-is-on-the-way
-    if (result.response_metadata !== undefined && result.response_metadata.messages !== undefined) {
-      result.response_metadata.messages.forEach((msg) => {
-        const errReg: RegExp = /\[ERROR\](.*)/;
-        const warnReg: RegExp = /\[WARN\](.*)/;
-        if (errReg.test(msg)) {
-          const errMatch = msg.match(errReg);
-          if (errMatch != null) {
-            this.logger.error(errMatch[1].trim());
+      // log warnings in response metadata
+      if (result.response_metadata !== undefined && result.response_metadata.warnings !== undefined) {
+        result.response_metadata.warnings.forEach(this.logger.warn.bind(this.logger));
+      }
+
+      // log warnings and errors in response metadata messages
+      // related to https://api.slack.com/changelog/2016-09-28-response-metadata-is-on-the-way
+      if (result.response_metadata !== undefined && result.response_metadata.messages !== undefined) {
+        result.response_metadata.messages.forEach((msg) => {
+          const errReg: RegExp = /\[ERROR\](.*)/;
+          const warnReg: RegExp = /\[WARN\](.*)/;
+          if (errReg.test(msg)) {
+            const errMatch = msg.match(errReg);
+            if (errMatch != null) {
+              this.logger.error(errMatch[1].trim());
+            }
+          } else if (warnReg.test(msg)) {
+            const warnMatch = msg.match(warnReg);
+            if (warnMatch != null) {
+              this.logger.warn(warnMatch[1].trim());
+            }
           }
-        } else if (warnReg.test(msg)) {
-          const warnMatch = msg.match(warnReg);
-          if (warnMatch != null) {
-            this.logger.warn(warnMatch[1].trim());
-          }
-        }
-      });
-    }
+        });
+      }
 
-    if (!result.ok) {
-      throw platformErrorFromResult(result as (WebAPICallResult & { error: string; }));
-    }
+      if (!result.ok) {
+        throw platformErrorFromResult(result as (WebAPICallResult & { error: string; }));
+      }
 
-    return result;
+      return result;
+    } catch (err) {
+      err.stack += `\n${originalStack}`;
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
###  Summary

When an API call within `@slack/web-api` fails, the resulting error's stack loses the call context:

```
Error: An API error occurred: account_inactive
     at Object.platformErrorFromResult (/project/node_modules/@slack/web-api/src/errors.ts:94:5)
     at WebClient.apiCall (/project/node_modules/@slack/web-api/src/WebClient.ts:188:13)
     at runMicrotasks (<anonymous>)
     at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

This PR appends the original stack leading up to the call so that developers can more easily trace failing calls.

For more details, see https://github.com/slackapi/node-slack-sdk/issues/561#issuecomment-679265974

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
