### PR TITLE
InstallProviderOptions authVersion as optional

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -28,7 +28,7 @@ It may be helpful to read the tutorials on [getting started](https://slack.dev/n
 This package exposes an `InstallProvider` class, which sets up the required configuration and exposes methods such as `generateInstallUrl`, `handleCallback`, `authorize` for use within your apps. At a minimum, `InstallProvider` takes a `clientId` and `clientSecret` (both which can be obtained under the **Basic Information** of your app configuration). `InstallProvider` also requires a `stateSecret`, which is used to encode the generated state, and later used to decode that same state to verify it wasn't tampered with during the OAuth flow. **Note**: This example is not ready for production because it only stores installations (tokens) in memory. Please go to the [storing installations in a database](#storing-installations-in-a-database) section to learn how to plug in your own database.
 
 ```javascript
-const { InstallProvider } = require('@slack/oauth');;
+const { InstallProvider } = require('@slack/oauth');
 
 // initialize the installProvider
 const installer = new InstallProvider({
@@ -44,7 +44,7 @@ const installer = new InstallProvider({
 </summary>
 
   ```javascript
-  const { InstallProvider } = require('@slack/oauth');;
+  const { InstallProvider } = require('@slack/oauth');
 
   // initialize the installProvider
   const installer = new InstallProvider({

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -315,7 +315,7 @@ export interface InstallProviderOptions {
   stateStore?: StateStore; // default ClearStateStore
   stateSecret?: string; // ClearStateStoreOptions['secret']; // required when using default stateStore
   installationStore?: InstallationStore; // default MemoryInstallationStore
-  authVersion: 'v1' | 'v2'; // default 'v2'
+  authVersion?: 'v1' | 'v2'; // default 'v2'
   logger?: Logger;
   logLevel?: LogLevel;
   clientOptions?: Omit<WebClientOptions, 'logLevel' | 'logger'>;


### PR DESCRIPTION
###  Summary

This PR fixes a little typo in the oauth documentation and change the InstallProviderOptions.authVersion type to optional because the constructor has a fallback to 'v2' in this case.

Currently following the documentation example in https://github.com/slackapi/node-slack-sdk/blob/main/docs/_packages/oauth.md#initialize-the-installer I've got this error:

<img width="844" alt="authversion_error" src="https://user-images.githubusercontent.com/2389019/91657602-1ed03680-eaba-11ea-83cb-dce46b728c2d.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
