### PR TITLE
Add external_id to View interface

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,6 +42,7 @@ export interface View {
   private_metadata?: string;
   clear_on_close?: boolean; // defaults to false
   notify_on_close?: boolean; // defaults to false
+  external_id?: string;
 }
 
 /*
@@ -85,7 +86,7 @@ export interface Confirm {
  * Action Types
  */
 
- // Selects and Multiselects are available in different surface areas so I've seperated them here
+// Selects and Multiselects are available in different surface areas so I've seperated them here
 export type Select = UsersSelect | StaticSelect | ConversationsSelect | ChannelsSelect | ExternalSelect;
 
 export type MultiSelect =


### PR DESCRIPTION
###  Summary

Adds `external_id` as optional prop to View interface

Note: this has been introduced in the published `"@slack/types": "feat-workflow-steps"`, but in the interest of cleaning up dependencies and this not being workflow-steps-specific, suggesting the change here.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
