### PR TITLE
Add support for Workflow Steps from Apps

### DIFF
--- a/docs/_reference/oauth.md
+++ b/docs/_reference/oauth.md
@@ -20,9 +20,71 @@ slug: oauth
 </thead>
 <tbody>
 <tr>
-<td align="center">{ clientId, clientSecret, stateSecret, stateStore, installationStore, authVersion, logger, logLevel, }</td>
-<td align="center"><code>InstallProviderOptions</code></td>
+<td align="center">opts</td>
+<td align="center"><code><a href="#installprovideroptions" title="">InstallProviderOptions</a></code></td>
 <td align="center">✓</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<strong>Options:</strong>
+<table>
+<thead>
+<tr>
+<th align="center">Name</th>
+<th align="center">Type</th>
+<th></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">authorizationUrl</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">authVersion</td>
+<td align="center"><code>'v1' | 'v2'</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientId</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientOptions</td>
+<td align="center"><code>Omit&#x3C;WebClientOptions, 'logLevel' | 'logger'></code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientSecret</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">installationStore</td>
+<td align="center"><code><a href="#installationstore" title="">InstallationStore</a></code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">logger</td>
+<td align="center"><code>Logger</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">logLevel</td>
+<td align="center"><code>LogLevel</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">stateSecret</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">stateStore</td>
+<td align="center"><code><a href="#statestore" title="">StateStore</a></code></td>
 <td></td>
 </tr>
 </tbody>
@@ -286,6 +348,69 @@ slug: oauth
 <tr>
 <td align="center">storeInstallation</td>
 <td align="center"><code>(installation: <a href="#installation" title="">Installation</a>, logger?: Logger) => Promise&#x3C;void></code></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<h2 id="installprovideroptions">InstallProviderOptions</h2>
+<h3>Fields</h3>
+<table>
+<thead>
+<tr>
+<th align="center">Name</th>
+<th align="center">Type</th>
+<th></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">authorizationUrl</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">authVersion</td>
+<td align="center"><code>'v1' | 'v2'</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientId</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientOptions</td>
+<td align="center"><code>Omit&#x3C;WebClientOptions, 'logLevel' | 'logger'></code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">clientSecret</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">installationStore</td>
+<td align="center"><code><a href="#installationstore" title="">InstallationStore</a></code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">logger</td>
+<td align="center"><code>Logger</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">logLevel</td>
+<td align="center"><code>LogLevel</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">stateSecret</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">stateStore</td>
+<td align="center"><code><a href="#statestore" title="">StateStore</a></code></td>
 <td></td>
 </tr>
 </tbody>

--- a/docs/_reference/types.md
+++ b/docs/_reference/types.md
@@ -1439,6 +1439,11 @@ slug: types
 <td></td>
 </tr>
 <tr>
+<td align="center">external_id</td>
+<td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
 <td align="center">notify_on_close</td>
 <td align="center"><code>boolean</code></td>
 <td></td>
@@ -1446,6 +1451,11 @@ slug: types
 <tr>
 <td align="center">private_metadata</td>
 <td align="center"><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td align="center">submit_disabled</td>
+<td align="center"><code>boolean</code></td>
 <td></td>
 </tr>
 <tr>
@@ -1460,7 +1470,7 @@ slug: types
 </tr>
 <tr>
 <td align="center">type</td>
-<td align="center"><code>'home' | 'modal'</code></td>
+<td align="center"><code>'home' | 'modal' | 'workflow_step'</code></td>
 <td></td>
 </tr>
 </tbody>

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/types",
-  "version": "1.8.0-workflowStepsBeta.2",
+  "version": "1.8.0",
   "description": "Shared type definitions for the Node Slack SDK",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/types",
-  "version": "1.8.0-workflowStepsBeta.1",
+  "version": "1.8.0-workflowStepsBeta.2",
   "description": "Shared type definitions for the Node Slack SDK",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/types",
-  "version": "1.8.0",
+  "version": "1.8.0-workflowStepsBeta.1",
   "description": "Shared type definitions for the Node Slack SDK",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,6 +42,7 @@ export interface View {
   private_metadata?: string;
   clear_on_close?: boolean; // defaults to false
   notify_on_close?: boolean; // defaults to false
+  submit_disabled?: boolean; // defaults to false
 }
 
 /*

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -43,6 +43,7 @@ export interface View {
   clear_on_close?: boolean; // defaults to false
   notify_on_close?: boolean; // defaults to false
   submit_disabled?: boolean; // defaults to false
+  external_id?: string;
 }
 
 /*
@@ -86,7 +87,7 @@ export interface Confirm {
  * Action Types
  */
 
- // Selects and Multiselects are available in different surface areas so I've seperated them here
+// Selects and Multiselects are available in different surface areas so I've seperated them here
 export type Select = UsersSelect | StaticSelect | ConversationsSelect | ChannelsSelect | ExternalSelect;
 
 export type MultiSelect =

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export interface Dialog {
 
 export interface View {
   title?: PlainTextElement;
-  type: 'home' | 'modal';
+  type: 'home' | 'modal' | 'workflow_step';
   blocks: (KnownBlock | Block)[];
   callback_id?: string;
   close?: PlainTextElement;

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "5.11.0",
+  "version": "5.10.0-workflowStepsBeta.1",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "5.11.0-workflowStepsBeta.1",
+  "version": "5.11.0",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/types": "feat-workflow-steps",
+    "@slack/types": "^1.7.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=8.9.0",
     "@types/p-queue": "^2.3.2",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "5.10.0-workflowStepsBeta.1",
+  "version": "5.11.0-workflowStepsBeta.1",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/types": "^1.7.0",
+    "@slack/types": "feat-workflow-steps",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=8.9.0",
     "@types/p-queue": "^2.3.2",

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1420,11 +1420,11 @@ export interface WorkflowsStepCompletedArguments extends WebAPICallOptions, Toke
   workflow_step_execute_id: string;
   outputs?: object;
 }
- 
+
 export interface WorkflowsStepFailedArguments extends WebAPICallOptions, TokenOverridable {
   workflow_step_execute_id: string;
   error: {
-      message: string;
+    message: string;
   };
 }
 

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -380,6 +380,12 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       set: bindApiCall<UsersProfileSetArguments, WebAPICallResult>(this, 'users.profile.set'),
     },
   };
+
+  public readonly workflows = {
+    stepCompleted: bindApiCall<WorkflowsStepCompletedArguments, WebAPICallResult>(this, 'workflows.stepCompleted'),
+    stepFailed: bindApiCall<WorkflowsStepFailedArguments, WebAPICallResult>(this, 'workflows.stepFailed'),
+    updateStep: bindApiCall<WorkflowsUpdateStepArguments, WebAPICallResult>(this, 'workflows.updateStep'),
+  };
 }
 
 /**
@@ -1405,6 +1411,31 @@ export interface ViewsUpdateArguments extends WebAPICallOptions, TokenOverridabl
   view: View;
   external_id?: string;
   hash?: string;
+}
+
+  /*
+   * `workflows.*`
+   */
+export interface WorkflowsStepCompletedArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_execute_id: string;
+  outputs?: object;
+}
+ 
+export interface WorkflowsStepFailedArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_execute_id: string;
+  error: {
+      message: string;
+  };
+}
+
+export interface WorkflowsUpdateStepArguments extends WebAPICallOptions, TokenOverridable {
+  workflow_step_edit_id: string;
+  inputs?: object;
+  outputs?: {
+    type: string;
+    name: string;
+    label: string;
+  }[];
 }
 
 export * from '@slack/types';


### PR DESCRIPTION
###  Summary

This pull request adds support for [Workflow Steps from Apps](https://api.slack.com/workflows/steps).

Packages affected:
- @slack/types
- @slack/web-api

---

> Workflow Steps provide the ability for Slack apps to create and process custom Workflow Steps for use in Workflows. Steps can be built to do things such as send data to external services, create tasks in project management systems, or update tickets. These steps can then be shared and used by anyone in the Workflow Builder to incorporate into Workflows they're building.
> 
> For more information on Workflow Steps, read full details here: https://api.slack.com/workflows/steps
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
