### PR TITLE
feat: upgrade p-queue (no changes)

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -49,12 +49,11 @@
     "@slack/types": "^1.7.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=8.9.0",
-    "@types/p-queue": "^2.3.2",
     "axios": "^0.19.0",
     "eventemitter3": "^3.1.0",
     "form-data": "^2.5.0",
     "is-stream": "^1.1.0",
-    "p-queue": "^2.4.2",
+    "p-queue": "^6.6.1",
     "p-retry": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
###  Summary

`p-queue` now provides its own types, and `@types/p-queue` throws a deprecation warning,
so remove it. (I only care about the deprecation warning.)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
