### PR TITLE
added new dispatch-action flag to input blocks

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -300,6 +300,7 @@ export interface InputBlock extends Block {
   hint?: PlainTextElement;
   optional?: boolean;
   element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons | Checkboxes;
+  dispatch_actions?: boolean;
 }
 
 export interface MessageAttachment {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -300,7 +300,7 @@ export interface InputBlock extends Block {
   hint?: PlainTextElement;
   optional?: boolean;
   element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons | Checkboxes;
-  dispatch_actions?: boolean;
+  dispatch_action?: boolean;
 }
 
 export interface MessageAttachment {


### PR DESCRIPTION
###  Summary

Adding support for the new `distpatch_action` flag to input blocks. Mentioned in https://api.slack.com/changelog#October_2020

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
