### PR TITLE
added user_id to oauth v1 responses

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -219,7 +219,7 @@ export class InstallProvider {
           user: {
             token: resp.access_token,
             scopes: resp.scope.split(','),
-            id: '', // Todo: no value for this
+            id: resp.user_id !== undefined ? resp.user_id : '' ,
           },
         };
 
@@ -400,6 +400,7 @@ interface OAuthV1Response {
   error?: string;
   // app_id is currently undefined but leaving it in here incase the v1 method adds it
   app_id: string | undefined;
+  user_id?: string; // Not documented but showing up on responses
 }
 
 export interface StateStore {


### PR DESCRIPTION
###  Summary

Fixes issue: #1103. Added missing `user_id` field in `OAuthV1Response`. This value is now included in the `installation` object for `v1` OAuth flow

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
