### PR TITLE
Org Apps: merging installation types

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -165,15 +165,34 @@ const installer = new InstallProvider({
     // returns nothing
     storeInstallation: (installation) => {
       // replace myDB.set with your own database or OEM setter
-      myDB.set(installation.team.id, installation);
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+        // enterprise app, org wide installation
+        myDB.set(installation.enterprise.id, installation);
+      } else if (installation.team.id !== undefined) {
+        // non enterprise org app installation
+        myDB.set(installation.team.id, installation);
+      } else {
+        throw new Error('Failed saving installation data to installationStore');
+      }
       return;
     },
     // takes in an installQuery as an argument
     // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
     // returns installation object from database
-    fetchInstallation: (installQuery) => {
+    fetchInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      return myDB.get(installQuery.teamId);
+      let result = undefined;
+      // enterprise org app installation lookup
+      if (InstallQuery.enterpriseId !== undefined) {
+        result = await myDB.get(installQuery.enterpriseId);
+      }
+
+      // non enterprise org app lookup
+      if (result === undefined && InstallQuery.teamId !== undefined) {
+        result = await myDB.get(installQuery.teamId);
+      }
+
+      return result;
     },
   },
 });

--- a/examples/oauth-v1/app.js
+++ b/examples/oauth-v1/app.js
@@ -59,7 +59,7 @@ app.get('/slack/oauth_redirect', async (req, res) => {
 slackEvents.on('app_home_opened', async (event, body) => {
   try {
     if (event.tab === 'home') {
-      const DBInstallData = await installer.authorize({teamId:body.team_id});
+      const DBInstallData = await installer.authorize({teamId:body.team_id, enterpriseId: body.enterprise_id});
       const web = new WebClient(DBInstallData.botToken);
       await web.views.publish({
         user_id: event.user,

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -34,11 +34,8 @@ const installer = new InstallProvider({
       if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // enterprise app, org wide installation
         keyv.set(installation.enterprise.id, installation);
-      } else if (installation.enterprise !== undefined) {
-        // enterprise app, single workspace installation
-        keyv.set(`${installation.enterprise.id}-${installation.team.id}`, installation);
       } else if (installation.team.id !== undefined) {
-        // non enterprise installation
+        // non enterprise org app installation
         keyv.set(installation.team.id, installation);
       } else {
         throw new Error('Failed saving installation data to installationStore');
@@ -53,12 +50,7 @@ const installer = new InstallProvider({
         result = await keyv.get(InstallQuery.enterpriseId);
       }
 
-      // non org app installation but still in enterprise lookup
-      if (result === undefined && InstallQuery.enterpriseId !== undefined && InstallQuery.teamId !== undefined) {
-        result = await keyv.get(`${InstallQuery.enterpriseId}-${InstallQuery.teamId}`);
-      }
-
-      // non enterprise lookup
+      // non org app lookup
       if (result === undefined && InstallQuery.teamId !== undefined) {
         result = await keyv.get(InstallQuery.teamId);
       }

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -33,15 +33,13 @@ const installer = new InstallProvider({
     storeInstallation: (installation) => {
       if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // enterprise app, org wide installation
-        keyv.set(installation.enterprise.id, installation);
+        return await keyv.set(installation.enterprise.id, installation);
       } else if (installation.team.id !== undefined) {
         // non enterprise org app installation
-        keyv.set(installation.team.id, installation);
+        return await keyv.set(installation.team.id, installation);
       } else {
         throw new Error('Failed saving installation data to installationStore');
       }
-
-      return
     },
     fetchInstallation: async (InstallQuery) => {
       let result = undefined;

--- a/examples/oauth-v2/package.json
+++ b/examples/oauth-v2/package.json
@@ -11,7 +11,7 @@
   "repository": "slackapi/node-slack-sdk",
   "dependencies": {
     "@slack/events-api": "^2.3.2",
-    "@slack/oauth": "^1.0.0",
+    "@slack/oauth": "feat-org-apps",
     "@slack/web-api": "^5.8.0",
     "express": "^4.17.1",
     "keyv": "^4.0.0"

--- a/node-slack-sdk.code-workspace
+++ b/node-slack-sdk.code-workspace
@@ -9,6 +9,10 @@
 			"path": "packages/web-api"
 		},
 		{
+			"name": "OAuth",
+			"path": "packages/oauth"
+		},
+		{
 			"name": "Events API",
 			"path": "packages/events-api"
 		},

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -32,7 +32,7 @@ It may be helpful to read the tutorials on [getting started](https://slack.dev/n
 
 ### Initialize the installer
 
-This package exposes an `InstallProvider` class, which sets up the required configuration and exposes methods such as `generateInstallUrl`, `handleCallback`, `authorize` for use within your apps. At a minimum, `InstallProvider` takes a `clientId` and `clientSecret` (both which can be obtained under the **Basic Information** of your app configuration). `InstallProvider` also requires a `stateSecret`, which is used to encode the generated state, and later used to decode that same state to verify it wasn't tampered with during the OAuth flow. **Note**: This example is not ready for production because it only stores installations (tokens) in memory. Please go to the [storing installations in a database](#storing-installations-in-a-database) section to learn how to plug in your own database.
+This package exposes an `InstallProvider` class, which sets up the required configuration and exposes methods such as `generateInstallUrl`, `handleCallback`, `authorize`, `orgAuthorize` for use within your apps. At a minimum, `InstallProvider` takes a `clientId` and `clientSecret` (both which can be obtained under the **Basic Information** of your app configuration). `InstallProvider` also requires a `stateSecret`, which is used to encode the generated state, and later used to decode that same state to verify it wasn't tampered with during the OAuth flow. **Note**: This example is not ready for production because it only stores installations (tokens) in memory. Please go to the [storing installations in a database](#storing-installations-in-a-database) section to learn how to plug in your own database.
 
 ```javascript
 const { InstallProvider } = require('@slack/oauth');;
@@ -162,9 +162,11 @@ app.get('/slack/oauth_redirect', (req, res) => {
 
 Although this package uses a default `MemoryInstallationStore`, it isn't recommended for production use since the access tokens it stores would be lost when the process terminates or restarts. Instead, `InstallProvider` has an option for supplying your own installation store, which is used to save and retrieve install information (like tokens) to your own database.
 
-An installation store is an object that provides two methods: `storeInstallation` and `fetchInstallation`. `storeInstallation` takes an `installation` as an argument, which is an object that contains all installation related data (like tokens, teamIds, enterpriseIds, etc). `fetchInstallation` takes in a `installQuery`, which is used to query the database. The `installQuery` can contain `teamId`, `enterpriseId`, `userId`, and `conversationId`.   
+An installation store is an object that provides four methods: `storeInstallation`, `storeOrgInstallation`, `fetchInstallation` and `fetchOrgInstallation`. `storeInstallation` and `storeOrgInstallation` takes an `installation` as an argument, which is an object that contains all installation related data (like tokens, teamIds, enterpriseIds, etc). `fetchInstallation` and `fetchOrgInstallation` takes in a `installQuery`, which is used to query the database. The `installQuery` can contain `teamId`, `enterpriseId`, `userId`, and `conversationId`. 
 
-In the following example, the `installationStore` option is used and the object is defined in line. The required methods are implemented by calling an example database library with simple get and set operations.
+**Note**: `fetchOrgInstallation` and `storeOrgInstallation` were introduced to support Org wide app installations (currently in beta).  
+
+In the following example, the `installationStore` option is used and the object is defined in line. The methods are implemented by calling an example database library with simple get and set operations.
 
 ```javascript
 const installer = new InstallProvider({
@@ -176,34 +178,39 @@ const installer = new InstallProvider({
     // returns nothing
     storeInstallation: (installation) => {
       // replace myDB.set with your own database or OEM setter
-      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
-        // enterprise app, org wide installation
-        myDB.set(installation.enterprise.id, installation);
-      } else if (installation.team.id !== undefined) {
+      if (installation.team.id !== undefined) {
         // non enterprise org app installation
-        myDB.set(installation.team.id, installation);
+        return myDB.set(installation.team.id, installation);
       } else {
         throw new Error('Failed saving installation data to installationStore');
       }
-      return;
     },
     // takes in an installQuery as an argument
     // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
     // returns installation object from database
     fetchInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      let result = undefined;
-      // enterprise org app installation lookup
-      if (InstallQuery.enterpriseId !== undefined) {
-        result = await myDB.get(installQuery.enterpriseId);
-      }
-
       // non enterprise org app lookup
-      if (result === undefined && InstallQuery.teamId !== undefined) {
-        result = await myDB.get(installQuery.teamId);
+      return await myDB.get(installQuery.teamId);
+    },
+    // takes in an installation object as an argument
+    // returns nothing
+    storeOrgInstallation: (installation) => {
+      // replace myDB.set with your own database or OEM setter
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+        // enterprise app, org wide installation
+        return myDB.set(installation.enterprise.id, installation);
+      } else {
+        throw new Error('Failed saving installation data to installationStore');
       }
-
-      return result;
+    },
+    // takes in an installQuery as an argument
+    // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
+    // returns installation object from database
+    fetchInstallation: async (installQuery) => {
+      // replace myDB.get with your own database or OEM getter
+      // enterprise org app installation lookup
+      return await myDB.get(installQuery.enterpriseId);
     },
   },
 });
@@ -212,12 +219,13 @@ const installer = new InstallProvider({
 
 ### Reading tokens and other installation data
 
-You can use the the `installationProvider.authorize()` function to fetch data that has been saved in your installation store.
+You can use the the `installationProvider.authorize()` function to fetch data that has been saved in your installation store. For Org wide app installations, you can use `installationProvider.orgAuthorize()`
 
 ```javascript
 // installer.authorize takes in an installQuery as an argument
 // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
-const result = installer.installationStore.fetchInstallation({teamId:'my-team-ID', enterpriseId:'my-enterprise-ID'});
+const result = installer.authorize({teamId:'my-team-ID'});
+const orgResult = installer.orgAuthorize({enterpriseId:'my-enterprise-ID'});
 /*
 result = {
   botToken: '',
@@ -233,13 +241,14 @@ result = {
 <strong><i>Reading extended installation data</i></strong>
 </summary>
 
-The `installer.authorize()` method only returns a subset of the installation data returned by the installation store. To fetch the entire saved installation, use the `installer.installationStore.fetchInstallation()` method. 
+The `installer.authorize()`/`installer.orgAuthorize()` methods only returns a subset of the installation data returned by the installation store. To fetch the entire saved installation, use the `installer.installationStore.fetchInstallation()`/`installer.installationStore.fetchOrgInstallation()` methods. 
 
 ```javascript
 // installer.installationStore.fetchInstallation takes in an installQuery as an argument
 // installQuery = {teamId: 'string', enterpriseId: 'string', userId: string, conversationId: 'string'};
 // returns an installation object
 const result = installer.installationStore.fetchInstallation({teamId:'my-team-ID', enterpriseId:'my-enterprise-ID'});
+const orgResult = installer.installationStore.fetchOrgInstallation({enterpriseId:'my-enterprise-ID'});
 ```
 </details>
 

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@slack/oauth",
-<<<<<<< HEAD
   "version": "1.3.0",
-=======
-  "version": "1.2.0-orgAppsBeta.3",
->>>>>>> Publish
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@slack/oauth",
+<<<<<<< HEAD
   "version": "1.3.0",
+=======
+  "version": "1.2.0-orgAppsBeta.3",
+>>>>>>> Publish
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "1.3.0",
+  "version": "1.3.0-orgAppsBeta.4",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -463,13 +463,13 @@ class MemoryInstallationStore implements InstallationStore {
     // db write
     if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
       this.devDB[installation.enterprise.id] = installation;
-    } else if (installation.team.id !== undefined) {
+    } else if (installation.team !== null && installation.team.id !== undefined) {
       this.devDB[installation.team.id] = installation;
     } else {
       throw new Error('Failed saving installation data to installationStore');
     }
 
-    return;
+    return Promise.resolve();
   }
 
   public async fetchInstallation(query: InstallationQuery, logger?: Logger): Promise<Installation> {
@@ -496,9 +496,9 @@ class MemoryInstallationStore implements InstallationStore {
 // result. This is a normalized shape.
 export interface Installation {
   team: {
-    id?: string;
-    name?: string;
-  };
+    id: string;
+    name: string;
+  } | null;
   enterprise?: {
     id: string;
     name?: string;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -268,6 +268,7 @@ export class InstallProvider {
             id: botId,
           },
           tokenType: resp.token_type,
+          isEnterpriseInstall: resp.is_enterprise_install,
         };
 
         if (resp.enterprise !== null) {
@@ -369,6 +370,7 @@ interface OAuthV2Response {
   bot_user_id: string;
   team: { id: string, name: string };
   enterprise: { name: string, id: string } | null;
+  is_enterprise_install: boolean;
   error?: string;
   incoming_webhook?: {
     url: string,
@@ -457,8 +459,16 @@ class MemoryInstallationStore implements InstallationStore {
     if (logger !== undefined) {
       logger.warn('Storing Access Token. Please use a real Installation Store for production!');
     }
+
     // db write
-    this.devDB[installation.team.id] = installation;
+    if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+      this.devDB[installation.enterprise.id] = installation;
+    } else if (installation.team.id !== undefined) {
+      this.devDB[installation.team.id] = installation;
+    } else {
+      throw new Error('Failed saving installation data to installationStore');
+    }
+
     return;
   }
 
@@ -466,9 +476,19 @@ class MemoryInstallationStore implements InstallationStore {
     if (logger !== undefined) {
       logger.warn('Retrieving Access Token from DB. Please use a real Installation Store for production!');
     }
-    // db read
-    const item = this.devDB[query.teamId];
-    return item;
+
+    let item: Installation | undefined = undefined;
+    // enterprise org app installation lookup
+    if (query.enterpriseId !== undefined) {
+      item = this.devDB[query.enterpriseId];
+    }
+
+    // non org app lookup
+    if (item === undefined && query.teamId !== undefined) {
+      item = this.devDB[query.teamId];
+    }
+
+    return item!;
   }
 }
 
@@ -476,13 +496,14 @@ class MemoryInstallationStore implements InstallationStore {
 // result. This is a normalized shape.
 export interface Installation {
   team: {
-    id: string;
-    name: string;
+    id?: string;
+    name?: string;
   };
   enterprise?: {
     id: string;
     name?: string;
   };
+  isEnterpriseInstall?: boolean;
   bot?: {
     token: string;
     scopes: string[];

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -74,6 +74,7 @@ export class InstallProvider {
     this.clientSecret = clientSecret;
     this.handleCallback = this.handleCallback.bind(this);
     this.authorize = this.authorize.bind(this);
+    this.orgAuthorize = this.orgAuthorize.bind(this);
     this.authVersion = authVersion;
 
     this.authorizationUrl = authorizationUrl;
@@ -90,11 +91,41 @@ export class InstallProvider {
   }
 
   /**
-   * Fetches data from the installationStore.
+   * Fetches data from the installationStore for non Org Installations.
    */
   public async authorize(source: InstallationQuery): Promise<AuthorizeResult> {
     try {
       const queryResult = await this.installationStore.fetchInstallation(source, this.logger);
+
+      if (queryResult === undefined) {
+        throw new Error('Failed fetching data from the Installation Store');
+      }
+
+      const authResult: AuthorizeResult = {};
+      authResult.userToken = queryResult.user.token;
+      authResult.teamId = queryResult.team.id;
+      if (queryResult.bot !== undefined) {
+        authResult.botToken = queryResult.bot.token;
+        authResult.botId = queryResult.bot.id;
+        authResult.botUserId = queryResult.bot.userId;
+      }
+
+      return authResult;
+    } catch (error) {
+      throw new AuthorizationError(error.message);
+    }
+  }
+
+  /**
+   * Fetches data from the installationStore for Org Installations.
+   */
+  public async orgAuthorize(source: OrgInstallationQuery): Promise<AuthorizeResult> {
+    try {
+      if (this.installationStore.fetchOrgInstallation === undefined) {
+        throw new Error('Installation Store is missing the fetchOrgInstallation method');
+      }
+
+      const queryResult = await this.installationStore.fetchOrgInstallation(source, this.logger);
 
       if (queryResult === undefined) {
         throw new Error('Failed fetching data from the Installation Store');
@@ -202,7 +233,7 @@ export class InstallProvider {
       const client = new WebClient('', this.clientOptions);
 
       let resp;
-      let installation: Installation;
+      let installation: Installation | OrgInstallation;
       if (this.authVersion === 'v1') {
         // convert response type from WebApiCallResult to OAuthResponse
         resp = await client.oauth.access({
@@ -253,28 +284,45 @@ export class InstallProvider {
         const botId = await getBotId(resp.access_token, this.clientOptions);
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response
-        installation = {
-          team: resp.team,
-          appId: resp.app_id,
-          user: {
-            token: resp.authed_user.access_token,
-            scopes: resp.authed_user.scope !== undefined ? resp.authed_user.scope.split(',') : undefined,
-            id: resp.authed_user.id,
-          },
-          bot: {
-            scopes: resp.scope.split(','),
-            token: resp.access_token,
-            userId: resp.bot_user_id,
-            id: botId,
-          },
-          tokenType: resp.token_type,
-          isEnterpriseInstall: resp.is_enterprise_install,
-        };
 
-        if (resp.enterprise !== null) {
-          installation.enterprise = {
-            id: resp.enterprise.id,
-            name: resp.enterprise.name,
+        if (resp.is_enterprise_install) {
+          // org installation
+          installation = {
+            enterprise: resp.enterprise!,
+            appId: resp.app_id,
+            user: {
+              token: resp.authed_user.access_token,
+              scopes: resp.authed_user.scope !== undefined ? resp.authed_user.scope.split(',') : undefined,
+              id: resp.authed_user.id,
+            },
+            bot: {
+              scopes: resp.scope.split(','),
+              token: resp.access_token,
+              userId: resp.bot_user_id,
+              id: botId,
+            },
+            tokenType: resp.token_type,
+            isEnterpriseInstall: resp.is_enterprise_install,
+          };
+        } else {
+          // workspace or non org enterprise installation
+          installation = {
+            team: resp.team!,
+            ...(resp.enterprise !== null && resp.enterprise !== undefined) ? { enterprise: resp.enterprise } : {},
+            appId: resp.app_id,
+            user: {
+              token: resp.authed_user.access_token,
+              scopes: resp.authed_user.scope !== undefined ? resp.authed_user.scope.split(',') : undefined,
+              id: resp.authed_user.id,
+            },
+            bot: {
+              scopes: resp.scope.split(','),
+              token: resp.access_token,
+              userId: resp.bot_user_id,
+              id: botId,
+            },
+            tokenType: resp.token_type,
+            ...(resp.is_enterprise_install !== undefined) ? { isEnterpriseInstall: resp.is_enterprise_install } : {},
           };
         }
       }
@@ -288,8 +336,17 @@ export class InstallProvider {
         };
       }
 
-      // save access code to installationStore
-      await this.installationStore.storeInstallation(installation, this.logger);
+      if (installation.isEnterpriseInstall) {
+        if (this.installationStore.storeOrgInstallation === undefined) {
+          throw new Error('Installation store is missing the storeOrgInstallation method');
+        }
+        // save token to orgInstallationStore
+        await this.installationStore.storeOrgInstallation(installation as OrgInstallation, this.logger);
+      } else {
+        // save token to InstallationStore
+        await this.installationStore.storeInstallation(installation as Installation, this.logger);
+      }
+
       if (options !== undefined && options.success !== undefined) {
         this.logger.debug('calling passed in options.success');
         options.success(installation, installOptions, req, res);
@@ -336,7 +393,7 @@ export interface CallbackOptions {
   // installation. when provided, this function must complete the
   // callbackRes.
   success?: (
-    installation: Installation,
+    installation: Installation | OrgInstallation,
     options: InstallURLOptions,
     callbackReq: IncomingMessage,
     callbackRes: ServerResponse,
@@ -443,12 +500,14 @@ class ClearStateStore implements StateStore {
 
 export interface InstallationStore {
   storeInstallation: (installation: Installation, logger?: Logger) => Promise<void>;
+  storeOrgInstallation?: (installation: OrgInstallation, logger?: Logger) => Promise<void>;
   fetchInstallation: (query: InstallationQuery, logger?: Logger) => Promise<Installation>;
+  fetchOrgInstallation?: (query: OrgInstallationQuery, logger?: Logger) => Promise<OrgInstallation>;
 }
 
 // using a javascript object as a makeshift database for development
 interface DevDatabase {
-  [key: string]: Installation;
+  [key: string]: Installation | OrgInstallation;
 }
 
 // Default Install Store. Should only be used for development
@@ -461,9 +520,7 @@ class MemoryInstallationStore implements InstallationStore {
     }
 
     // db write
-    if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
-      this.devDB[installation.enterprise.id] = installation;
-    } else if (installation.team !== null && installation.team.id !== undefined) {
+    if (isNotOrgInstall(installation)) {
       this.devDB[installation.team.id] = installation;
     } else {
       throw new Error('Failed saving installation data to installationStore');
@@ -472,23 +529,43 @@ class MemoryInstallationStore implements InstallationStore {
     return Promise.resolve();
   }
 
+  public async storeOrgInstallation(installation: OrgInstallation, logger?: Logger): Promise<void> {
+    if (logger !== undefined) {
+      logger.warn('Storing Access Token. Please use a real Installation Store for production!');
+    }
+
+    // db write
+    if (installation.isEnterpriseInstall) {
+      this.devDB[installation.enterprise.id] = installation;
+    } else {
+      throw new Error('Failed saving installation data to installationStore');
+    }
+
+    return Promise.resolve();
+  }
+
+  // non org app lookup
   public async fetchInstallation(query: InstallationQuery, logger?: Logger): Promise<Installation> {
     if (logger !== undefined) {
       logger.warn('Retrieving Access Token from DB. Please use a real Installation Store for production!');
     }
 
-    let item: Installation | undefined = undefined;
-    // enterprise org app installation lookup
+    if (query.teamId !== undefined) {
+      return this.devDB[query.teamId] as Installation;
+    }
+    throw new Error('Failed fetching installation');
+  }
+
+  // enterprise org app installation lookup
+  public async fetchOrgInstallation(query: OrgInstallationQuery, logger?: Logger): Promise<OrgInstallation> {
+    if (logger !== undefined) {
+      logger.warn('Retrieving Access Token from DB. Please use a real Installation Store for production!');
+    }
+
     if (query.enterpriseId !== undefined) {
-      item = this.devDB[query.enterpriseId];
+      return this.devDB[query.enterpriseId] as OrgInstallation;
     }
-
-    // non org app lookup
-    if (item === undefined && query.teamId !== undefined) {
-      item = this.devDB[query.teamId];
-    }
-
-    return item!;
+    throw new Error('Failed fetching installation');
   }
 }
 
@@ -498,7 +575,7 @@ export interface Installation {
   team: {
     id: string;
     name: string;
-  } | null;
+  };
   enterprise?: {
     id: string;
     name?: string;
@@ -525,12 +602,48 @@ export interface Installation {
   tokenType?: string;
 }
 
+// this shape is for org installed apps
+export interface OrgInstallation {
+  enterprise: {
+    id: string;
+    name?: string;
+  };
+  bot?: {
+    token: string;
+    scopes: string[];
+    id?: string;
+    userId: string;
+  };
+  user: {
+    token?: string;
+    scopes?: string[];
+    id: string;
+  };
+  incomingWebhook?: {
+    url: string;
+    channel: string;
+    channelId: string;
+    configurationUrl: string;
+  };
+  appId: string | undefined;
+  tokenType?: string;
+  isEnterpriseInstall: boolean;
+}
+
 // This is intentionally structurally identical to AuthorizeSourceData
 // from App. It is redefined so that this class remains loosely coupled to
 // the rest of Bolt.
 export interface InstallationQuery {
   teamId: string;
   enterpriseId?: string;
+  userId?: string;
+  conversationId?: string;
+}
+
+// NOTE: `enterpriseId` is no longer optional, and `teamId` is optional
+export interface OrgInstallationQuery {
+  enterpriseId: string;
+  teamId?: string;
   userId?: string;
   conversationId?: string;
 }
@@ -543,17 +656,19 @@ export interface AuthorizeResult {
   userToken?: string;
   botId?: string;
   botUserId?: string;
+  teamId?: string;
 }
 
 // Default function to call when OAuth flow is successful
 function callbackSuccess(
-  installation: Installation,
+  installation: Installation | OrgInstallation,
   _options: InstallURLOptions | undefined,
   _req: IncomingMessage,
   res: ServerResponse,
 ): void {
   let redirectUrl;
-  if (installation.team !== null && installation.team.id !== undefined && installation.appId !== undefined) {
+
+  if (isNotOrgInstall(installation) && installation.appId !== undefined) {
     // redirect back to Slack native app
     // Changes to the workspace app was installed to, to the app home
     redirectUrl = `slack://app?team=${installation.team.id}&id=${installation.appId}`;
@@ -593,6 +708,11 @@ async function getBotId(token: string, clientOptions: WebClientOptions): Promise
   // If a user token was used for auth.test, there is no bot_id
   // return an empty string in this case
   return '';
+}
+
+// type guard to confirm an installation isn't an OrgInstallation
+function isNotOrgInstall(installation: Installation | OrgInstallation): installation is Installation {
+  return (installation as Installation).team !== undefined && (installation as Installation).team !== null;
 }
 
 export { Logger, LogLevel } from './logger';

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -368,7 +368,7 @@ interface OAuthV2Response {
   token_type: string;
   access_token: string;
   bot_user_id: string;
-  team: { id: string, name: string };
+  team: { id: string, name: string } | null;
   enterprise: { name: string, id: string } | null;
   is_enterprise_install: boolean;
   error?: string;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -103,6 +103,7 @@ export class InstallProvider {
 
       const authResult: AuthorizeResult = {};
       authResult.userToken = queryResult.user.token;
+      // Question: Should queryResult.team.id be passed in over source.teamId?
       authResult.teamId = queryResult.team.id;
       if (queryResult.bot !== undefined) {
         authResult.botToken = queryResult.bot.token;
@@ -144,6 +145,14 @@ export class InstallProvider {
         authResult.botToken = queryResult.bot.token;
         authResult.botId = queryResult.bot.id;
         authResult.botUserId = queryResult.bot.userId;
+      }
+
+      /**
+       *  since queryResult is a org installation, it won't have team.id. If one was passed in via source,
+       *  we should add it to the authResult
+       */
+      if (source.teamId !== undefined) {
+        authResult.teamId = source.teamId;
       }
 
       return authResult;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -284,7 +284,7 @@ export class InstallProvider {
 
         // get botId
         const authResult = await runAuthTest(resp.access_token, this.clientOptions);
-        const botId = authResult.bot_id !== undefined ? authResult.bot_id : '';
+        const botId = authResult.bot_id;
         const orgDashboardGrantAccess = authResult.url;
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -580,7 +580,6 @@ export interface Installation {
     id: string;
     name?: string;
   };
-  isEnterpriseInstall?: boolean;
   bot?: {
     token: string;
     scopes: string[];
@@ -600,13 +599,14 @@ export interface Installation {
   };
   appId: string | undefined;
   tokenType?: string;
+  isEnterpriseInstall?: boolean;
 }
 
 // this shape is for org installed apps
 export interface OrgInstallation {
   enterprise: {
     id: string;
-    name?: string;
+    name?: string; // is this ever not included for org apps?
   };
   bot?: {
     token: string;
@@ -672,6 +672,13 @@ function callbackSuccess(
     // redirect back to Slack native app
     // Changes to the workspace app was installed to, to the app home
     redirectUrl = `slack://app?team=${installation.team.id}&id=${installation.appId}`;
+  } else if (
+      installation.isEnterpriseInstall &&
+      installation.appId !== undefined &&
+      installation.enterprise !== undefined &&
+      installation.enterprise.name !== undefined) {
+    // org app install
+    redirectUrl = `https://${installation.enterprise.name}.enterprise.slack.com/manage/organization/apps/profile/${installation.appId}/workspaces/add`;
   } else {
     // redirect back to Slack native app
     // does not change the workspace the slack client was last in

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -258,7 +258,7 @@ export class InstallProvider {
         // need to create a botUser + request bot scope to have this be part of resp
         if (resp.bot !== undefined) { 
           const authResult = await runAuthTest(resp.bot.bot_access_token, this.clientOptions);
-          const botId = authResult.bot_id !== undefined ? authResult.bot_id : '';
+          const botId = authResult.bot_id;
 
           installation.bot = {
             id: botId,

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -313,7 +313,7 @@ export class InstallProvider {
           // workspace or non org enterprise installation
           installation = {
             team: resp.team!,
-            ...(resp.enterprise !== null && resp.enterprise !== undefined) ? { enterprise: resp.enterprise } : {},
+            enterprise: resp.enterprise ?? undefined, // sets enterprise to undefined if resp.enterprise is null
             appId: resp.app_id,
             user: {
               token: resp.authed_user.access_token,
@@ -327,7 +327,7 @@ export class InstallProvider {
               id: botId,
             },
             tokenType: resp.token_type,
-            ...(resp.is_enterprise_install !== undefined) ? { isEnterpriseInstall: resp.is_enterprise_install } : {},
+            isEnterpriseInstall: resp.is_enterprise_install,
           };
         }
       }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -285,7 +285,7 @@ export class InstallProvider {
         // get botId
         const authResult = await runAuthTest(resp.access_token, this.clientOptions);
         const botId = authResult.bot_id !== undefined ? authResult.bot_id : '';
-        const orgDashboardGrantAccess = authResult.url !== undefined ? authResult.url : undefined;
+        const orgDashboardGrantAccess = authResult.url;
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response
 

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -267,9 +267,9 @@ describe('WebClient', function () {
     it('should properly serialize simple API arguments', function () {
       const scope = nock('https://slack.com')
         // NOTE: this could create false negatives if the serialization order changes (it shouldn't matter)
-        .post(/api/, 'token=xoxb-faketoken&foo=stringval&bar=42&baz=false')
+        .post(/api/, 'token=xoxb-faketoken&team_id=T12345678&foo=stringval&bar=42&baz=false')
         .reply(200, { ok: true });
-      return this.client.apiCall('method', { foo: 'stringval', bar: 42, baz: false })
+      return this.client.apiCall('method', { foo: 'stringval', bar: 42, baz: false, team_id: 'T12345678' })
         .then(() => {
           scope.done();
         });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -79,6 +79,11 @@ export class WebClient extends Methods {
   private logger: Logger;
 
   /**
+   * This object's teamId value
+   */
+  private teamId?: string;
+
+  /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
    */
   constructor(token?: string, {
@@ -91,6 +96,7 @@ export class WebClient extends Methods {
     tls = undefined,
     rejectRateLimitedCalls = false,
     headers = {},
+    teamId = undefined,
   }: WebClientOptions = {}) {
     super();
 
@@ -102,6 +108,7 @@ export class WebClient extends Methods {
     // NOTE: may want to filter the keys to only those acceptable for TLS options
     this.tlsConfig = tls !== undefined ? tls : {};
     this.rejectRateLimitedCalls = rejectRateLimitedCalls;
+    this.teamId = teamId;
 
     // Logging
     if (typeof logger !== 'undefined') {
@@ -154,7 +161,10 @@ export class WebClient extends Methods {
     }
 
     const response = await this.makeRequest(method, Object.assign(
-      { token: this.token },
+      {
+        token: this.token,
+        team_id: this.teamId,
+      },
       options,
     ));
     const result = this.buildResult(response);
@@ -490,6 +500,7 @@ export interface WebClientOptions {
   tls?: TLSOptions;
   rejectRateLimitedCalls?: boolean;
   headers?: object;
+  teamId?: string;
 }
 
 export type TLSOptions = Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -456,6 +456,7 @@ export interface Searchable {
   highlight?: boolean;
   sort: 'score' | 'timestamp';
   sort_dir: 'asc' | 'desc';
+  team_id?: string;
 }
 
 // A set of method names is initialized here and added to each time an argument type extends the CursorPaginationEnabled
@@ -775,6 +776,7 @@ export interface AuthTestArguments extends WebAPICallOptions, TokenOverridable {
    */
 export interface BotsInfoArguments extends WebAPICallOptions, TokenOverridable  {
   bot?: string;
+  team_id?: string;
 }
 
   /*
@@ -827,6 +829,7 @@ export interface ChannelsArchiveArguments extends WebAPICallOptions, TokenOverri
 export interface ChannelsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   validate?: boolean;
+  team_id?: string;
 }
 export interface ChannelsHistoryArguments extends WebAPICallOptions, TokenOverridable, TimelinePaginationEnabled {
   channel: string;
@@ -854,6 +857,7 @@ export interface ChannelsLeaveArguments extends WebAPICallOptions, TokenOverrida
 export interface ChannelsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   exclude_members?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('channels.list');
 export interface ChannelsMarkArguments extends WebAPICallOptions, TokenOverridable {
@@ -942,6 +946,7 @@ export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOv
   thread_ts?: string;
   unfurl_links?: boolean;
   unfurl_media?: boolean;
+  team_id?: string;
 }
 export interface ChatScheduledMessagesListArguments extends WebAPICallOptions, TokenOverridable,
   CursorPaginationEnabled {
@@ -981,6 +986,7 @@ export interface ConversationsCloseArguments extends WebAPICallOptions, TokenOve
 export interface ConversationsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   is_private?: boolean;
+  team_id?: string;
 }
 export interface ConversationsHistoryArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled,
   TimelinePaginationEnabled {
@@ -1007,6 +1013,7 @@ export interface ConversationsLeaveArguments extends WebAPICallOptions, TokenOve
 export interface ConversationsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   types?: string; // comma-separated list of conversation types
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('conversations.list');
 export interface ConversationsMarkArguments extends WebAPICallOptions, TokenOverridable {
@@ -1090,6 +1097,7 @@ export interface FilesListArguments extends WebAPICallOptions, TokenOverridable,
   ts_from?: string;
   ts_to?: string;
   types?: string; // comma-separated list of file types
+  team_id?: string;
 }
 export interface FilesRevokePublicURLArguments extends WebAPICallOptions, TokenOverridable {
   file: string; // file id
@@ -1164,6 +1172,7 @@ export interface GroupsArchiveArguments extends WebAPICallOptions, TokenOverrida
 export interface GroupsCreateArguments extends WebAPICallOptions, TokenOverridable {
   name: string;
   validate?: boolean;
+  team_id?: string;
 }
 export interface GroupsCreateChildArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
@@ -1190,6 +1199,7 @@ export interface GroupsLeaveArguments extends WebAPICallOptions, TokenOverridabl
 export interface GroupsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   exclude_archived?: boolean;
   exclude_members?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('groups.list');
 export interface GroupsMarkArguments extends WebAPICallOptions, TokenOverridable {
@@ -1252,6 +1262,7 @@ export interface IMRepliesArguments extends WebAPICallOptions, TokenOverridable 
 export interface MigrationExchangeArguments extends WebAPICallOptions, TokenOverridable {
   users: string; // comma-separated list of users
   to_old?: boolean;
+  team_id?: string;
 }
 
   /*
@@ -1339,6 +1350,7 @@ export interface ReactionsListArguments extends WebAPICallOptions, TokenOverrida
   CursorPaginationEnabled {
   user?: string;
   full?: boolean;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('reactions.list');
 export interface ReactionsRemoveArguments extends WebAPICallOptions, TokenOverridable {
@@ -1423,9 +1435,11 @@ export interface TeamAccessLogsArguments extends WebAPICallOptions, TokenOverrid
   before?: number;
   count?: number;
   page?: number;
+  team_id?: string;
 }
 export interface TeamBillableInfoArguments extends WebAPICallOptions, TokenOverridable {
   user?: string;
+  team_id?: string;
 }
 export interface TeamInfoArguments extends WebAPICallOptions, TokenOverridable {}
 export interface TeamIntegrationLogsArguments extends WebAPICallOptions, TokenOverridable {
@@ -1435,9 +1449,11 @@ export interface TeamIntegrationLogsArguments extends WebAPICallOptions, TokenOv
   page?: number;
   service_id?: string;
   user?: string;
+  team_id?: string;
 }
 export interface TeamProfileGetArguments extends WebAPICallOptions, TokenOverridable {
   visibility?: 'all' | 'visible' | 'hidden';
+  team_id?: string;
 }
 
   /*
@@ -1488,6 +1504,7 @@ export interface UsersConversationsArguments extends WebAPICallOptions, TokenOve
   exclude_archived?: boolean;
   types?: string; // comma-separated list of conversation types
   user?: string;
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('users.conversations');
 export interface UsersDeletePhotoArguments extends WebAPICallOptions, TokenOverridable {}
@@ -1500,6 +1517,7 @@ export interface UsersInfoArguments extends WebAPICallOptions, TokenOverridable,
 }
 export interface UsersListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled, LocaleAware {
   presence?: boolean; // deprecated, defaults to false
+  team_id?: string;
 }
 cursorPaginationEnabledMethods.add('users.list');
 export interface UsersLookupByEmailArguments extends WebAPICallOptions, TokenOverridable {

--- a/support/integration-tests/.gitignore
+++ b/support/integration-tests/.gitignore
@@ -1,3 +1,3 @@
 # node / npm stuff
-/node_modules
-/package-lock.json
+node_modules
+package-lock.json


### PR DESCRIPTION
###  Summary

Merge the `OrgInstallation` and `Installation` interfaces into one generic `Installation<IsEnterpriseInstall>` interface.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
