### PR TITLE
Typescript: Adds the optional OAuth2 state type to InstallURLOptions interface

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -328,6 +328,7 @@ export interface InstallURLOptions {
   redirectUri?: string;
   userScopes?: string | string[]; // cannot be used with authVersion=v1
   metadata?: string; // Arbitrary data can be stored here, potentially to save app state or use for custom redirect
+  state?: string;
 }
 
 export interface CallbackOptions {


### PR DESCRIPTION
###  Summary

Adds the missing type of OAuth2 `state` property to `InstallURLOptions` while generating the URL using the `generateInstallUrl` method.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
