### PR TITLE
[socket-mode] Pass an agent to WebSocket in a proper way

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -451,7 +451,7 @@ export class SocketModeClient extends EventEmitter {
     const options: WebSocket.ClientOptions = {
       perMessageDeflate: false,
       ...this.clientOptions.tls,
-      ...this.clientOptions.agent,
+      ...(this.clientOptions.agent !== undefined ? { agent: this.clientOptions.agent } : {}),
     };
 
     let websocket: WebSocket;

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -451,7 +451,7 @@ export class SocketModeClient extends EventEmitter {
     const options: WebSocket.ClientOptions = {
       perMessageDeflate: false,
       ...this.clientOptions.tls,
-      ...(this.clientOptions.agent !== undefined ? { agent: this.clientOptions.agent } : {}),
+      agent: this.clientOptions.agent,
     };
 
     let websocket: WebSocket;


### PR DESCRIPTION
###  Summary

Fix passing an agent to `WebSocket`. `this.clientOptions.agent` was wrongly spread to WebSocket options, which effectively mean it wasn't used. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
