### PR TITLE
Standardize fetchInstallation to use installQuery as argument

### DIFF
--- a/docs/_tutorials/migrating_to_v6.md
+++ b/docs/_tutorials/migrating_to_v6.md
@@ -41,19 +41,19 @@ installationStore: {
       // change the line below so it saves to your database
       return await database.set(installation.team.id, installation);
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.teamId);
+      return await database.get(installQuery.teamId);
     },
     storeOrgInstallation: async (installation) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it saves to your database
       return await database.set(installation.enterprise.id, installation);
     },
-    fetchOrgInstallation: async (InstallQuery) => {
+    fetchOrgInstallation: async (installQuery) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.enterpriseId);
+      return await database.get(installQuery.enterpriseId);
     },
   },
 ```
@@ -72,15 +72,15 @@ installationStore: {
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // replace database.get so it fetches from your database
-      if (InstallQuery.isEnterpriseInstall && InstallQuery.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
-        return await database.get(InstallQuery.enterpriseId);
+        return await database.get(installQuery.enterpriseId);
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
-        return await database.get(InstallQuery.teamId);
+        return await database.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -40,16 +40,16 @@ const installer = new InstallProvider({
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
-      if (InstallQuery.isEnterpriseInstall) {
-        if (InstallQuery.enterpriseId !== undefined) {       
+    fetchInstallation: async (installQuery) => {
+      if (installQuery.isEnterpriseInstall) {
+        if (installQuery.enterpriseId !== undefined) {       
           // fetching org installation
-          return await keyv.get(InstallQuery.enterpriseId)
+          return await keyv.get(installQuery.enterpriseId)
         }
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // fetching single team installation
-        return await keyv.get(InstallQuery.teamId);
+        return await keyv.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -68,9 +68,9 @@ const installationStore = {
         resolve();
     });
   },
-  fetchInstallation: (query) => {
+  fetchInstallation: (installQuery) => {
     // db read
-    const item = devDB[query.teamId];
+    const item = devDB[installQuery.teamId];
     return new Promise((resolve) => {
         resolve(item);
     });


### PR DESCRIPTION
###  Summary

Currently, there is a lack of standard arg usage with `fetchInstallation`. 

This PR aligns all instances to use `installQuery` instead of `InstallQuery` (which suggests a class is being passed) and `query` (which is used once and is the odd instance out). To note, `installQuery` is already referenced across the package in various forms of documentation.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
