### PR TITLE
Attempt to fix flaky tests based on delayed promises

### DIFF
--- a/packages/interactive-messages/src/adapter.spec.js
+++ b/packages/interactive-messages/src/adapter.spec.js
@@ -662,7 +662,7 @@ describe('SlackMessageAdapter', function () {
         const timeout = this.adapter.syncResponseTimeout;
         this.timeout(timeout);
         this.adapter.action(requestPayload.callback_id, function () {
-          return delayed(timeout * 0.1, undefined, 'test error');
+          return delayed(0, undefined, 'test error');
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return assertResponseStatusAndMessage(dispatchResponse, 500);

--- a/packages/interactive-messages/test/helpers.js
+++ b/packages/interactive-messages/test/helpers.js
@@ -85,7 +85,8 @@ function createStreamRequest(signingSecret, ts, rawBody) {
 /**
  * Returns a Promise that resolves or rejects in approximately the specified amount of time with
  * the specified value or error reason.
- * @param {number} ms time in milliseconds in which to resolve or reject
+ * @param {number} ms time in milliseconds in which to resolve or reject. Zero is a special value which creates a
+ * Promise that resolves or rejects as soon as possible.
  * @param {*} value value used for resolve
  * @param {string} [rejectionReason] reason used for rejection
  * @returns {Promise<*>} a promise of the value type
@@ -96,14 +97,28 @@ function delayed(ms, value, rejectionReason) {
     error = new Error(rejectionReason);
   }
   return new Promise(function (resolve, reject) {
-    var id = setTimeout(function () {
-      clearTimeout(id);
-      if (error) {
-        reject(error);
-      } else {
-        resolve(value);
-      }
-    }, ms);
+    if (ms > 0) {
+      var id = setTimeout(function () {
+        clearTimeout(id);
+        if (error) {
+          reject(error);
+        } else {
+          resolve(value);
+        }
+      }, ms);
+    } else if (ms === 0) {
+      // setImmediate allows the returned Promise to resolve much sooner than setTimeout.
+      // See: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout
+      setImmediate(() => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(value);
+        }
+      });
+    } else {
+      reject(new Error('Cannot delay for a negative amount of time'));
+    }
   });
 }
 


### PR DESCRIPTION
###  Summary

schedule delayed promises sooner than possible with setTimeout to avoid flaky tests

fixes #1165 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
