### PR TITLE
Fix type for tlsConfig in WebClient.ts

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -61,7 +61,7 @@ export class WebClient extends Methods {
   /**
    * Configuration for custom TLS handling
    */
-  private tlsConfig: TLSOptions;
+  private tlsConfig: TLSOptions | {};
 
   /**
    * Preference for immediately rejecting API calls which result in a rate-limited response


### PR DESCRIPTION
###  Summary

Fixes type for tlsConfig in WebClient.ts as per line 109

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
