### PR TITLE
fix type definition of ChatPostMessageArguments

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -113,7 +113,7 @@ describe('WebClient', function () {
             response_metadata: {
               warnings: ['testWarning1', 'testWarning2'],
               messages: [
-                "[ERROR] unsupported type: sections [json-pointer:/blocks/0/type]", 
+                "[ERROR] unsupported type: sections [json-pointer:/blocks/0/type]",
                 "[WARN] A Content-Type HTTP header was presented but did not declare a charset, such as a 'utf-8'"
               ]
             }
@@ -164,7 +164,9 @@ describe('WebClient', function () {
         { method: 'chat.postEphemeral', args: { channel: "C123", blocks: [] } },
         { method: 'chat.postMessage', args: { channel: "C123", blocks: [] } },
         { method: 'chat.scheduleMessage', args: { channel: "C123", post_at: "100000000", blocks: [] } },
-        { method: 'chat.update', args: { channel: "C123", ts: "123.456", blocks: [] } }
+        { method: 'chat.update', args: { channel: "C123", ts: "123.456", blocks: [] } },
+        { method: 'chat.postMessage', args: { channel: "C123", attachments: [{ blocks: [] }] } },
+        { method: 'chat.postMessage', args: { channel: "C123", attachments: [{ blocks: [], fallback: "  " }] } },
       ];
 
       warningTestPatterns.reduce((acc, { method, args }) => {

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -159,6 +159,57 @@ describe('WebClient', function () {
             assert.isTrue(logger.error.calledOnce);
           });
       });
+
+      const warningTestPatterns = [
+        { method: 'chat.postEphemeral', args: { channel: "C123", blocks: [] } },
+        { method: 'chat.postMessage', args: { channel: "C123", blocks: [] } },
+        { method: 'chat.scheduleMessage', args: { channel: "C123", post_at: "100000000", blocks: [] } },
+        { method: 'chat.update', args: { channel: "C123", ts: "123.456", blocks: [] } }
+      ];
+
+      warningTestPatterns.reduce((acc, { method, args }) => {
+        const textPatterns = [{ text: "text" }]
+          .map(v => ({ method, args: Object.assign({}, v, args) }))
+        return acc.concat(textPatterns)
+      }, []).forEach(({ method, args }) => {
+        it(`should not send warning to logs when client executes ${method} with text argument`, function () {
+          const logger = {
+            debug: sinon.spy(),
+            info: sinon.spy(),
+            warn: sinon.spy(),
+            error: sinon.spy(),
+            setLevel: sinon.spy(),
+            setName: sinon.spy(),
+          };
+          const warnClient = new WebClient(token, { logLevel: LogLevel.WARN, logger });
+          return warnClient.apiCall(method, args)
+            .then(() => {
+              assert.isTrue(logger.warn.calledThrice);
+            });
+        });
+      });
+
+      warningTestPatterns.reduce((acc, { method, args }) => {
+        const textPatterns = [{ text: "" }, { text: null }, {}]
+          .map(v => ({ method, args: Object.assign({}, v, args) }))
+        return acc.concat(textPatterns)
+      }, []).forEach(({ method, args }) => {
+        it(`should send warning to logs when client executes ${method} without text argument(${args.text === "" ? "empty" : args.text})`, function () {
+          const logger = {
+            debug: sinon.spy(),
+            info: sinon.spy(),
+            warn: sinon.spy(),
+            error: sinon.spy(),
+            setLevel: sinon.spy(),
+            setName: sinon.spy(),
+          };
+          const warnClient = new WebClient(token, { logLevel: LogLevel.WARN, logger });
+          return warnClient.apiCall(method, args)
+            .then(() => {
+              assert.isTrue(logger.warn.callCount === 4)
+            });
+        });
+      });
     });
 
     describe('with OAuth scopes in the response headers', function () {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -961,7 +961,7 @@ export interface ChatPostEphemeralArguments extends WebAPICallOptions, TokenOver
 }
 export interface ChatPostMessageArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  text: string;
+  text?: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];

--- a/packages/web-api/test/types/webclient-named-method-types.test-d.ts
+++ b/packages/web-api/test/types/webclient-named-method-types.test-d.ts
@@ -9,10 +9,24 @@ expectType<Promise<WebAPICallResult>>(web.chat.postMessage({
   text: 'TEXT',
   key: 'VALUE',
 }));
+expectType<Promise<WebAPICallResult>>(web.chat.postMessage({
+  channel: 'CHANNEL',
+  blocks: [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          'text',
+      },
+    },
+  ],
+  key: 'VALUE',
+}));
 
 // calling a method directly with under-specified arguments should not work
 expectError(web.chat.postMessage({
-  channel: 'CHANNEL',
+  text: 'TEXT',
 }));
 
 // assigning an object with a specific type that includes arbitrary arguments should not work


### PR DESCRIPTION
###  Summary

Made `text` property of `ChatPostMessageArguments` optional.

close: #1172

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
