### PR TITLE
Add new `user_auth_blocks` property to chat.unfurl 

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -359,6 +359,7 @@ export interface ChatUnfurlArguments extends WebAPICallOptions, TokenOverridable
   user_auth_message?: string;
   user_auth_required?: boolean;
   user_auth_url?: string;
+  user_auth_blocks?: (KnownBlock | Block)[];
 }
 export interface ChatUpdateArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;


### PR DESCRIPTION
###  Summary

Add support for new `user_auth_blocks` property to chat.unfurl.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
