### PR TITLE
SocketModeClient: Add useful debug logging for trouble shooting

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -529,7 +529,7 @@ export class SocketModeClient extends EventEmitter {
    * each incoming message.
    */
   private async onWebsocketMessage({ data }: { data: string }): Promise<void> {
-    this.logger.debug('received a message on the WebSocket');
+    this.logger.debug(`received a message on the WebSocket: ${data}`);
 
     // parse message into slack event
     let event: {


### PR DESCRIPTION
###  Summary

This pull request adds a useful debug logging output in the message receiver. 

This output should be particularly helpful when a developer is not sure why the listeners in an app do not match for incoming requests. For instance, your app may handle only one event though the app actually receives multiple events (say, `app_mention` + `message`).

The following is an example app and its output with this PR's change:

```js
const { SocketModeClient } = require('@slack/socket-mode');
const appToken = process.env.SLACK_APP_TOKEN;
const client = new SocketModeClient({ appToken, logLevel: 'debug' });
client.on('message', async ({event, body, ack}) => { await ack(); });
(async () => { await client.start(); })();
```

```
$ npx node app.js
[DEBUG]  web-api:WebClient:0 initialized
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: disconnected
[DEBUG]  socket-mode:SocketModeClient:0 initialized
[DEBUG]  socket-mode:SocketModeClient:0 start()
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connecting
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connecting:authenticating
[DEBUG]  web-api:WebClient:0 apiCall('apps.connections.open') start
[DEBUG]  web-api:WebClient:0 will perform http request
[DEBUG]  web-api:WebClient:0 http response received
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connecting:authenticated
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connecting:handshaking
[DEBUG]  socket-mode:SocketModeClient:0 received a message on the WebSocket: {"type":"hello","num_connections":1,"debug_info":{"host":"applink-111-zxntm","build_number":10,"approximate_connection_time":18060},"connection_info":{"app_id":"A111"}}
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connected
[DEBUG]  socket-mode:SocketModeClient:0 transitioning to state: connected:ready
[DEBUG]  socket-mode:SocketModeClient:0 received a message on the WebSocket: {"envelope_id":"796c1f1c-ce92-4d7a-9ec3-4e400f9721f0","payload":{"token":"fixed-value","team_id":"T111","api_app_id":"A111","event":{"client_msg_id":"8937bef5-00a6-4e92-a07d-56ca7c2fa9cb","type":"message","text":"hi there!","user":"U111","ts":"1613035457.010900","team":"T111","channel":"C111","event_ts":"1613035457.010900","channel_type":"channel"},"type":"event_callback","event_id":"Ev01NG3L680Y","event_time":1613035457,"authorizations":[{"enterprise_id":null,"team_id":"T111","user_id":"U111","is_bot":true,"is_enterprise_install":false}],"is_ext_shared_channel":false,"event_context":"1-message-T111-C111"},"type":"events_api","accepts_response_payload":false,"retry_attempt":0,"retry_reason":""}
[DEBUG]  socket-mode:SocketModeClient:0 calling ack events_api
[DEBUG]  socket-mode:SocketModeClient:0 send() in state: connected,ready
[DEBUG]  socket-mode:SocketModeClient:0 sending message on websocket: {"envelope_id":"796c1f1c-ce92-4d7a-9ec3-4e400f9721f0","payload":{}}
```

From Slack app security perspective, it's safe enough to print request payloads. Nevertheless, modal submission or channel messages in Slack may contain confidential business information. Thus, we generally do not recommend turning this on in production environment.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
