### PR TITLE
Clear timer if input promise resolves before time runs out

### DIFF
--- a/packages/interactive-messages/src/util.spec.js
+++ b/packages/interactive-messages/src/util.spec.js
@@ -2,6 +2,7 @@ require('mocha');
 const { assert } = require('chai');
 const { promiseTimeout, errorCodes } = require('./util');
 const { delayed } = require('../test/helpers');
+const sinon = require('sinon');
 
 // test suite
 describe('promiseTimeout', function () {
@@ -42,4 +43,50 @@ describe('promiseTimeout', function () {
       assert.equal(error.code, errorCodes.PROMISE_TIMEOUT);
     });
   });
+
+  describe('timers', function() {
+    beforeEach(function() {
+      this.clock = sinon.useFakeTimers()
+    })
+
+    afterEach(function() {
+      this.clock.restore()
+    });
+
+    it('should clear timer when input resolves faster than timeout', function () {
+      sinon.spy(this.clock, 'clearTimeout');
+      const value = 'test';
+      const input = new Promise(function (resolve) {
+        setTimeout(function() {
+          resolve(value);
+        }, 10);
+      });
+      const output = promiseTimeout(20, input);
+      this.clock.tick(15);
+      const self = this;
+      return output.then(function (v) {
+        assert.isTrue(self.clock.clearTimeout.calledOnce);
+        assert.equal(v, value);
+      });
+    });
+
+    it('should clear timer when input resolves slower than timeout', function () {
+      sinon.spy(this.clock, 'clearTimeout');
+      const value = 'test';
+      const input = new Promise(function (resolve) {
+        setTimeout(function() {
+          resolve(value);
+        }, 20);
+      });
+      const output = promiseTimeout(10, input);
+      this.clock.tick(11);
+      const self = this;
+      return output.then(function (value) {
+        throw new Error('should not resolve. value: ' + value);
+      }, function (error) {
+        assert.isTrue(self.clock.clearTimeout.calledOnce);
+        assert.equal(error.code, errorCodes.PROMISE_TIMEOUT);
+      });
+    });
+  })
 });

--- a/packages/interactive-messages/src/util.ts
+++ b/packages/interactive-messages/src/util.ts
@@ -16,8 +16,9 @@ export const errorCodes = {
  */
 export function promiseTimeout<T>(ms: number, promise: T | Promise<T>): Promise<T> {
   // Create a promise that rejects in `ms` milliseconds
+  let id: ReturnType<typeof setTimeout>;
   const timeout = new Promise<never>((_resolve, reject) => {
-    const id = setTimeout(
+    id = setTimeout(
       () => {
         clearTimeout(id);
         reject(errorWithCode(new Error('Promise timed out'), ErrorCode.PromiseTimeout));
@@ -30,7 +31,10 @@ export function promiseTimeout<T>(ms: number, promise: T | Promise<T>): Promise<
   return Promise.race([
     promise as Promise<T>,
     timeout,
-  ]);
+  ]).then((value) => {
+    clearTimeout(id);
+    return value;
+  });
 }
 
 // NOTE: before this can be an external module:


### PR DESCRIPTION
###  Summary

Issue: https://github.com/slackapi/node-slack-sdk/issues/1180
Fixes a bug in the [implementation of promiseTimeout](https://github.com/slackapi/node-slack-sdk/blob/cc32ba7a4ee8b21cfe553d2c490a700110e118e0/packages/interactive-messages/src/util.ts#L17) where an uncleared timer would keep Node process waiting before exiting even if the input promise resolves faster than the timeout.
I discovered this when writing an integration test for a Slack action handler using Jest. Test runner would keep waiting on scheduled timer for a default timeout duration of 2.5 sec and issue a warning.
The solution is to clear the timeout on `Promise.race` resolution.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
