### PR TITLE
Fix #1185 Add state metadata to Installation interface

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -332,6 +332,11 @@ export class InstallProvider {
           configurationUrl: resp.incoming_webhook.configuration_url,
         };
       }
+      if (installOptions !== undefined && installOptions.metadata !== undefined) {
+        // Pass the metadata in state parameter if exists.
+        // Developers can use the value for additional/custom data associated with the installation.
+        installation.metadata = installOptions.metadata;
+      }
       // End: Build the installation object
 
       // Save installation object to installation store
@@ -596,6 +601,9 @@ export interface Installation<AuthVersion extends ('v1' | 'v2') = ('v1' | 'v2'),
 
   /** The version of Slack's auth flow that produced this installation. Synthesized as `v2` when not present. */
   authVersion?: AuthVersion;
+
+  /** A string value that can be held in the state parameter in the OAuth flow. */
+  metadata?: string;
 }
 
 /**


### PR DESCRIPTION
###  Summary

This pull request resolves #1185 by adding `metadata` in `Installation` interface. Refer to the issue #1185 and my comments in the code for more details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
