### PR TITLE
Fix #1195 Make text arg optional in chat.* methods

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1153,7 +1153,7 @@ export interface ChatMeMessageArguments extends WebAPICallOptions, TokenOverrida
 }
 export interface ChatPostEphemeralArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  text: string;
+  text?: string;
   user: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];
@@ -1180,7 +1180,7 @@ export interface ChatPostMessageArguments extends WebAPICallOptions, TokenOverri
 }
 export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  text: string;
+  text?: string;
   post_at: string;
   as_user?: boolean;
   attachments?: MessageAttachment[];

--- a/packages/web-api/test/types/webclient-named-method-types.test-d.ts
+++ b/packages/web-api/test/types/webclient-named-method-types.test-d.ts
@@ -1,6 +1,9 @@
 import { expectType, expectError } from 'tsd';
 import { WebClient, WebAPICallResult } from '../../';
 import { ChatPostMessageResponse } from '../../src/response/ChatPostMessageResponse';
+import { ChatScheduleMessageResponse } from '../../src/response/ChatScheduleMessageResponse';
+import { ChatPostEphemeralResponse } from '../../src/response/ChatPostEphemeralResponse';
+import { ChatUpdateResponse } from '../../src/response/ChatUpdateResponse';
 
 const web = new WebClient('TOKEN');
 
@@ -41,3 +44,40 @@ expectError(web.chat.postMessage({
 //   channel: 'CHANNEL',
 //   key: 'VALUE',
 // }));
+
+expectType<Promise<ChatPostMessageResponse>>(web.chat.postMessage({
+  channel: 'C111',
+  blocks: [],
+  // no text should be accepted
+}));
+expectType<Promise<ChatUpdateResponse>>(web.chat.update({
+  channel: 'C111',
+  ts: '111.222',
+  blocks: [],
+  // no text should be accepted
+}));
+
+expectType<Promise<ChatScheduleMessageResponse>>(web.chat.scheduleMessage({
+  channel: 'C111',
+  post_at: '11111',
+  blocks: [],
+  // no text should be accepted
+}));
+expectType<Promise<ChatScheduleMessageResponse>>(web.chat.scheduleMessage({
+  channel: 'C111',
+  post_at: '11111',
+  text: 'Hi there!',
+  blocks: [],
+}));
+expectType<Promise<ChatPostEphemeralResponse>>(web.chat.postEphemeral({
+  channel: 'C111',
+  user: 'U111',
+  blocks: [],
+  // no text should be accepted
+}));
+expectType<Promise<ChatPostEphemeralResponse>>(web.chat.postEphemeral({
+  channel: 'C111',
+  user: 'U111',
+  text: 'Hi there!',
+  blocks: [],
+}));


### PR DESCRIPTION
###  Summary

This pull request resolves #1195 by changing the type of `text` argument for `chat.postEphemeral` and `chat.scheduleMessage`, in addition to `chat.postMessage` & `chat.update`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
