### PR TITLE
Add integration tests with real Slack servers

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -21,7 +21,7 @@ and to allow lerna to link them to each other.
 
 ### Testing
 
-This project has tests for individual packages inside of each's respective `test` directory. It also has
+This project has tests for individual packages as `*.spec.js` files and inside of each's respective `test` directory. It also has
 integration tests in the `integration-tests` directory under the root `support` directory. You can run the entire test
 suite using the npm script `npm test` at the top level. This script will use Lerna to invoke tests in each package and
 the integration tests.
@@ -39,6 +39,8 @@ ensures that backwards compatibility is tested and the APIs look reasonable in v
 the most modern syntax.
 
 We have included `launch.json` files that store configuration for `vscode` debugging in each pacakge. This allows you to set breakpoints in test files and interactively debug. Open the project in `vscode` and navigate to the debug screen on the left sidebar. The icon for it looks like a little lock bug with an x inside. At the top in `vscode`, select the configuration to run and press the green play icon to start debugging. Alternatively, on mac, you can press `cmd + shift + d` to get to the debug screen and `F5` to start debugging. If you are using `vscode` debugging, don't forget to lint the source (`npm run lint`) manually.
+
+Also, for verifying the behavior with the real Slack server-side and developer experience with installed packages, you can run the tests amd scripts under `prod-server-integration-tests`. Refer to the README file in the directory for details. These tests are supposed to be run in the project maintainers' manual execution. They are not part of CI builds for now.
 
 ### Generating Documentation
 

--- a/prod-server-integration-tests/.gitignore
+++ b/prod-server-integration-tests/.gitignore
@@ -1,0 +1,3 @@
+logs/
+node_modules/
+package-lock.json

--- a/prod-server-integration-tests/README.md
+++ b/prod-server-integration-tests/README.md
@@ -1,0 +1,29 @@
+First off, you need to link `@slack/*` packages to `../packages/*` to verify the latest revision's behavior.
+
+```bash
+./link.sh
+```
+
+### How to run tests
+
+```bash
+# with all of the bot scopes
+export SLACK_SDK_TEST_BOT_TOKEN=xoxb-
+# with all of the user scopes
+export SLACK_SDK_TEST_USER_TOKEN=xoxp-
+# admin user's token for a workspace in an Enterprise Grid org
+export SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN=xoxp-
+# org-level admin user's token
+export SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN=xoxp-
+
+npm test
+```
+
+### How to run example scripts
+
+```bash
+# some examples may use different env variable names
+export SLACK_BOT_TOKEN=xoxb-(your own token)
+# Run the script
+npx node scripts/pagination.js # or whatever you want to run
+```

--- a/prod-server-integration-tests/link.sh
+++ b/prod-server-integration-tests/link.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+current_dir=`dirname $0`
+cd ${current_dir}
+npm unlink @slack/web-api \
+  && npm unlink @slack/socket-mode \
+  && npm i \
+  && cd ../packages/web-api \
+  && npm link \
+  && cd - \
+  && cd ../packages/socket-mode \
+  && npm link \
+  && cd - \
+  && npm i \
+  && npm link @slack/web-api \
+  && npm link @slack/socket-mode

--- a/prod-server-integration-tests/package.json
+++ b/prod-server-integration-tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@slack/web-api-code-snippets",
+  "description": "Basic examples of using @slack/web-api package",
+  "scripts": {
+    "test": "mocha --timeout 10000",
+    "test:clean": "./link.sh && mocha --timeout 10000"
+  },
+  "repository": "https://github.com/slackapi/node-slack-sdk",
+  "author": "Slack Technologies, Inc.",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^4",
+    "winston": "^3.3.3"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "mocha": "^8.3.2"
+  }
+}

--- a/prod-server-integration-tests/scripts/admin/usersSessionSettings.js
+++ b/prod-server-integration-tests/scripts/admin/usersSessionSettings.js
@@ -1,0 +1,48 @@
+// export SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN=
+// export SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN=
+
+const { WebClient } = require('@slack/web-api');
+
+(async () => {
+  // fetch 3 active members from a workspace
+  const teamAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN);
+  const users = await teamAdminClient.users.list({
+    exclude_archived: true,
+    limit: 100
+  });
+  const userIds = [];
+  for (const u of users.members) {
+    if (userIds.length >= 3) {
+      break;
+    }
+    if (!u.is_bot && !u.deleted && !u.is_app_user && !u.is_owner && u.id !== 'USLACKBOT') {
+      userIds.push(u.id);
+    }
+  }
+
+  // call get/set/clearSettings APIs
+  const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, {
+    logLevel: 'debug'
+  });
+
+  const get = await orgAdminClient.admin.users.session.getSettings({
+    user_ids: userIds
+  });
+  console.log(JSON.stringify(get, null, 2));
+
+  const set = await orgAdminClient.admin.users.session.setSettings({
+    user_ids: userIds,
+    duration: 60 * 60 * 24 * 30
+  });
+  console.log(JSON.stringify(set, null, 2));
+
+  const get2 = await orgAdminClient.admin.users.session.getSettings({
+    user_ids: userIds
+  });
+  console.log(JSON.stringify(get2, null, 2));
+
+  const clear = await orgAdminClient.admin.users.session.clearSettings({
+    user_ids: userIds
+  });
+  console.log(JSON.stringify(clear, null, 2));
+})();

--- a/prod-server-integration-tests/scripts/api_test.js
+++ b/prod-server-integration-tests/scripts/api_test.js
@@ -1,0 +1,6 @@
+const { WebClient } = require('@slack/web-api');
+const client = new WebClient();
+(async () => {
+  const response = await client.api.test({ foo: "bar" });
+  console.log(JSON.stringify(response, null, 2));
+})();

--- a/prod-server-integration-tests/scripts/auth_test.js
+++ b/prod-server-integration-tests/scripts/auth_test.js
@@ -1,0 +1,7 @@
+const { WebClient } = require('@slack/web-api');
+const token = process.env.SLACK_BOT_TOKEN;
+const client = new WebClient(token);
+(async () => {
+  const response = await client.auth.test();
+  console.log(JSON.stringify(response, null, 2));
+})();

--- a/prod-server-integration-tests/scripts/pagination.js
+++ b/prod-server-integration-tests/scripts/pagination.js
@@ -1,0 +1,15 @@
+const { WebClient } = require('@slack/web-api');
+const token = process.env.SLACK_BOT_TOKEN;
+const client = new WebClient(token);
+const user = process.env.SLACK_USER_ID;
+const parameters = { limit: 1 };
+if (user !== undefined) {
+  parameters.user = user;
+}
+
+(async () => {
+  // https://api.slack.com/methods/reactions.list
+  for await (const page of client.paginate('reactions.list', parameters)) {
+    console.log(JSON.stringify(page, null, 2));
+  }
+})();

--- a/prod-server-integration-tests/scripts/socket-mode.js
+++ b/prod-server-integration-tests/scripts/socket-mode.js
@@ -1,0 +1,6 @@
+const { SocketModeClient } = require('@slack/socket-mode');
+const appToken = process.env.SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN;
+const socketModeClient = new SocketModeClient({ appToken, logLevel: 'debug' });
+(async () => {
+  await socketModeClient.start();
+})();

--- a/prod-server-integration-tests/test/admin-web-api.js
+++ b/prod-server-integration-tests/test/admin-web-api.js
@@ -1,0 +1,72 @@
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+describe('admin.* Web APIs', function () {
+  // admin user's token for a workspace in an Enterprise Grid org
+  const teamAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, { logger, });
+  // org-level admin user's token
+  const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
+
+  describe('admin.users.session.{get|set|clear}Settings', function () {
+    it('should work', async function () {
+      // fetch 3 active members from a workspace
+      const users = await teamAdminClient.users.list({
+        exclude_archived: true,
+        limit: 100
+      });
+      const userIds = [];
+      for (const u of users.members) {
+        if (userIds.length >= 3) {
+          break;
+        }
+        if (!u.is_bot && !u.deleted && !u.is_app_user && !u.is_owner && u.id !== 'USLACKBOT') {
+          userIds.push(u.id);
+        }
+      }
+
+      // call get/set/clearSettings APIs
+      const get = await orgAdminClient.admin.users.session.getSettings({
+        user_ids: userIds
+      });
+      logger.info(get);
+      assert.isUndefined(get.error);
+
+      const set = await orgAdminClient.admin.users.session.setSettings({
+        user_ids: userIds,
+        duration: 60 * 60 * 24 * 30
+      });
+      logger.info(set);
+      assert.isUndefined(set.error);
+
+      const get2 = await orgAdminClient.admin.users.session.getSettings({
+        user_ids: userIds
+      });
+      logger.info(get2);
+      assert.isUndefined(get2.error);
+      assert.equal(get2.session_settings.length, userIds.length);
+
+      const clear = await orgAdminClient.admin.users.session.clearSettings({
+        user_ids: userIds
+      });
+      logger.info(clear);
+      assert.isUndefined(clear.error);
+
+      const get3 = await orgAdminClient.admin.users.session.getSettings({
+        user_ids: userIds
+      });
+      logger.info(get3);
+      assert.isUndefined(get3.error);
+      assert.equal(get3.session_settings.length, 0);
+      assert.equal(get3.no_settings_applied.length, userIds.length);
+    });
+  });
+});

--- a/prod-server-integration-tests/test/web-api.js
+++ b/prod-server-integration-tests/test/web-api.js
@@ -1,0 +1,31 @@
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+describe('Web APIs', function () {
+  const botClient = new WebClient(process.env.SLACK_SDK_TEST_BOT_TOKEN, { logger, });
+  const userClient = new WebClient(process.env.SLACK_SDK_TEST_USER_TOKEN, { logger, });
+
+  describe('auth.test', function () {
+
+    it('should work with a bot token', async function () {
+      const response = await botClient.auth.test();
+      logger.info(response);
+      assert.isUndefined(response.error);
+    });
+
+    it('should work with a user token', async function () {
+      const response = await userClient.auth.test();
+      logger.info(response);
+      assert.isUndefined(response.error);
+    });
+  });
+});


### PR DESCRIPTION
###  Summary

This pull request is a proposal for better quality assurance tests.

@stevengill @mwbrooks I'd like to know your thoughts on the following:

* where to place these
* the directory name (integration-tests is taken by support/integration-tests)
* the project structure
* better way than using `npm link`?
* should do tests in TypeScript?

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
