### PR TITLE
Add a unit test verifying #1037 is no longer an issue

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -13,6 +13,7 @@ const { CaptureConsole } = require('@aoberoi/capture-console');
 const nock = require('nock');
 const Busboy = require('busboy');
 const sinon = require('sinon');
+const axios = require('axios').default;
 
 const token = 'xoxb-faketoken';
 
@@ -29,6 +30,20 @@ describe('WebClient', function () {
     it('should build a client without a token', function () {
       const client = new WebClient();
       assert.instanceOf(client, WebClient);
+    });
+    it('should not modify global defaults in axios', function () {
+      // https://github.com/slackapi/node-slack-sdk/issues/1037
+      const client = new WebClient();
+
+      const globalDefault = axios.defaults.headers.post['Content-Type'];
+      // The axios.default's defaults should not be modified.
+      // Specifically, defaults.headers.post should be kept as-is
+      assert.exists(globalDefault);
+
+      const instanceDefault = client.axios.defaults.headers.post['Content-Type'];
+      // WebClient intentionally removes the default Content-Type
+      // from the underlying AxiosInstance used for performing web API calls
+      assert.notExists(instanceDefault)
     });
   });
 


### PR DESCRIPTION
###  Summary

This pull request verifies #1037 is no longer an issue on this library side.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
