### PR TITLE
Pass logger through to WebClient and fix broken logLevel warning

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -41,7 +41,7 @@ export class InstallProvider {
     installationStore = new MemoryInstallationStore(),
     authVersion = 'v2',
     logger = undefined,
-    logLevel = LogLevel.INFO,
+    logLevel = undefined,
     clientOptions = {},
     authorizationUrl = 'https://slack.com/oauth/v2/authorize',
   }: InstallProviderOptions) {
@@ -57,7 +57,7 @@ export class InstallProvider {
         this.logger.debug('The logLevel given to OAuth was ignored as you also gave logger');
       }
     } else {
-      this.logger = getLogger('OAuth:InstallProvider', logLevel, logger);
+      this.logger = getLogger('OAuth:InstallProvider', logLevel ?? LogLevel.INFO, logger);
     }
 
     // Setup stateStore
@@ -84,6 +84,7 @@ export class InstallProvider {
     }
 
     this.clientOptions = {
+      logger,
       logLevel: this.logger.getLevel(),
       ...clientOptions,
     };

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -323,7 +323,7 @@ export class SocketModeClient extends EventEmitter {
 
   constructor({
     logger = undefined,
-    logLevel = LogLevel.INFO,
+    logLevel = undefined,
     autoReconnectEnabled = true,
     clientPingTimeout = 30000,
     appToken = undefined,
@@ -344,12 +344,13 @@ export class SocketModeClient extends EventEmitter {
         this.logger.debug('The logLevel given to Socket Mode was ignored as you also gave logger');
       }
     } else {
-      this.logger = getLogger(SocketModeClient.loggerName, logLevel, logger);
+      this.logger = getLogger(SocketModeClient.loggerName, logLevel ?? LogLevel.INFO, logger);
     }
 
     this.clientOptions = clientOptions;
 
     this.webClient = new WebClient('', {
+      logger,
       logLevel: this.logger.getLevel(),
       headers: { Authorization: `Bearer ${appToken}` },
       ...clientOptions,

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -89,7 +89,7 @@ export class WebClient extends Methods {
   constructor(token?: string, {
     slackApiUrl = 'https://slack.com/api/',
     logger = undefined,
-    logLevel = LogLevel.INFO,
+    logLevel = undefined,
     maxRequestConcurrency = 3,
     retryConfig = retryPolicies.tenRetriesInAboutThirtyMinutes,
     agent = undefined,
@@ -117,7 +117,7 @@ export class WebClient extends Methods {
         this.logger.debug('The logLevel given to WebClient was ignored as you also gave logger');
       }
     } else {
-      this.logger = getLogger(WebClient.loggerName, logLevel, logger);
+      this.logger = getLogger(WebClient.loggerName, logLevel ?? LogLevel.INFO, logger);
     }
 
     this.axios = axios.create({


### PR DESCRIPTION
###  Summary

This fixes two things:

1. A custom `logger` passed to `InstallProvider` or `SocketModeClient` won't be used for the `WebClient` they create.
2. The `The logLevel given to <class> was ignored as you also gave logger` warning is always triggered when passing a custom `logger`, since `logLevel` defaults to `LogLevel.INFO`.

I didn't create issues for these because it was faster to just create a fix :sweat_smile:. If you want me to create issues, just let me know.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
