### PR TITLE
Resolve inconsistent package dependencies across slack packages

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -38,8 +38,8 @@
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
-    "@slack/logger": "^2.0.0",
-    "@slack/web-api": "^5.7.0",
+    "@slack/logger": "^3.0.0",
+    "@slack/web-api": "^6.0.0",
     "@types/jsonwebtoken": "^8.3.7",
     "@types/node": ">=12",
     "jsonwebtoken": "^8.5.1",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -45,8 +45,8 @@
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
-    "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/types": "^1.7.0",
+    "@slack/logger": "^3.0.0",
+    "@slack/types": "^2.0.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=12.0.0",
     "axios": "^0.21.1",


### PR DESCRIPTION
###  Summary

This pull request resolves the build settings of `@slack/web-api` and `@slack/oauth` packages. The major issue this pull request is resolving is that only `@slack/web-api`'s requires older major version of `@slack/logger`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
