### PR TITLE
Update the web-api responses (2021-04-23 PT)

### DIFF
--- a/packages/web-api/src/response/ConversationsCloseResponse.ts
+++ b/packages/web-api/src/response/ConversationsCloseResponse.ts
@@ -1,8 +1,10 @@
 /* tslint:disable */
 import { WebAPICallResult } from '../WebClient';
 export type ConversationsCloseResponse = WebAPICallResult & {
-  ok?:       boolean;
-  error?:    string;
-  needed?:   string;
-  provided?: string;
+  ok?:             boolean;
+  already_closed?: boolean;
+  no_op?:          boolean;
+  error?:          string;
+  needed?:         string;
+  provided?:       string;
 };

--- a/packages/web-api/src/response/ConversationsInfoResponse.ts
+++ b/packages/web-api/src/response/ConversationsInfoResponse.ts
@@ -46,6 +46,7 @@ export interface Channel {
   is_global_shared?:           boolean;
   is_org_default?:             boolean;
   is_org_mandatory?:           boolean;
+  connected_limited_team_ids?: string[];
 }
 
 export interface Purpose {

--- a/packages/web-api/src/response/ConversationsOpenResponse.ts
+++ b/packages/web-api/src/response/ConversationsOpenResponse.ts
@@ -1,11 +1,13 @@
 /* tslint:disable */
 import { WebAPICallResult } from '../WebClient';
 export type ConversationsOpenResponse = WebAPICallResult & {
-  ok?:       boolean;
-  channel?:  Channel;
-  error?:    string;
-  needed?:   string;
-  provided?: string;
+  ok?:           boolean;
+  channel?:      Channel;
+  no_op?:        boolean;
+  already_open?: boolean;
+  error?:        string;
+  needed?:       string;
+  provided?:     string;
 };
 
 export interface Channel {

--- a/packages/web-api/src/response/SearchAllResponse.ts
+++ b/packages/web-api/src/response/SearchAllResponse.ts
@@ -138,6 +138,7 @@ export interface MessagesMatch {
   blocks?:       Block[];
   attachments?:  MatchAttachment[];
   is_mpim?:      boolean;
+  score?:        number;
 }
 
 export interface MatchAttachment {

--- a/packages/web-api/src/response/SearchMessagesResponse.ts
+++ b/packages/web-api/src/response/SearchMessagesResponse.ts
@@ -32,6 +32,7 @@ export interface Match {
   blocks?:       Block[];
   attachments?:  MatchAttachment[];
   is_mpim?:      boolean;
+  score?:        number;
 }
 
 export interface MatchAttachment {


### PR DESCRIPTION
###  Summary

This pull request adds the latest fields to the web-api response types by running `./scripts/generate-web-api-types.sh`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
