### PR TITLE
Added exclusion logic for Electron based apps to prevent changing User-Agent header

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -54,7 +54,8 @@
     "form-data": "^2.5.0",
     "is-stream": "^1.1.0",
     "p-queue": "^6.6.1",
-    "p-retry": "^4.0.0"
+    "p-retry": "^4.0.0",
+    "is-electron": "^2.2.0"
   },
   "devDependencies": {
     "@aoberoi/capture-console": "^1.1.0",

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -15,6 +15,7 @@ import PQueue from 'p-queue'; // tslint:disable-line:import-name
 import pRetry, { AbortError } from 'p-retry';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import FormData from 'form-data'; // tslint:disable-line:import-name
+import isElectron from 'is-electron';
 
 import { Methods, CursorPaginationEnabled, cursorPaginationEnabledMethods } from './methods';
 import { getUserAgent } from './instrument';
@@ -122,12 +123,7 @@ export class WebClient extends Methods {
 
     this.axios = axios.create({
       baseURL: slackApiUrl,
-      headers: Object.assign(
-        {
-          'User-Agent': getUserAgent(),
-        },
-        headers,
-      ),
+      headers: isElectron() ? headers : Object.assign({ 'User-Agent': getUserAgent() }, headers),
       httpAgent: agent,
       httpsAgent: agent,
       transformRequest: [this.serializeApiCallOptions.bind(this)],


### PR DESCRIPTION
This pull request resolves #982

###  Summary

1. Added is-electron package;
2. Added exclusion logic for Electron based apps to prevent changing User-Agent header - [issue](https://github.com/slackapi/node-slack-sdk/issues/982).


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
