### PR TITLE
Add missing API methods

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -182,6 +182,7 @@ import { WorkflowsUpdateStepResponse } from './response/WorkflowsUpdateStepRespo
 import { AdminUsersSessionGetSettingsResponse } from './response/AdminUsersSessionGetSettingsResponse';
 import { AdminUsersSessionSetSettingsResponse } from './response/AdminUsersSessionSetSettingsResponse';
 import { AdminUsersSessionClearSettingsResponse } from './response/AdminUsersSessionClearSettingsResponse';
+import { AdminAppsClearResolutionResponse } from './response/AdminAppsClearResolutionResponse';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
 
@@ -221,11 +222,13 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
   public abstract apiCall(method: string, options?: WebAPICallOptions): Promise<WebAPICallResult>;
 
   public readonly admin = {
+    // TODO: admin.analytics.getFile
     apps: {
       approve: bindApiCall<AdminAppsApproveArguments, AdminAppsApproveResponse>(this, 'admin.apps.approve'),
       approved: {
         list: bindApiCall<AdminAppsApprovedListArguments, AdminAppsApprovedListResponse>(this, 'admin.apps.approved.list'),
       },
+      clearResolution: bindApiCall<AdminAppsClearResolutionArguments, AdminAppsClearResolutionResponse>(this, 'admin.apps.clearResolution'),
       requests: {
         list: bindApiCall<AdminAppsRequestsListArguments, AdminAppsRequestsListResponse>(this, 'admin.apps.requests.list'),
       },
@@ -234,6 +237,8 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         list:
           bindApiCall<AdminAppsRestrictedListArguments, AdminAppsRestrictedListResponse>(this, 'admin.apps.restricted.list'),
       },
+      // TODO: Use AdminAppsUninstallResponse when it's available
+      uninstall: bindApiCall<AdminAppsUninstallArguments, WebAPICallResult>(this, 'admin.apps.uninstall'),
     },
     barriers: {
       create: bindApiCall<AdminBarriersCreateArguments, AdminBarriersCreateResponse>(this, 'admin.barriers.create'),
@@ -412,24 +417,6 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     },
   };
 
-  public readonly channels = {
-    archive: bindApiCall<ChannelsArchiveArguments, WebAPICallResult>(this, 'channels.archive'),
-    create: bindApiCall<ChannelsCreateArguments, WebAPICallResult>(this, 'channels.create'),
-    history: bindApiCall<ChannelsHistoryArguments, WebAPICallResult>(this, 'channels.history'),
-    info: bindApiCall<ChannelsInfoArguments, WebAPICallResult>(this, 'channels.info'),
-    invite: bindApiCall<ChannelsInviteArguments, WebAPICallResult>(this, 'channels.invite'),
-    join: bindApiCall<ChannelsJoinArguments, WebAPICallResult>(this, 'channels.join'),
-    kick: bindApiCall<ChannelsKickArguments, WebAPICallResult>(this, 'channels.kick'),
-    leave: bindApiCall<ChannelsLeaveArguments, WebAPICallResult>(this, 'channels.leave'),
-    list: bindApiCall<ChannelsListArguments, WebAPICallResult>(this, 'channels.list'),
-    mark: bindApiCall<ChannelsMarkArguments, WebAPICallResult>(this, 'channels.mark'),
-    rename: bindApiCall<ChannelsRenameArguments, WebAPICallResult>(this, 'channels.rename'),
-    replies: bindApiCall<ChannelsRepliesArguments, WebAPICallResult>(this, 'channels.replies'),
-    setPurpose: bindApiCall<ChannelsSetPurposeArguments, WebAPICallResult>(this, 'channels.setPurpose'),
-    setTopic: bindApiCall<ChannelsSetTopicArguments, WebAPICallResult>(this, 'channels.setTopic'),
-    unarchive: bindApiCall<ChannelsUnarchiveArguments, WebAPICallResult>(this, 'channels.unarchive'),
-  };
-
   public readonly chat = {
     delete: bindApiCall<ChatDeleteArguments, ChatDeleteResponse>(this, 'chat.delete'),
     deleteScheduledMessage:
@@ -473,13 +460,6 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       this, 'conversations.unarchive'),
   };
 
-  public readonly views = {
-    open: bindApiCall<ViewsOpenArguments, ViewsOpenResponse>(this, 'views.open'),
-    publish: bindApiCall<ViewsPublishArguments, ViewsPublishResponse>(this, 'views.publish'),
-    push: bindApiCall<ViewsPushArguments, ViewsPushResponse>(this, 'views.push'),
-    update: bindApiCall<ViewsUpdateArguments, ViewsUpdateResponse>(this, 'views.update'),
-  };
-
   public readonly dialog = {
     open: bindApiCall<DialogOpenArguments, DialogOpenResponse>(this, 'dialog.open'),
   };
@@ -518,45 +498,8 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     },
   };
 
-  public readonly groups = {
-    archive: bindApiCall<GroupsArchiveArguments, WebAPICallResult>(this, 'groups.archive'),
-    create: bindApiCall<GroupsCreateArguments, WebAPICallResult>(this, 'groups.create'),
-    createChild: bindApiCall<GroupsCreateChildArguments, WebAPICallResult>(this, 'groups.createChild'),
-    history: bindApiCall<GroupsHistoryArguments, WebAPICallResult>(this, 'groups.history'),
-    info: bindApiCall<GroupsInfoArguments, WebAPICallResult>(this, 'groups.info'),
-    invite: bindApiCall<GroupsInviteArguments, WebAPICallResult>(this, 'groups.invite'),
-    kick: bindApiCall<GroupsKickArguments, WebAPICallResult>(this, 'groups.kick'),
-    leave: bindApiCall<GroupsLeaveArguments, WebAPICallResult>(this, 'groups.leave'),
-    list: bindApiCall<GroupsListArguments, WebAPICallResult>(this, 'groups.list'),
-    mark: bindApiCall<GroupsMarkArguments, WebAPICallResult>(this, 'groups.mark'),
-    open: bindApiCall<GroupsOpenArguments, WebAPICallResult>(this, 'groups.open'),
-    rename: bindApiCall<GroupsRenameArguments, WebAPICallResult>(this, 'groups.rename'),
-    replies: bindApiCall<GroupsRepliesArguments, WebAPICallResult>(this, 'groups.replies'),
-    setPurpose: bindApiCall<GroupsSetPurposeArguments, WebAPICallResult>(this, 'groups.setPurpose'),
-    setTopic: bindApiCall<GroupsSetTopicArguments, WebAPICallResult>(this, 'groups.setTopic'),
-    unarchive: bindApiCall<GroupsUnarchiveArguments, WebAPICallResult>(this, 'groups.unarchive'),
-  };
-
-  public readonly im = {
-    close: bindApiCall<IMCloseArguments, WebAPICallResult>(this, 'im.close'),
-    history: bindApiCall<IMHistoryArguments, WebAPICallResult>(this, 'im.history'),
-    list: bindApiCall<IMListArguments, WebAPICallResult>(this, 'im.list'),
-    mark: bindApiCall<IMMarkArguments, WebAPICallResult>(this, 'im.mark'),
-    open: bindApiCall<IMOpenArguments, WebAPICallResult>(this, 'im.open'),
-    replies: bindApiCall<IMRepliesArguments, WebAPICallResult>(this, 'im.replies'),
-  };
-
   public readonly migration = {
     exchange: bindApiCall<MigrationExchangeArguments, MigrationExchangeResponse>(this, 'migration.exchange'),
-  };
-
-  public readonly mpim = {
-    close: bindApiCall<MPIMCloseArguments, WebAPICallResult>(this, 'mpim.close'),
-    history: bindApiCall<MPIMHistoryArguments, WebAPICallResult>(this, 'mpim.history'),
-    list: bindApiCall<MPIMListArguments, WebAPICallResult>(this, 'mpim.list'),
-    mark: bindApiCall<MPIMMarkArguments, WebAPICallResult>(this, 'mpim.mark'),
-    open: bindApiCall<MPIMOpenArguments, WebAPICallResult>(this, 'mpim.open'),
-    replies: bindApiCall<MPIMRepliesArguments, WebAPICallResult>(this, 'mpim.replies'),
   };
 
   public readonly oauth = {
@@ -645,12 +588,79 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     },
   };
 
+  public readonly views = {
+    open: bindApiCall<ViewsOpenArguments, ViewsOpenResponse>(this, 'views.open'),
+    publish: bindApiCall<ViewsPublishArguments, ViewsPublishResponse>(this, 'views.publish'),
+    push: bindApiCall<ViewsPushArguments, ViewsPushResponse>(this, 'views.push'),
+    update: bindApiCall<ViewsUpdateArguments, ViewsUpdateResponse>(this, 'views.update'),
+  };
+
   public readonly workflows = {
     stepCompleted: bindApiCall<WorkflowsStepCompletedArguments, WorkflowsStepCompletedResponse>(
       this, 'workflows.stepCompleted'),
     stepFailed: bindApiCall<WorkflowsStepFailedArguments, WorkflowsStepFailedResponse>(this, 'workflows.stepFailed'),
     updateStep: bindApiCall<WorkflowsUpdateStepArguments, WorkflowsUpdateStepResponse>(this, 'workflows.updateStep'),
   };
+
+  // ---------------------------------
+  // Deprecated methods
+  // ---------------------------------
+
+  public readonly channels = {
+    archive: bindApiCall<ChannelsArchiveArguments, WebAPICallResult>(this, 'channels.archive'),
+    create: bindApiCall<ChannelsCreateArguments, WebAPICallResult>(this, 'channels.create'),
+    history: bindApiCall<ChannelsHistoryArguments, WebAPICallResult>(this, 'channels.history'),
+    info: bindApiCall<ChannelsInfoArguments, WebAPICallResult>(this, 'channels.info'),
+    invite: bindApiCall<ChannelsInviteArguments, WebAPICallResult>(this, 'channels.invite'),
+    join: bindApiCall<ChannelsJoinArguments, WebAPICallResult>(this, 'channels.join'),
+    kick: bindApiCall<ChannelsKickArguments, WebAPICallResult>(this, 'channels.kick'),
+    leave: bindApiCall<ChannelsLeaveArguments, WebAPICallResult>(this, 'channels.leave'),
+    list: bindApiCall<ChannelsListArguments, WebAPICallResult>(this, 'channels.list'),
+    mark: bindApiCall<ChannelsMarkArguments, WebAPICallResult>(this, 'channels.mark'),
+    rename: bindApiCall<ChannelsRenameArguments, WebAPICallResult>(this, 'channels.rename'),
+    replies: bindApiCall<ChannelsRepliesArguments, WebAPICallResult>(this, 'channels.replies'),
+    setPurpose: bindApiCall<ChannelsSetPurposeArguments, WebAPICallResult>(this, 'channels.setPurpose'),
+    setTopic: bindApiCall<ChannelsSetTopicArguments, WebAPICallResult>(this, 'channels.setTopic'),
+    unarchive: bindApiCall<ChannelsUnarchiveArguments, WebAPICallResult>(this, 'channels.unarchive'),
+  };
+
+  public readonly groups = {
+    archive: bindApiCall<GroupsArchiveArguments, WebAPICallResult>(this, 'groups.archive'),
+    create: bindApiCall<GroupsCreateArguments, WebAPICallResult>(this, 'groups.create'),
+    createChild: bindApiCall<GroupsCreateChildArguments, WebAPICallResult>(this, 'groups.createChild'),
+    history: bindApiCall<GroupsHistoryArguments, WebAPICallResult>(this, 'groups.history'),
+    info: bindApiCall<GroupsInfoArguments, WebAPICallResult>(this, 'groups.info'),
+    invite: bindApiCall<GroupsInviteArguments, WebAPICallResult>(this, 'groups.invite'),
+    kick: bindApiCall<GroupsKickArguments, WebAPICallResult>(this, 'groups.kick'),
+    leave: bindApiCall<GroupsLeaveArguments, WebAPICallResult>(this, 'groups.leave'),
+    list: bindApiCall<GroupsListArguments, WebAPICallResult>(this, 'groups.list'),
+    mark: bindApiCall<GroupsMarkArguments, WebAPICallResult>(this, 'groups.mark'),
+    open: bindApiCall<GroupsOpenArguments, WebAPICallResult>(this, 'groups.open'),
+    rename: bindApiCall<GroupsRenameArguments, WebAPICallResult>(this, 'groups.rename'),
+    replies: bindApiCall<GroupsRepliesArguments, WebAPICallResult>(this, 'groups.replies'),
+    setPurpose: bindApiCall<GroupsSetPurposeArguments, WebAPICallResult>(this, 'groups.setPurpose'),
+    setTopic: bindApiCall<GroupsSetTopicArguments, WebAPICallResult>(this, 'groups.setTopic'),
+    unarchive: bindApiCall<GroupsUnarchiveArguments, WebAPICallResult>(this, 'groups.unarchive'),
+  };
+
+  public readonly im = {
+    close: bindApiCall<IMCloseArguments, WebAPICallResult>(this, 'im.close'),
+    history: bindApiCall<IMHistoryArguments, WebAPICallResult>(this, 'im.history'),
+    list: bindApiCall<IMListArguments, WebAPICallResult>(this, 'im.list'),
+    mark: bindApiCall<IMMarkArguments, WebAPICallResult>(this, 'im.mark'),
+    open: bindApiCall<IMOpenArguments, WebAPICallResult>(this, 'im.open'),
+    replies: bindApiCall<IMRepliesArguments, WebAPICallResult>(this, 'im.replies'),
+  };
+
+  public readonly mpim = {
+    close: bindApiCall<MPIMCloseArguments, WebAPICallResult>(this, 'mpim.close'),
+    history: bindApiCall<MPIMHistoryArguments, WebAPICallResult>(this, 'mpim.history'),
+    list: bindApiCall<MPIMListArguments, WebAPICallResult>(this, 'mpim.list'),
+    mark: bindApiCall<MPIMMarkArguments, WebAPICallResult>(this, 'mpim.mark'),
+    open: bindApiCall<MPIMOpenArguments, WebAPICallResult>(this, 'mpim.open'),
+    replies: bindApiCall<MPIMRepliesArguments, WebAPICallResult>(this, 'mpim.replies'),
+  };
+
 }
 
 /**
@@ -718,6 +728,11 @@ export interface AdminAppsApprovedListArguments extends WebAPICallOptions, Token
   team_id?: string;
   enterprise_id?: string;
 }
+export interface AdminAppsClearResolutionArguments extends WebAPICallOptions {
+  app_id: string;
+  enterprise_id?: string;
+  team_id?: string;
+}
 cursorPaginationEnabledMethods.add('admin.apps.approved.list');
 export interface AdminAppsRequestsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id?: string;
@@ -734,6 +749,11 @@ export interface AdminAppsRestrictedListArguments extends WebAPICallOptions, Tok
 }
 cursorPaginationEnabledMethods.add('admin.apps.restricted.list');
 
+export interface AdminAppsUninstallArguments extends WebAPICallOptions {
+  app_id: string;
+  enterprise_id?: string;
+  team_ids?: string[];
+}
 export interface AdminBarriersCreateArguments extends WebAPICallOptions, TokenOverridable {
   barriered_from_usergroup_ids: string[];
   primary_usergroup_id: string;

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -183,6 +183,7 @@ import { AdminUsersSessionGetSettingsResponse } from './response/AdminUsersSessi
 import { AdminUsersSessionSetSettingsResponse } from './response/AdminUsersSessionSetSettingsResponse';
 import { AdminUsersSessionClearSettingsResponse } from './response/AdminUsersSessionClearSettingsResponse';
 import { AdminAppsClearResolutionResponse } from './response/AdminAppsClearResolutionResponse';
+import { AdminAppsUninstallResponse } from './response/AdminAppsUninstallResponse';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
 
@@ -237,8 +238,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         list:
           bindApiCall<AdminAppsRestrictedListArguments, AdminAppsRestrictedListResponse>(this, 'admin.apps.restricted.list'),
       },
-      // TODO: Use AdminAppsUninstallResponse when it's available
-      uninstall: bindApiCall<AdminAppsUninstallArguments, WebAPICallResult>(this, 'admin.apps.uninstall'),
+      uninstall: bindApiCall<AdminAppsUninstallArguments, AdminAppsUninstallResponse>(this, 'admin.apps.uninstall'),
     },
     barriers: {
       create: bindApiCall<AdminBarriersCreateArguments, AdminBarriersCreateResponse>(this, 'admin.barriers.create'),

--- a/packages/web-api/src/response/AdminAppsUninstallResponse.ts
+++ b/packages/web-api/src/response/AdminAppsUninstallResponse.ts
@@ -1,0 +1,8 @@
+/* tslint:disable */
+import { WebAPICallResult } from '../WebClient';
+export type AdminAppsUninstallResponse = WebAPICallResult & {
+  ok?:       boolean;
+  error?:    string;
+  needed?:   string;
+  provided?: string;
+};

--- a/packages/web-api/src/response/AdminConversationsSearchResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsSearchResponse.ts
@@ -32,4 +32,5 @@ export interface Conversation {
   is_pending_ext_shared?:         boolean;
   connected_team_ids?:            string[];
   conversation_host_id?:          string;
+  channel_email_addresses?:       string[];
 }

--- a/packages/web-api/src/response/UsersInfoResponse.ts
+++ b/packages/web-api/src/response/UsersInfoResponse.ts
@@ -30,6 +30,16 @@ export interface User {
   locale?:              string;
   has_2fa?:             boolean;
   is_email_confirmed?:  boolean;
+  enterprise_user?:     EnterpriseUser;
+}
+
+export interface EnterpriseUser {
+  id?:              string;
+  enterprise_id?:   string;
+  enterprise_name?: string;
+  is_admin?:        boolean;
+  is_owner?:        boolean;
+  teams?:           string[];
 }
 
 export interface Profile {

--- a/packages/web-api/src/response/index.ts
+++ b/packages/web-api/src/response/index.ts
@@ -5,6 +5,7 @@ export { AdminAppsClearResolutionResponse } from './AdminAppsClearResolutionResp
 export { AdminAppsRequestsListResponse } from './AdminAppsRequestsListResponse';
 export { AdminAppsRestrictResponse } from './AdminAppsRestrictResponse';
 export { AdminAppsRestrictedListResponse } from './AdminAppsRestrictedListResponse';
+export { AdminAppsUninstallResponse } from './AdminAppsUninstallResponse';
 export { AdminBarriersCreateResponse } from './AdminBarriersCreateResponse';
 export { AdminBarriersDeleteResponse } from './AdminBarriersDeleteResponse';
 export { AdminBarriersListResponse } from './AdminBarriersListResponse';


### PR DESCRIPTION
###  Summary

This pull request adds the following API methods to `WebClient`.

* admin.apps.clearResolution
* admin.apps.uninstall

Also, I moved the non-conversation API methods to the bottom as they no longer work (we may want to delete them in the near future but we won't do so in v6.2).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
