### PR TITLE
Add Timepicker to @slack/types

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,3 @@
-
 /*
  * Reusable shapes for argument values
  */
@@ -292,7 +291,16 @@ export interface SectionBlock extends Block {
   type: 'section';
   text?: PlainTextElement | MrkdwnElement; // either this or fields must be defined
   fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
-  accessory?: Button | Overflow | Datepicker | Timepicker | Select | MultiSelect | Action | ImageElement | RadioButtons | Checkboxes;
+  accessory?: Button
+    | Overflow
+    | Datepicker
+    | Timepicker
+    | Select
+    | MultiSelect
+    | Action
+    | ImageElement
+    | RadioButtons
+    | Checkboxes;
 }
 
 export interface FileBlock extends Block {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -220,6 +220,13 @@ export interface Datepicker extends Action {
   confirm?: Confirm;
 }
 
+export interface Timepicker extends Action {
+  type: 'timepicker';
+  initial_time?: string;
+  placeholder?: PlainTextElement;
+  confirm?: Confirm;
+}
+
 export interface RadioButtons extends Action {
   type: 'radio_buttons';
   initial_option?: Option;
@@ -274,7 +281,7 @@ export interface ContextBlock extends Block {
 
 export interface ActionsBlock extends Block {
   type: 'actions';
-  elements: (Button | Overflow | Datepicker | Select | RadioButtons | Checkboxes | Action)[];
+  elements: (Button | Overflow | Datepicker | Timepicker | Select | RadioButtons | Checkboxes | Action)[];
 }
 
 export interface DividerBlock extends Block {
@@ -285,7 +292,7 @@ export interface SectionBlock extends Block {
   type: 'section';
   text?: PlainTextElement | MrkdwnElement; // either this or fields must be defined
   fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
-  accessory?: Button | Overflow | Datepicker | Select | MultiSelect | Action | ImageElement | RadioButtons | Checkboxes;
+  accessory?: Button | Overflow | Datepicker | Timepicker | Select | MultiSelect | Action | ImageElement | RadioButtons | Checkboxes;
 }
 
 export interface FileBlock extends Block {
@@ -304,7 +311,7 @@ export interface InputBlock extends Block {
   label: PlainTextElement;
   hint?: PlainTextElement;
   optional?: boolean;
-  element: Select | MultiSelect | Datepicker | PlainTextInput | RadioButtons | Checkboxes;
+  element: Select | MultiSelect | Datepicker | Timepicker | PlainTextInput | RadioButtons | Checkboxes;
   dispatch_action?: boolean;
 }
 


### PR DESCRIPTION
###  Summary

Noticed that @slack/types does not include an interface for the time picker block element. Added it and included it in all of the corresponding union types.

Also, I think there are some opportunities for refactoring that would make this package even more useful than it already is. While developing v.2 of [slack-block-builder](https://github.com/raycharius/slack-block-builder), I've noticed I'm doing a lot of typing on my end, since a lot of the types aren't available through this package. 

- Moving union types to their own exported types. For example, elements supported within the `ActionsBlock` having a type of `ActionsElements`. For `SectionBlock`, `SectionElements`. Etc.
- Moving enum values to their own exported enums.

Happy to take a shot at that, too, and send over a PR, if that's something you could see in the scope here.

Cheers!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
