### PR TITLE
Update apps.connections.open API response type in SocketModeClient

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/web-api": "^6.0.0",
+    "@slack/web-api": "^6.2.3",
     "@types/node": ">=12.0.0",
     "@types/p-queue": "^2.3.2",
     "@types/ws": "^7.2.5",

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -3,7 +3,7 @@ import WebSocket from 'ws'; // tslint:disable-line:import-name
 import Finity, { StateMachine } from 'finity'; // tslint:disable-line:import-name
 import {
   WebClient,
-  WebAPICallResult,
+  AppsConnectionsOpenResponse,
   WebAPICallError,
   ErrorCode as APICallErrorCode,
   addAppMetadata,
@@ -66,7 +66,7 @@ export class SocketModeClient extends EventEmitter {
         .submachine(Finity.configure()
           .initialState('authenticating')
             .do(() => {
-              return this.webClient.apps.connections.open().then((result: WebAPICallResult) => {
+              return this.webClient.apps.connections.open().then((result: AppsConnectionsOpenResponse) => {
                 return result;
               }).catch((error) => {
                 this.logger.error(error);
@@ -154,7 +154,7 @@ export class SocketModeClient extends EventEmitter {
             .submachine(Finity.configure()
             .initialState('authenticating')
               .do(() => {
-                return this.webClient.apps.connections.open().then((result: WebAPICallResult) => {
+                return this.webClient.apps.connections.open().then((result: AppsConnectionsOpenResponse) => {
                   return result;
                 }).catch((error) => {
                   this.logger.error(error);
@@ -367,7 +367,7 @@ export class SocketModeClient extends EventEmitter {
    * Begin an Socket Mode session. This method must be called before any messages can
    * be sent or received.
    */
-  public start(): Promise<WebAPICallResult> {
+  public start(): Promise<AppsConnectionsOpenResponse> {
     this.logger.debug('start()');
 
     // delegate behavior to state machine


### PR DESCRIPTION
###  Summary

This pull request updates the Web API response type that `SocketModeClient` returns in its `start()` method. As with https://github.com/slackapi/bolt-js/pull/915, the new type inherits the `WebAPICallResult` interface. Thus, the change in this PR is backward-compatible.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
