### PR TITLE
Update the web-api response types (2021-05-18 PT)

### DIFF
--- a/packages/web-api/src/response/ChatScheduleMessageResponse.ts
+++ b/packages/web-api/src/response/ChatScheduleMessageResponse.ts
@@ -7,6 +7,7 @@ export type ChatScheduleMessageResponse = WebAPICallResult & {
   post_at?:              number;
   message?:              Message;
   error?:                string;
+  response_metadata?:    ResponseMetadata;
   needed?:               string;
   provided?:             string;
 };
@@ -115,4 +116,8 @@ export interface Icons {
   image_36?: string;
   image_48?: string;
   image_72?: string;
+}
+
+export interface ResponseMetadata {
+  messages?: string[];
 }

--- a/packages/web-api/src/response/ChatScheduledMessagesListResponse.ts
+++ b/packages/web-api/src/response/ChatScheduledMessagesListResponse.ts
@@ -16,7 +16,7 @@ export interface ResponseMetadata {
 export interface ScheduledMessage {
   id?:           string;
   channel_id?:   string;
-  text?:         string;
   post_at?:      number;
   date_created?: number;
+  text?:         string;
 }


### PR DESCRIPTION
###  Summary

`chat.scheduleMessage` API started returning `response_metadata` for error messages. see also: https://github.com/slackapi/java-slack-sdk/commit/5ef7a037e031a13ee7110424407a50b571117e35

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
