### PR TITLE
Publish @slack/socket-mode@1.1.0

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

This release includes only a single update about types, which is backward-compatible.

https://github.com/slackapi/node-slack-sdk/milestone/6?closed=1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
