### PR TITLE
Fix #1240 by enabling to pass integer as post_at in chat.scheduleMessage API calls

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1225,7 +1225,7 @@ export interface ChatPostMessageArguments extends WebAPICallOptions, TokenOverri
 export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
   text?: string;
-  post_at: string;
+  post_at: string | number;
   as_user?: boolean;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];

--- a/packages/web-api/test/types/webclient-named-method-types.test-d.ts
+++ b/packages/web-api/test/types/webclient-named-method-types.test-d.ts
@@ -65,7 +65,13 @@ expectType<Promise<ChatScheduleMessageResponse>>(web.chat.scheduleMessage({
 }));
 expectType<Promise<ChatScheduleMessageResponse>>(web.chat.scheduleMessage({
   channel: 'C111',
-  post_at: '11111',
+  post_at: '1621497568',
+  text: 'Hi there!',
+  blocks: [],
+}));
+expectType<Promise<ChatScheduleMessageResponse>>(web.chat.scheduleMessage({
+  channel: 'C111',
+  post_at: 1621497568,
   text: 'Hi there!',
   blocks: [],
 }));

--- a/prod-server-integration-tests/test/web-api.js
+++ b/prod-server-integration-tests/test/web-api.js
@@ -28,4 +28,30 @@ describe('Web APIs', function () {
       assert.isUndefined(response.error);
     });
   });
+
+  describe('cha.scheduleMessage', function () {
+    it('should accept either an integer or a string value for post_at', async function() {
+      const channelId = process.env.SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID;
+      const postAt = Number.parseInt((Date.now() / 1000) + 60 * 15);
+      try {
+        const params = {
+          text: 'Hi there!',
+          channel: channelId,
+          post_at: postAt,
+        };
+        assert.isTrue(typeof params.post_at === 'number');
+        assert.isTrue(Number.isInteger(params.post_at));
+        const response1 = await botClient.chat.scheduleMessage(params);
+        assert.isUndefined(response1.error);
+
+        params.post_at = "" + params.post_at;
+        assert.isTrue(typeof params.post_at === 'string');
+        const response2 = await botClient.chat.scheduleMessage(params);
+        assert.isUndefined(response2.error);
+      } catch (e) {
+        console.log(e.code + " / " + JSON.stringify(e.data));
+        throw e;
+      }
+    });
+  });
 });


### PR DESCRIPTION
###  Summary

This pull request fixes #1240 by correcting the argument type for `post_at` in `ChatScheduleMessageArguments`. The argument should accept either `number` (specifically integer value) or `string` value for it. Although both `number` and `string` actually works, the API document https://api.slack.com/methods/chat.scheduleMessage recommends `number` over `string`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
