### PR TITLE
Add Support for Token Rotation

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -91,7 +91,7 @@ export class InstallProvider {
   }
 
   /**
-   * Fetches data from the installationStore for non Org Installations.
+   * Fetches data from the installationStore
    */
   public async authorize(source: InstallationQuery<boolean>): Promise<AuthorizeResult> {
     try {
@@ -129,6 +129,87 @@ export class InstallProvider {
         authResult.botToken = queryResult.bot.token;
         authResult.botId = queryResult.bot.id;
         authResult.botUserId = queryResult.bot.userId;
+
+        // Token Rotation Enabled (Bot Token)
+        if (queryResult.bot.refreshToken !== undefined) {
+          authResult.botRefreshToken = queryResult.bot.refreshToken;
+          authResult.botTokenExpiresAt = queryResult.bot.expiresAt; // utc, seconds
+        }
+      }
+
+      // Token Rotation Enabled (User Token)
+      if (queryResult.user.refreshToken !== undefined) {
+        authResult.userRefreshToken = queryResult.user.refreshToken;
+        authResult.userTokenExpiresAt = queryResult.user.expiresAt; // utc, seconds
+      }
+
+      /*
+      * Token Rotation (Expiry Check + Refresh)
+      * The presence of `(bot|user)TokenExpiresAt` indicates having opted into token rotation.
+      * If the token has expired, or will expire within 2 hours, the token is refreshed and
+      * the `authResult` and `Installation` are updated with the new values.
+      */
+      if (authResult.botRefreshToken !== undefined || authResult.userRefreshToken !== undefined) {
+        const currentUTCSec = Math.floor(Date.now() / 1000); // seconds
+        const tokensToRefresh: string[] = [];
+        let client: WebClient;
+
+        if (authResult.botRefreshToken !== undefined && authResult.botTokenExpiresAt !== undefined) {
+          const botTokenExpiresIn = authResult.botTokenExpiresAt - currentUTCSec;
+          if (botTokenExpiresIn <= 7200) { // 2 hours
+            tokensToRefresh.push(authResult.botRefreshToken);
+          }
+        }
+
+        if (authResult.userRefreshToken !== undefined && authResult.userTokenExpiresAt !== undefined) {
+          const userTokenExpiresIn = authResult.userTokenExpiresAt - currentUTCSec;
+          if (userTokenExpiresIn <= 7200) { // 2 hours
+            tokensToRefresh.push(authResult.userRefreshToken);
+          }
+        }
+
+        if (tokensToRefresh.length > 0) {
+          const installationUpdates: any = { ...queryResult }; // TODO :: TS
+          client = new WebClient(undefined, this.clientOptions);
+
+          // TODO :: Concurrent Calls?
+          // TODO :: Retry Strategy
+          for (const refreshToken of tokensToRefresh) {
+
+            const refreshResp = await client.oauth.v2.access({
+              client_id: this.clientId,
+              client_secret: this.clientSecret,
+              grant_type: 'refresh_token',
+              refresh_token: refreshToken,
+            }) as OAuthV2Response;
+
+            // TODO :: Sort out TS issues
+            const tokenType: 'bot' | 'user' = refreshResp.token_type!; // TODO :: TS
+
+            if (tokenType === 'bot') {
+              authResult.botToken = refreshResp.access_token;
+              authResult.botRefreshToken = refreshResp.refresh_token;
+              authResult.botTokenExpiresAt = currentUTCSec + refreshResp.expires_in!; // TODO :: TS
+            }
+
+            if (tokenType === 'user') {
+              authResult.userToken = refreshResp.access_token;
+              authResult.userRefreshToken = refreshResp.refresh_token;
+              authResult.userTokenExpiresAt = currentUTCSec + refreshResp.expires_in!; // TODO :: TS
+            }
+
+            installationUpdates[tokenType].token = refreshResp.access_token;
+            installationUpdates[tokenType].refreshToken = refreshResp.refresh_token;
+            installationUpdates[tokenType].expiresAt = currentUTCSec + refreshResp.expires_in!; // TODO :: TS
+
+            const updatedInstallation = {
+              ...installationUpdates,
+              [tokenType]: { ...queryResult[tokenType], ...installationUpdates[tokenType] }, // bot | user
+            };
+
+            await this.installationStore.storeInstallation(updatedInstallation);
+          }
+        }
       }
 
       return authResult;
@@ -227,6 +308,7 @@ export class InstallProvider {
       // Start: Build the installation object
       let installation: Installation;
       let resp: OAuthV1Response | OAuthV2Response;
+
       if (this.authVersion === 'v1') {
         // convert response type from WebApiCallResult to OAuthResponse
         const v1Resp = await client.oauth.access({
@@ -269,6 +351,7 @@ export class InstallProvider {
         resp = v1Resp;
         installation = v1Installation;
       } else {
+
         // convert response type from WebApiCallResult to OAuthResponse
         const v2Resp = await client.oauth.v2.access({
           code,
@@ -294,9 +377,13 @@ export class InstallProvider {
           authVersion: 'v2',
         };
 
+        const currentUTC = Math.floor(Date.now() / 1000); // utc, seconds
+
+        // Installation has Bot Token
         if (v2Resp.access_token !== undefined && v2Resp.scope !== undefined && v2Resp.bot_user_id !== undefined) {
-          // A bot user/scope was requested
+
           const authResult = await runAuthTest(v2Resp.access_token, this.clientOptions);
+
           v2Installation.bot = {
             scopes: v2Resp.scope.split(','),
             token: v2Resp.access_token,
@@ -305,20 +392,31 @@ export class InstallProvider {
           };
 
           if (v2Resp.is_enterprise_install) {
-            // if it is an org enterprise install, add the enterprise url
             v2Installation.enterpriseUrl = authResult.url;
           }
 
-        } else if (v2Resp.authed_user.access_token !== undefined) {
-          // Only user scopes were requested
+          // Token Rotation is Enabled
+          if (v2Resp.refresh_token !== undefined && v2Resp.expires_in !== undefined) {
+            v2Installation.bot.refreshToken = v2Resp.refresh_token;
+            v2Installation.bot.expiresAt = currentUTC + v2Resp.expires_in; // utc, seconds
+          }
+        }
+
+        // Installation has User Token
+        if (v2Resp.authed_user !== undefined && v2Resp.authed_user.access_token !== undefined) {
+
           // TODO: confirm if it is possible to do an org enterprise install without a bot user
           const authResult = await runAuthTest(v2Resp.authed_user.access_token, this.clientOptions);
-          if (v2Resp.is_enterprise_install) {
+
+          if (v2Resp.is_enterprise_install && v2Installation.enterpriseUrl === undefined) {
             v2Installation.enterpriseUrl = authResult.url;
           }
-        } else {
-          // TODO: make this a coded error
-          throw new Error('The response from the authorization URL contained inconsistent information. Please file a bug.');
+
+          // Token Rotation is Enabled
+          if (v2Resp.authed_user.refresh_token !== undefined && v2Resp.authed_user.expires_in !== undefined) {
+            v2Installation.user.refreshToken = v2Resp.authed_user.refresh_token;
+            v2Installation.user.expiresAt = currentUTC + v2Resp.authed_user.expires_in; // utc, seconds
+          }
         }
 
         resp = v2Resp;
@@ -333,6 +431,7 @@ export class InstallProvider {
           configurationUrl: resp.incoming_webhook.configuration_url,
         };
       }
+
       if (installOptions !== undefined && installOptions.metadata !== undefined) {
         // Pass the metadata in state parameter if exists.
         // Developers can use the value for additional/custom data associated with the installation.
@@ -455,7 +554,7 @@ export interface InstallationStore {
     installation: Installation<AuthVersion, boolean>,
     logger?: Logger): Promise<void>;
   fetchInstallation:
-    (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
+  (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
 }
 
 // using a javascript object as a makeshift database for development
@@ -565,12 +664,16 @@ export interface Installation<AuthVersion extends ('v1' | 'v2') = ('v1' | 'v2'),
 
   user: {
     token: AuthVersion extends 'v1' ? string : (string | undefined);
+    refreshToken?: AuthVersion extends 'v1' ? never : (string | undefined);
+    expiresAt?: AuthVersion extends 'v1' ? never : (number | undefined);
     scopes: AuthVersion extends 'v1' ? string[] : (string[] | undefined);
     id: string;
   };
 
   bot?: {
     token: string;
+    refreshToken?: string;
+    expiresAt?: number;
     scopes: string[];
     id: string; // retrieved from auth.test
     userId: string;
@@ -636,7 +739,11 @@ export type OrgInstallationQuery = InstallationQuery<true>;
 // of Bolt.
 export interface AuthorizeResult {
   botToken?: string;
+  botRefreshToken?: string;
+  botTokenExpiresAt?: number;
   userToken?: string;
+  userRefreshToken?: string;
+  userTokenExpiresAt?: number;
   botId?: string;
   botUserId?: string;
   teamId?: string;
@@ -702,17 +809,21 @@ function isNotOrgInstall(installation: Installation): installation is Installati
 }
 
 // Response shape from oauth.v2.access - https://api.slack.com/methods/oauth.v2.access#response
-interface OAuthV2Response extends WebAPICallResult {
+export interface OAuthV2Response extends WebAPICallResult {
   app_id: string;
   authed_user: {
     id: string,
     scope?: string,
     access_token?: string,
     token_type?: string,
+    refresh_token?: string,
+    expires_in?: number,
   };
   scope?: string;
-  token_type?: 'bot';
+  token_type?: 'bot' | 'user';
   access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
   bot_user_id?: string;
   team: { id: string, name: string } | null;
   enterprise: { name: string, id: string } | null;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -200,7 +200,7 @@ export class InstallProvider {
    *
    * The return value is an Array of Promises made up of the resolution of each token refresh attempt.
    */
-  private async refreshExpiringTokens(tokensToRefresh: string[]): Promise<OAuthV2ExchangeResponse[]> {
+  private async refreshExpiringTokens(tokensToRefresh: string[]): Promise<OAuthV2TokenRefreshResponse[]> {
     const client = new WebClient(undefined, this.clientOptions);
 
     const refreshPromises = tokensToRefresh.map(async (refreshToken) => {
@@ -209,7 +209,7 @@ export class InstallProvider {
         client_secret: this.clientSecret,
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
-      }).catch(e => e) as OAuthV2ExchangeResponse;
+      }).catch(e => e) as OAuthV2TokenRefreshResponse;
     });
 
     return Promise.all(refreshPromises);
@@ -859,7 +859,7 @@ export interface OAuthV2Response extends WebAPICallResult {
   };
 }
 
-export interface OAuthV2ExchangeResponse extends WebAPICallResult {
+export interface OAuthV2TokenRefreshResponse extends WebAPICallResult {
   app_id: string;
   scope: string;
   token_type: 'bot' | 'user';

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -506,6 +506,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     access: bindApiCall<OAuthAccessArguments, OauthAccessResponse>(this, 'oauth.access'),
     v2: {
       access: bindApiCall<OAuthV2AccessArguments, OauthV2AccessResponse>(this, 'oauth.v2.access'),
+      exchange: bindApiCall<OAuthV2AccessArguments, OauthV2AccessResponse>(this, 'oauth.v2.exchange'),
     },
   };
 
@@ -1596,8 +1597,10 @@ export interface OAuthAccessArguments extends WebAPICallOptions {
 export interface OAuthV2AccessArguments extends WebAPICallOptions {
   client_id: string;
   client_secret: string;
-  code: string;
+  code?: string; // code is not required for token rotation
   redirect_uri?: string;
+  grant_type?: string;
+  refresh_token?: string;
 }
 /*
  * `pins.*`

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -506,7 +506,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     access: bindApiCall<OAuthAccessArguments, OauthAccessResponse>(this, 'oauth.access'),
     v2: {
       access: bindApiCall<OAuthV2AccessArguments, OauthV2AccessResponse>(this, 'oauth.v2.access'),
-      exchange: bindApiCall<OAuthV2AccessArguments, OauthV2AccessResponse>(this, 'oauth.v2.exchange'),
+      exchange: bindApiCall<OAuthV2ExchangeArguments, OauthV2AccessResponse>(this, 'oauth.v2.exchange'),
     },
   };
 
@@ -1597,10 +1597,17 @@ export interface OAuthAccessArguments extends WebAPICallOptions {
 export interface OAuthV2AccessArguments extends WebAPICallOptions {
   client_id: string;
   client_secret: string;
-  code?: string; // code is not required for token rotation
+  code?: string; // not required for token rotation
   redirect_uri?: string;
   grant_type?: string;
   refresh_token?: string;
+}
+
+export interface OAuthV2ExchangeArguments extends WebAPICallOptions {
+  client_id: string;
+  client_secret: string;
+  grant_type: string;
+  refresh_token: string;
 }
 /*
  * `pins.*`


### PR DESCRIPTION
#1241

Although the original consensus was to tie the expiry check and subsequent refresh to making a call to the API, it was at some point decided that this should occur when events are received. The current state of this draft reflects that decision.

### HOW IT WORKS
On OAuth installation (the only installation flow allowed when token rotation is enabled), new access tokens are stored as they have been, but now include an accompanying `refresh_token` and `expires_in`. The `refresh_token` (does not expire) is used to "trade-in" for a new `access_token` and `refresh_token` pair. 

For each token (bot|user), we use the `expires_in` value to calculate and store a corresponding future expiry timestamp (UTC, seconds).

Each time an event is received, `authorize` gets run. Here we determine if token rotation is enabled. If so, we check the expiry of the token(s) and refresh those that have expired or will expire within 2 hours. We then update the returned `authResult` and the `Installation`.

### NOTABLE CHANGES
1. `AuthorizationResult` has four new keys: `botRefreshToken`, `botTokenExpiresAt`, `userRefreshToken`, and `userTokenExpiresAt`. This was to handle apps that have both User and Bot tokens while still keeping the shape flat.

2. `Installation` has four new keys: a `refreshToken` and `expiresAt` for both the `user` and `bot` objects.

### TO CONSIDER
2 hours is the current window of time we try to get ahead of an expiry. If customization of the TTL is introduced later on, this is likely too inflexible and will need to be revisited.

Refreshing on incoming events still feels strange, but it appears to work as expected thus far. Logic for the expiry checks are run on every incoming event, which is no problem with single user testing, but I'm unsure if results would be different with events constantly pouring in across many channels.

### TODO / OUTSTANDING
- [x] Address TypeScript issues
- [ ] Write tests - _will write during beta_
- [ ] ~Retry on failure to refresh (discussion)~
- [x] Revisit possibility of concurrent calls (discussion)
- [ ] ~Introduce `deleteInstallation` (discussion)~
- [x] Verify non-token rotation-enabled apps still work as expected
- [x] Stress testing

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
