### PR TITLE
Fix an error in RTM client doc

### DIFF
--- a/docs/_packages/rtm_api.md
+++ b/docs/_packages/rtm_api.md
@@ -497,7 +497,7 @@ const token = process.env.SLACK_BOT_TOKEN;
 const rtm = new RTMClient(token);
 
 const trackedUserIds = [];
-function addPresenceSubscriptions(userIds) {
+async function addPresenceSubscriptions(userIds) {
   await rtm.subscribePresence(trackedUserIds.concat(userIds));
   trackedUserIds.push(...userIds);
 }


### PR DESCRIPTION
###  Summary

While answering a question about RTMClient, I've found a code error in the doc.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
