### PR TITLE
Update the web-api response types (2021-05-25 PT)

### DIFF
--- a/packages/web-api/src/response/AdminConversationsSearchResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsSearchResponse.ts
@@ -33,4 +33,5 @@ export interface Conversation {
   connected_team_ids?:            string[];
   conversation_host_id?:          string;
   channel_email_addresses?:       string[];
+  connected_limited_team_ids?:    string[];
 }

--- a/packages/web-api/src/response/FilesUploadResponse.ts
+++ b/packages/web-api/src/response/FilesUploadResponse.ts
@@ -67,4 +67,6 @@ export interface Public {
   channel_name?:      string;
   team_id?:           string;
   share_user_id?:     string;
+  thread_ts?:         string;
+  latest_reply?:      string;
 }

--- a/packages/web-api/src/response/RemindersListResponse.ts
+++ b/packages/web-api/src/response/RemindersListResponse.ts
@@ -16,4 +16,5 @@ export interface Reminder {
   recurring?:   boolean;
   time?:        number;
   complete_ts?: number;
+  channel?:     string;
 }

--- a/packages/web-api/src/response/StarsListResponse.ts
+++ b/packages/web-api/src/response/StarsListResponse.ts
@@ -136,6 +136,7 @@ export interface Message {
   upload?:            boolean;
   display_as_bot?:    boolean;
   is_locked?:         boolean;
+  inviter?:           string;
 }
 
 export interface Attachment {


### PR DESCRIPTION
###  Summary

This pull request updates a few API response types to have more properties. The types are generated by `./scripts/generate-web-api-types.sh` as always.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
