### PR TITLE
Changed type of created on UsersConversationsResponse

### DIFF
--- a/packages/web-api/src/response/UsersConversationsResponse.ts
+++ b/packages/web-api/src/response/UsersConversationsResponse.ts
@@ -13,7 +13,7 @@ export interface Channel {
   enterprise_id?:         string;
   id?:                    string;
   name?:                  string;
-  created?:               string;
+  created?:               number;
   creator?:               string;
   unlinked?:              number;
   name_normalized?:       string;


### PR DESCRIPTION
###  Summary

For the users.conversations response the type on the Channel object was set to string. This type is number on all other channel response types and I confirmed that we do get a number back from the API.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
