### PR TITLE
Publish @slack/oauth@2.1.0

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

Here is a new minor release for `@slack/oauth`.

In addition to https://github.com/slackapi/node-slack-sdk/milestone/7?closed=1, the following changes are also included.

* https://github.com/slackapi/node-slack-sdk/pull/1206
* https://github.com/slackapi/node-slack-sdk/pull/1208

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
