### PR TITLE
Update README + docs with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 [![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
 <!-- TODO: npm versions with scoped packages: https://github.com/rvagg/nodei.co/issues/24 -->
 
+### **Deprecation Notice**
+
+_`@slack/events-api` and `@slack/interactive-messages` officially reached EOL on May 31st, 2021. Development has fully stopped for these packages and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
+
+___
+
+## Getting Started
+
 Visit the [documentation site](https://slack.dev/node-slack-sdk) for all the lovely details.
 
 _This SDK is a collection of single-purpose packages. The packages are aimed at making building Slack apps

--- a/docs/_main/index.md
+++ b/docs/_main/index.md
@@ -10,6 +10,14 @@ headings:
     - title: Getting Help
 ---
 
+### **Deprecation Notice**
+
+_`@slack/events-api` and `@slack/interactive-messages` officially reached EOL on May 31st, 2021. Development has fully stopped for these packages and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
+
+---
+
 The Slack platform offers several APIs to build apps. Each Slack API delivers part of the capabilities from the
 platform, so that you can pick just those that fit for your needs. This SDK offers a corresponding package for each of
 Slack's APIs. They are small and powerful when used independently, and work seamlessly when used together, too.

--- a/docs/_packages/events_api.md
+++ b/docs/_packages/events_api.md
@@ -9,6 +9,12 @@ The `@slack/events-api` package helps your app respond to events from Slack's [E
 such as new messages, emoji reactions, files, and much more. This package will help you start with convenient and secure
 defaults.
 
+### **Deprecation Notice**
+
+_`@slack/events-api` officially reached EOL on May 31st, 2021. Development has fully stopped for this package and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
+
 ## Installation
 
 ```shell

--- a/docs/_packages/interactive_messages.md
+++ b/docs/_packages/interactive_messages.md
@@ -9,6 +9,12 @@ order: 3
 The `@slack/interactive-messages` helps your app respond to interactions from Slack's
 [interactive messages](https://api.slack.com/messaging/interactivity), [actions](https://api.slack.com/actions), and [dialogs](https://api.slack.com/dialogs). This package will help you start with convenient and secure defaults.
 
+### **Deprecation Notice**
+
+_`@slack/interactive-messages` officially reached EOL on May 31st, 2021. Development has fully stopped for this package and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
+
 ## Installation
 
 ```shell

--- a/packages/events-api/README.md
+++ b/packages/events-api/README.md
@@ -4,6 +4,12 @@ The `@slack/events-api` package helps your app respond to events from Slack's [E
 such as new messages, emoji reactions, files, and much more. This package will help you start with convenient and secure
 defaults.
 
+### **Deprecation Notice**
+
+_`@slack/events-api` officially reached EOL on May 31st, 2021. Development has fully stopped for this package and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
+
 ## Installation
 
 ```shell

--- a/packages/interactive-messages/README.md
+++ b/packages/interactive-messages/README.md
@@ -1,8 +1,13 @@
 # Slack Interactive Messages for Node
 
-The `@slack/interactive-messages` helps your app respond to interactions from Slack's
+`@slack/interactive-messages` helps your app respond to interactions from Slack's
 [interactive messages](https://api.slack.com/messaging/interactivity), [actions](https://api.slack.com/actions), and [dialogs](https://api.slack.com/dialogs). This package will help you start with convenient and secure defaults.
 
+### **Deprecation Notice**
+
+_`@slack/interactive-messages` officially reached EOL on May 31st, 2021. Development has fully stopped for this package and all remaining open issues and pull requests have been closed._
+
+_At this time, we recommend migrating to [Bolt for JavaScript](https://github.com/slackapi/bolt-js), a framework that offers all of the functionality available in those packages (and more). To help with that process, we've provided some [migration samples](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for those looking to convert their existing apps._
 ## Installation
 
 ```shell


### PR DESCRIPTION
###  Summary

Update the README to reflect EOL of `@slack/events-api` and `@slack/interactive-messages`.

**Main**
![Screen Shot 2021-06-04 at 4 13 00 PM](https://user-images.githubusercontent.com/7788242/120871274-0660e100-c550-11eb-9552-8f30da5c4dfb.png)

**Interactive Messages**
![Screen Shot 2021-06-04 at 4 12 53 PM](https://user-images.githubusercontent.com/7788242/120871277-082aa480-c550-11eb-9b13-2f594cadc1df.png)

**Events API**
![Screen Shot 2021-06-04 at 4 12 43 PM](https://user-images.githubusercontent.com/7788242/120871279-095bd180-c550-11eb-8cdf-3a539dad8b1a.png)


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
