### PR TITLE
Update the releasing operation to have the step to maintain GitHub milestones

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -96,6 +96,7 @@ If you make a mistake, don't fret. NPM allows you to unpublish a release within 
   * If you are releasing without learna, change into the package directory and run `npm publish . --otp YOUR_OTP_CODE`.
 
 4. Close GitHub Milestone(s), create GitHub Release(s), and add release notes.
+  * Move any unfinished, open issues to the next GitHub Milestone
   * Close the relevant GitHub Milestone(s) for the release(s)
   * Release notes should mention contributors (@-mentions) and issues/PRs (#-mentions).
   * Example release: https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.2.0

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -95,9 +95,10 @@ If you make a mistake, don't fret. NPM allows you to unpublish a release within 
     `npm publish . --otp YOUR_OTP_CODE` in each of the package directories.
   * If you are releasing without learna, change into the package directory and run `npm publish . --otp YOUR_OTP_CODE`.
 
-4. Create GitHub Release(s) and add release notes.
+4. Close GitHub Milestone(s), create GitHub Release(s), and add release notes.
+  * Close the relevant GitHub Milestone(s) for the release(s)
   * Release notes should mention contributors (@-mentions) and issues/PRs (#-mentions).
-  * Example release: https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%405.11.0
+  * Example release: https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.2.0
 
 5. (Slack Internal) Communicate the release internally. Include a link to the GitHub Release(s).
 


### PR DESCRIPTION
###  Summary

This pull request updates the maintainers' guide to have the step to maintain GitHub milestones.

<img width="700" src="https://user-images.githubusercontent.com/19658/121162755-29a9ca00-c889-11eb-9605-607e4cb2cd07.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
