### PR TITLE
Fix #1250: Add Support for Axios timeout Customization

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -117,7 +117,7 @@ describe('WebClient', function () {
 
   describe('has an option to override the Axios timeout value', function () {
     it('should log warning and throw error if timeout exceeded', function (done) {
-      const timeoutOverride = 15; // ms, guaranteed failure
+      const timeoutOverride = 1; // ms, guaranteed failure
       
       const logger = {
         debug: sinon.spy(),

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -115,6 +115,46 @@ describe('WebClient', function () {
     });
   });
 
+  describe('has an option to override the Axios timeout value', function () {
+    it('should log warning and throw error if timeout exceeded', function (done) {
+      const timeoutOverride = 15; // ms, guaranteed failure
+      
+      const logger = {
+        debug: sinon.spy(),
+        info: sinon.spy(),
+        warn: sinon.spy(),
+        error: sinon.spy(),
+        setLevel: sinon.spy(),
+        setName: sinon.spy(),
+      };
+      
+      const client = new WebClient(undefined, { 
+        timeout: timeoutOverride, 
+        retryConfig: { retries: 0 },
+        logLevel: LogLevel.WARN, 
+        logger 
+      });  
+      
+      client.apiCall('users.list')
+        .then(_ => {
+          done(new Error("expected timeout to throw error"));
+        })
+        .catch(error => {
+          try {
+            assert.isTrue(logger.warn.calledOnce, 'expected Logger to be called once');
+            assert.instanceOf(error, Error);
+            assert.equal(error.code, ErrorCode.RequestError);
+            assert.equal(error.original.config.timeout, timeoutOverride);
+            assert.equal(error.original.isAxiosError, true);
+            assert.equal(error.original.request.aborted, true);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        }); 
+    });
+  });
+
   describe('apiCall()', function () {
     beforeEach(function () {
       this.client = new WebClient(token, { retryConfig: rapidRetryPolicy });
@@ -321,15 +361,14 @@ describe('WebClient', function () {
     });
 
     describe('when an API call fails', function () {
-      beforeEach(function () {
-        this.scope = nock('https://slack.com')
-          .post(/api/)
-          .reply(500);
-      });
-
       it('should return a Promise which rejects on error', function (done) {
-        const r = this.client.apiCall('method')
-        r.catch((error) => {
+        const client = new WebClient(undefined, { retryConfig: { retries: 0 } });
+        
+        this.scope = nock('https://slack.com')
+            .post(/api/)
+            .reply(500);
+
+        client.apiCall('method').catch((error) => {
           assert.instanceOf(error, Error);
           this.scope.done();
           done();

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -95,6 +95,7 @@ export class WebClient extends Methods {
     retryConfig = retryPolicies.tenRetriesInAboutThirtyMinutes,
     agent = undefined,
     tls = undefined,
+    timeout = 0,
     rejectRateLimitedCalls = false,
     headers = {},
     teamId = undefined,
@@ -122,6 +123,7 @@ export class WebClient extends Methods {
     }
 
     this.axios = axios.create({
+      timeout,
       baseURL: slackApiUrl,
       headers: isElectron() ? headers : Object.assign({ 'User-Agent': getUserAgent() }, headers),
       httpAgent: agent,
@@ -496,6 +498,7 @@ export interface WebClientOptions {
   retryConfig?: RetryOptions;
   agent?: Agent;
   tls?: TLSOptions;
+  timeout?: number;
   rejectRateLimitedCalls?: boolean;
   headers?: object;
   teamId?: string;


### PR DESCRIPTION
###  Summary

Fixes #1250.

Adds additional `timeout` prop to `WebClientOptions` to support custom Axios timeout value.
 
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
