### PR TITLE
Split `Option` into `PlainTextOption` and `MrkdwnOption` to account for menus that do not allow markdown

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,12 +67,21 @@ export interface MrkdwnElement {
   verbatim?: boolean;
 }
 
-export interface Option {
-  text: PlainTextElement | MrkdwnElement;
+export interface MrkdwnOption {
+  text: MrkdwnElement;
   value?: string;
   url?: string;
   description?: PlainTextElement;
 }
+
+export interface PlainTextOption {
+  text: PlainTextElement;
+  value?: string;
+  url?: string;
+  description?: PlainTextElement;
+}
+
+export type Option = MrkdwnOption | PlainTextOption;
 
 export interface Confirm {
   title?: PlainTextElement;
@@ -116,10 +125,10 @@ export interface StaticSelect extends Action {
   type: 'static_select';
   placeholder?: PlainTextElement;
   initial_option?: Option;
-  options?: Option[];
+  options?: PlainTextOption[];
   option_groups?: {
     label: PlainTextElement;
-    options: Option[];
+    options: PlainTextOption[];
   }[];
   confirm?: Confirm;
 }
@@ -127,11 +136,11 @@ export interface StaticSelect extends Action {
 export interface MultiStaticSelect extends Action {
   type: 'multi_static_select';
   placeholder?: PlainTextElement;
-  initial_options?: Option[];
-  options?: Option[];
+  initial_options?: PlainTextOption[];
+  options?: PlainTextOption[];
   option_groups?: {
     label: PlainTextElement;
-    options: Option[];
+    options: PlainTextOption[];
   }[];
   max_selected_items?: number;
   confirm?: Confirm;
@@ -182,7 +191,7 @@ export interface MultiChannelsSelect extends Action {
 
 export interface ExternalSelect extends Action {
   type: 'external_select';
-  initial_option?: Option;
+  initial_option?: PlainTextOption;
   placeholder?: PlainTextElement;
   min_query_length?: number;
   confirm?: Confirm;
@@ -190,7 +199,7 @@ export interface ExternalSelect extends Action {
 
 export interface MultiExternalSelect extends Action {
   type: 'multi_external_select';
-  initial_options?: Option[];
+  initial_options?: PlainTextOption[];
   placeholder?: PlainTextElement;
   min_query_length?: number;
   max_selected_items?: number;
@@ -208,7 +217,7 @@ export interface Button extends Action {
 
 export interface Overflow extends Action {
   type: 'overflow';
-  options: Option[];
+  options: PlainTextOption[];
   confirm?: Confirm;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -124,7 +124,7 @@ export interface MultiUsersSelect extends Action {
 export interface StaticSelect extends Action {
   type: 'static_select';
   placeholder?: PlainTextElement;
-  initial_option?: Option;
+  initial_option?: PlainTextOption;
   options?: PlainTextOption[];
   option_groups?: {
     label: PlainTextElement;


### PR DESCRIPTION
###  Summary

Closes #1268. Per the Slack API, only some menus allow `MrkdwnElement`s in their options' text properties. However, the SDK types erroneously allow all menu types to have `MrkdwnElement`s.

This PR addresses this type bug by turning `Option` into a union of `PlainTextOption` and `MrkdwnOption`. The appropriate menu types are also changed from `Option` to `PlainTextOption` to match how the API works.

I used [this API reference](https://api.slack.com/reference/block-kit/composition-objects#option) to determine which types to change.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
