### PR TITLE
Add support for deletion of an installation (InstallationStore / MemoryInstallationStore)

### DIFF
--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -53,6 +53,19 @@ const installer = new InstallProvider({
       }
       throw new Error('Failed fetching installation');
     },
+    deleteInstallation: async (installQuery) => {
+      if (installQuery.isEnterpriseInstall) {
+        if (installQuery.enterpriseId !== undefined) {       
+          // delete org installation
+          return await keyv.delete(installQuery.enterpriseId)
+        }
+      }
+      if (installQuery.teamId !== undefined) {
+        // delete single team installation
+        return await keyv.delete(installQuery.teamId);
+      }
+      throw new Error('Failed to delete installation');
+    },
   },
 });
 

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -184,11 +184,11 @@ const installer = new InstallProvider({
     // returns installation object from database
     fetchInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
         return await myDB.get(installQuery.enterpriseId);
       }
-      if (query.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
         return await myDB.get(installQuery.teamId);
       }

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -194,6 +194,21 @@ const installer = new InstallProvider({
       }
       throw new Error('Failed fetching installation');
     },
+    // takes in an installQuery as an argument
+    // installQuery = {teamId: 'string', enterpriseId: 'string', userId: 'string', conversationId: 'string', isEnterpriseInstall: boolean};
+    // returns nothing
+    deleteInstallation: async (installQuery) => {
+      // replace myDB.get with your own database or OEM getter
+      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+        // org wide app installation deletion
+        return await myDB.delete(installQuery.enterpriseId);
+      }
+      if (query.teamId !== undefined) {
+        // single team app installation deletion
+        return await myDB.delete(installQuery.teamId);
+      }
+      throw new Error('Failed to delete installation');
+    },
   },
 });
 ```

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -74,6 +74,13 @@ const installationStore = {
     return new Promise((resolve) => {
         resolve(item);
     });
+  },
+  deleteInstallation: (installQuery) => {
+    // db delete
+    delete devDB[installQuery.teamId];
+    return new Promise((resolve) => {
+        resolve();
+    });
   }
 }
 
@@ -450,7 +457,7 @@ describe('OAuth', async () => {
     });
   });
 
-  describe('MemoryInstallStore', async () => {
+  describe('MemoryInstallationStore', async () => {
     it('should store and fetch an installation', async () => {
       const installer = new InstallProvider({clientId, clientSecret, stateSecret});
       const fakeTeamId = storedInstallation.team.id;
@@ -459,6 +466,17 @@ describe('OAuth', async () => {
       const fetchedResult = await installer.installationStore.fetchInstallation({teamId:fakeTeamId});
       assert.deepEqual(fetchedResult, storedInstallation);
       assert.deepEqual(storedInstallation, installer.installationStore.devDB[fakeTeamId]);
+    });
+
+    it('should delete a stored installation', async () => {
+      const installer = new InstallProvider({clientId, clientSecret, stateSecret});
+      const fakeTeamId = storedInstallation.team.id;
+
+      await installer.installationStore.storeInstallation(storedInstallation);
+      assert.isNotEmpty(installer.installationStore.devDB);
+      
+      await installer.installationStore.deleteInstallation({ teamId:fakeTeamId }); 
+      assert.isEmpty(installer.installationStore.devDB);
     });
   });
 

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -520,17 +520,23 @@ class MemoryInstallationStore implements InstallationStore {
     if (logger !== undefined) {
       logger.warn('Deleting Access Token from DB. Please use a real Installation Store for production!');
     }
-    
+
     if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
       if (logger !== undefined) {
         logger.debug('deleting org installation');
       }
-      delete this.devDB[query.enterpriseId];
+
+      const { [query.enterpriseId]: _, ...devDB } = this.devDB;
+      this.devDB = devDB;
+
     } else if (query.teamId !== undefined) {
       if (logger !== undefined) {
         logger.debug('deleting single team installation');
       }
-      delete this.devDB[query.teamId];
+
+      const { [query.teamId]: _, ...devDB } = this.devDB;
+      this.devDB = devDB;
+
     } else {
       throw new Error('Failed to delete installation');
     }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -461,6 +461,7 @@ export interface InstallationStore {
 }
 
 // using a javascript object as a makeshift database for development
+// storing user tokens is not supported
 interface DevDatabase {
   [teamIdOrEnterpriseId: string]: Installation;
 }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -456,6 +456,8 @@ export interface InstallationStore {
     logger?: Logger): Promise<void>;
   fetchInstallation:
     (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
+  deleteInstallation:
+    (query: InstallationQuery<boolean>, logger?: Logger) => Promise<void>;
 }
 
 // using a javascript object as a makeshift database for development
@@ -512,6 +514,26 @@ class MemoryInstallationStore implements InstallationStore {
       return this.devDB[query.teamId] as Installation<'v1' | 'v2', false>;
     }
     throw new Error('Failed fetching installation');
+  }
+
+  public async deleteInstallation(query: InstallationQuery<boolean>, logger?: Logger): Promise<void> {
+    if (logger !== undefined) {
+      logger.warn('Deleting Access Token from DB. Please use a real Installation Store for production!');
+    }
+    
+    if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('deleting org installation');
+      }
+      delete this.devDB[query.enterpriseId];
+    } else if (query.teamId !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('deleting single team installation');
+      }
+      delete this.devDB[query.teamId];
+    } else {
+      throw new Error('Failed to delete installation');
+    }
   }
 }
 


### PR DESCRIPTION
###  Summary

Fixes #1271

Adds `deleteInstallation` to the `MemoryInstallationStore` class, as well as to the `InstallationStore` interface.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
