### PR TITLE
Make deleteInstallation optional

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -456,7 +456,8 @@ export interface InstallationStore {
     logger?: Logger): Promise<void>;
   fetchInstallation:
     (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
-  deleteInstallation:
+  // TODO :: remove optionality in v3.0
+  deleteInstallation?:
     (query: InstallationQuery<boolean>, logger?: Logger) => Promise<void>;
 }
 


### PR DESCRIPTION
###  Summary

Post-merge feedback pointed out that `deleteInstallation` not being optional will cause issues for folks that have introduced their own stores already. Designating it as optional until next major version (v3.0).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
