### PR TITLE
Add `SlashCommand` type to @slack/types package

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -401,3 +401,22 @@ export interface CallUserExternal {
   display_name: string;
   avatar_url: string;
 }
+
+export interface SlashCommand extends Record<string, any> {
+  token: string;
+  command: string;
+  text: string;
+  response_url: string;
+  trigger_id: string;
+  user_id: string;
+  user_name: string;
+  team_id: string;
+  team_domain: string;
+  channel_id: string;
+  channel_name: string;
+  api_app_id: string;
+  enterprise_id?: string;
+  enterprise_name?: string;
+  // exists for enterprise installs
+  is_enterprise_install?: string; // This should be a boolean, but payload for commands gives string 'true'
+}


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

- Adds the `SlashCommand` type from the [bolt-js](https://github.com/slackapi/bolt-js/blob/22f938e53ccef59e5a4acdd7b4d2a271430dd957/src/types/command/index.ts) project to `@slack/types` package.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
