### PR TITLE
Split up View type to improve TS linting

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -50,7 +50,6 @@ interface ModalView {
   clear_on_close?: boolean; // defaults to false
   notify_on_close?: boolean; // defaults to false
   external_id?: string;
-  submit_disabled?: boolean; // defaults to false
 }
 
 interface WorkflowStepView {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,19 +31,37 @@ export interface Dialog {
   state?: string;
 }
 
-export interface View {
-  title?: PlainTextElement;
-  type: 'home' | 'modal' | 'workflow_step';
+interface HomeView {
+  type: 'home';
   blocks: (KnownBlock | Block)[];
+  private_metadata?: string;
   callback_id?: string;
+  external_id?: string;
+}
+
+interface ModalView {
+  type: 'modal';
+  title: PlainTextElement;
+  blocks: (KnownBlock | Block)[];
   close?: PlainTextElement;
   submit?: PlainTextElement;
   private_metadata?: string;
+  callback_id?: string;
   clear_on_close?: boolean; // defaults to false
   notify_on_close?: boolean; // defaults to false
-  submit_disabled?: boolean; // defaults to false
   external_id?: string;
+  submit_disabled?: boolean; // defaults to false
 }
+
+interface WorkflowStepView {
+  type: 'workflow_step';
+  blocks: (KnownBlock | Block)[];
+  private_metadata?: string;
+  callback_id?: string;
+  submit_disabled?: boolean; // defaults to false
+}
+
+export type View = HomeView | ModalView | WorkflowStepView;
 
 /*
  * Block Elements


### PR DESCRIPTION
###  Summary

There a `View` type. It has three subset types `modal`, `home`, and `workflow_step`. As I've discovered while consuming `@slack/bolt` there is a benefit to split these three up. Specifically that the `modal` subset requires the `title` field but the other two subsets have no use for it. If a consumer of this attempts to send a `modal` view without a `title` they will receive an error so by splitting up the single `interface` into three we can prevent the consumer from having to make the same mistake as myself to learn that although the `title` field is optional for a `view`, when `type: "modal"` is the case the `title` field is required.

I had to rely on these two pieces of documentation to get all of the fields correct:
* [`workflow_step` docs](https://api.slack.com/reference/workflows/configuration-view)
* [`home` and `modal` docs](https://api.slack.com/reference/surfaces/views)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
