### PR TITLE
Fixed `PinsAddArguments` and `PinsRemoveArguments` interface

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1611,10 +1611,7 @@ export interface PinsListArguments extends WebAPICallOptions, TokenOverridable {
 }
 export interface PinsRemoveArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  // must supply one of:
-  file?: string; // file id
-  file_comment?: string;
-  timestamp?: string;
+  timestamp: string;
 }
 
 /*

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1604,10 +1604,7 @@ export interface OAuthV2AccessArguments extends WebAPICallOptions {
  */
 export interface PinsAddArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
-  // must supply one of:
-  file?: string; // file id
-  file_comment?: string;
-  timestamp?: string;
+  timestamp: string;
 }
 export interface PinsListArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;


### PR DESCRIPTION
###  Summary

Updated the `PinsAddArguments` and `PinsRemoveArguments` interface to the correct type [per the docs](https://api.slack.com/methods/pins.add). Specifically,

- The `file_comment` and `file` properties were removed, per
> We are phasing out support for pinning files and file comments only. This method will no longer accept the file and file_comment parameters beginning August 22, 2019.

- The `timestamp` property was made required, per
> Both the `channel` and `timestamp` arguments are required

Closes #1275 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
