### PR TITLE
Add Support for FileInstallationStore

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -204,7 +204,7 @@ const installer = new InstallProvider({
         // org wide app installation deletion
         return await myDB.delete(installQuery.enterpriseId);
       }
-      if (query.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation deletion
         return await myDB.delete(installQuery.teamId);
       }

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -185,11 +185,11 @@ const installer = new InstallProvider({
     // returns installation object from database
     fetchInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
         return await myDB.get(installQuery.enterpriseId);
       }
-      if (query.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
         return await myDB.get(installQuery.teamId);
       }
@@ -200,7 +200,7 @@ const installer = new InstallProvider({
     // returns nothing
     deleteInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation deletion
         return await myDB.delete(installQuery.enterpriseId);
       }

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -153,9 +153,11 @@ app.get('/slack/oauth_redirect', (req, res) => {
 
 ### Storing installations in a database
 
-Although this package uses a default `MemoryInstallationStore`, it isn't recommended for production use since the access tokens it stores would be lost when the process terminates or restarts. Instead, `InstallProvider` has an option for supplying your own installation store, which is used to save and retrieve install information (like tokens) to your own database.
+Although this package uses a default `MemoryInstallationStore`, it isn't recommended for production purposes since the access tokens it stores are lost when the process terminates or restarts. To override this default, `InstallProvider` allows for supplying your own `installationStore`, which is then used to save and retrieve installation information (like tokens) to your own database. 
 
-An installation store is an object that provides two methods: `storeInstallation`, and `fetchInstallation`. `storeInstallation` takes an `installation` as an argument, which is an object that contains all installation related data (like tokens, teamIds, enterpriseIds, etc). `fetchInstallation` takes in a `installQuery`, which is used to query the database. The `installQuery` can contain `teamId`, `enterpriseId`, `userId`, `conversationId` and `isEnterpriseInstall`. 
+For more persistent storage during development, `FileInstallationStore` is a provided alternative to `MemoryInstallationStore` and is available for import and use directly from the package. Customizable options for this store include specifying the `baseDir`, `clientId`, and `historicalDataEnabled`.
+
+An installation store is an object that provides three methods: `storeInstallation`, `fetchInstallation`, and `deleteInstallation`. `storeInstallation` takes an `installation` as an argument, which is an object that contains all installation related data (like tokens, teamIds, enterpriseIds, etc). `fetchInstallation` and `deleteInstallation` both take in an `installQuery`, which is used to query the database. The `installQuery` can contain `teamId`, `enterpriseId`, `userId`, `conversationId` and `isEnterpriseInstall`. 
 
 In the following example, the `installationStore` option is used and the object is defined in line. The methods are implemented by calling an example database library with simple get and set operations.
 
@@ -192,6 +194,21 @@ const installer = new InstallProvider({
         return await myDB.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
+    },
+    // takes in an installQuery as an argument
+    // installQuery = {teamId: 'string', enterpriseId: 'string', userId: 'string', conversationId: 'string', isEnterpriseInstall: boolean};
+    // returns nothing
+    deleteInstallation: async (installQuery) => {
+      // replace myDB.get with your own database or OEM getter
+      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+        // org wide app installation deletion
+        return await myDB.delete(installQuery.enterpriseId);
+      }
+      if (query.teamId !== undefined) {
+        // single team app installation deletion
+        return await myDB.delete(installQuery.teamId);
+      }
+      throw new Error('Failed to delete installation');
     },
   },
 });

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -199,11 +199,11 @@ const installer = new InstallProvider({
     // returns nothing
     deleteInstallation: async (installQuery) => {
       // replace myDB.get with your own database or OEM getter
-      if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation deletion
         return await myDB.delete(installQuery.enterpriseId);
       }
-      if (query.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation deletion
         return await myDB.delete(installQuery.teamId);
       }

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -1,9 +1,10 @@
 require('mocha');
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 
 const url = require('url');
 const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
+const fs = require('fs');
 const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
 
@@ -17,7 +18,7 @@ rewiremock(() => require('@slack/web-api')).with({
     auth = {
       test: sinon.fake.resolves({ bot_id: '' }),
     };
-    oauth = { 
+    oauth = {
       access: sinon.fake.resolves({
         team_id: 'fake-v1-team-id',
         team_name: 'fake-team-name',
@@ -31,7 +32,7 @@ rewiremock(() => require('@slack/web-api')).with({
       }),
       v2: {
         access: sinon.fake.resolves({
-          team: {id: 'fake-v2-team-id', name: 'fake-team-name' },
+          team: { id: 'fake-v2-team-id', name: 'fake-team-name' },
           access_token: 'botToken',
           authed_user: {
             id: 'userId',
@@ -50,6 +51,7 @@ rewiremock(() => require('@slack/web-api')).with({
 
 rewiremock.enable();
 const { InstallProvider } = require('./index');
+const { FileInstallationStore, MemoryInstallationStore } = require('./stores');
 rewiremock.disable();
 
 const clientSecret = 'MY_SECRET';
@@ -59,62 +61,62 @@ const stateSecret = 'stateSecret';
 // Memory database
 const devDB = {};
 
-// Installation Store for testing
+// MemoryInstallation Store for testing
 const installationStore = {
   storeInstallation: (installation) => {
     // db write
     devDB[installation.team.id] = installation;
     return new Promise((resolve) => {
-        resolve();
+      resolve();
     });
   },
   fetchInstallation: (installQuery) => {
     // db read
     const item = devDB[installQuery.teamId];
     return new Promise((resolve) => {
-        resolve(item);
+      resolve(item);
     });
   },
   deleteInstallation: (installQuery) => {
     // db delete
     delete devDB[installQuery.teamId];
     return new Promise((resolve) => {
-        resolve();
+      resolve();
     });
   }
 }
 
-const storedInstallation =  {
-    team: {
-      id: 'test-team-id',
-      name: 'team-name',
-    },
-    enterprise: {
-      id: 'test-enterprise-id',
-      name: 'ent-name',
-    },
-    bot: {
-      token: 'botToken',
-      scopes: ['chat:write'],
-      id: 'botId',
-      userId: 'botUserId',
-    },
-    user: {
-      token: 'userToken',
-      id: 'userId',
-    },
-    incomingWebhook: {
-      url: 'someURL',
-      channel: 'someChannel',
-      channelId: 'someChannelID',
-      configurationUrl: 'someConfigURL',
-    },
-    appId: undefined,
-    tokenType: 'tokenType',
-    isEnterpriseInstall: false,
+const storedInstallation = {
+  team: {
+    id: 'test-team-id',
+    name: 'team-name',
+  },
+  enterprise: {
+    id: 'test-enterprise-id',
+    name: 'ent-name',
+  },
+  bot: {
+    token: 'botToken',
+    scopes: ['chat:write'],
+    id: 'botId',
+    userId: 'botUserId',
+  },
+  user: {
+    token: 'userToken',
+    id: 'userId',
+  },
+  incomingWebhook: {
+    url: 'someURL',
+    channel: 'someChannel',
+    channelId: 'someChannelID',
+    configurationUrl: 'someConfigURL',
+  },
+  appId: 'fakeAppId',
+  tokenType: 'tokenType',
+  isEnterpriseInstall: false,
 }
 
-const storedOrgInstallation =  {
+const storedOrgInstallation = {
   team: null,
   enterprise: {
     id: 'test-enterprise-id',
@@ -157,7 +159,7 @@ describe('OAuth', async () => {
   };
   describe('constructor()', async () => {
     it('should build a default installer given a clientID, client secret and stateSecret', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret });
       assert.instanceOf(installer, InstallProvider);
       assert.equal(installer.authVersion, 'v2');
     });
@@ -174,179 +176,179 @@ describe('OAuth', async () => {
     });
 
     it('should build a default installer given a clientID, client secret, stateSecrect and installationStore', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
       assert.instanceOf(installer, InstallProvider);
     });
 
     it('should build a default installer given a clientID, client secret, stateSecrect and authVersion v2', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, authVersion: 'v2'});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, authVersion: 'v2' });
       assert.instanceOf(installer, InstallProvider);
       assert.equal(installer.authVersion, 'v2');
     });
 
     it('should build a default installer given a clientID, client secret, stateSecrect and authVersion v1', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, authVersion: 'v1'});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, authVersion: 'v1' });
       assert.instanceOf(installer, InstallProvider);
       assert.equal(installer.authVersion, 'v1');
     });
 
     it('should throw an error if missing a clientSecret', async () => {
       try {
-          const installer = new InstallProvider({clientId, stateSecret});
+        const installer = new InstallProvider({ clientId, stateSecret });
       } catch (error) {
-          assert.equal(error.code, ErrorCode.InstallerInitializationError);
-          assert.equal(error.message, 'You must provide a valid clientId and clientSecret');
+        assert.equal(error.code, ErrorCode.InstallerInitializationError);
+        assert.equal(error.message, 'You must provide a valid clientId and clientSecret');
       }
     });
 
     it('should throw an error if missing a clientID', async () => {
       try {
-          const installer = new InstallProvider({clientSecret, stateSecret});
+        const installer = new InstallProvider({ clientSecret, stateSecret });
       } catch (error) {
-          assert.equal(error.code, ErrorCode.InstallerInitializationError);
-          assert.equal(error.message, 'You must provide a valid clientId and clientSecret');
+        assert.equal(error.code, ErrorCode.InstallerInitializationError);
+        assert.equal(error.message, 'You must provide a valid clientId and clientSecret');
       }
     });
 
     it('should throw an error if missing a stateSecret when using default state store', async () => {
       try {
-          const installer = new InstallProvider({clientId, clientSecret});
+        const installer = new InstallProvider({ clientId, clientSecret });
       } catch (error) {
-          assert.equal(error.code, ErrorCode.InstallerInitializationError);
-          assert.equal(error.message, 'You must provide a State Secret to use the built-in state store');
+        assert.equal(error.code, ErrorCode.InstallerInitializationError);
+        assert.equal(error.message, 'You must provide a State Secret to use the built-in state store');
       }
     });
   });
 
   describe('installer.generateInstallUrl', async () => {
-      it('should return a generated v2 url', async () => {
-          const fakeStateStore = {
-            generateStateParam: sinon.fake.resolves('fakeState'),
-            verifyStateParam: sinon.fake.resolves({})
-          }
-          const installer = new InstallProvider({ clientId, clientSecret, stateStore: fakeStateStore });
-          const scopes = ['channels:read'];
-          const teamId = '1234Team';
-          const redirectUri = 'https://mysite.com/slack/redirect';
-          const userScopes = ['chat:write:user']
-          const installUrlOptions = {
-            scopes,
-            metadata: 'some_metadata',
-            teamId,
-            redirectUri,
-            userScopes,
-          }
-          try {
-              const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
-              assert.exists(generatedUrl);
-              assert.equal(fakeStateStore.generateStateParam.callCount, 1);
-              assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
-              assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
+    it('should return a generated v2 url', async () => {
+      const fakeStateStore = {
+        generateStateParam: sinon.fake.resolves('fakeState'),
+        verifyStateParam: sinon.fake.resolves({})
+      }
+      const installer = new InstallProvider({ clientId, clientSecret, stateStore: fakeStateStore });
+      const scopes = ['channels:read'];
+      const teamId = '1234Team';
+      const redirectUri = 'https://mysite.com/slack/redirect';
+      const userScopes = ['chat:write:user']
+      const installUrlOptions = {
+        scopes,
+        metadata: 'some_metadata',
+        teamId,
+        redirectUri,
+        userScopes,
+      }
+      try {
+        const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
+        assert.exists(generatedUrl);
+        assert.equal(fakeStateStore.generateStateParam.callCount, 1);
+        assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
+        assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
 
-              const parsedUrl = url.parse(generatedUrl, true);
-              assert.equal(parsedUrl.query.state, 'fakeState');
-              assert.equal(parsedUrl.pathname, '/oauth/v2/authorize');
-              assert.equal(scopes.join(','), parsedUrl.query.scope);
-              assert.equal(redirectUri, parsedUrl.query.redirect_uri);
-              assert.equal(teamId, parsedUrl.query.team);
-              assert.equal(userScopes.join(','), parsedUrl.query.user_scope);
-          } catch (error) {
-              assert.fail(error.message);
-          }
-      });
-      it('should return a generated url when passed a custom authorizationUrl', async () => {
-        const fakeStateStore = {
-          generateStateParam: sinon.fake.resolves('fakeState'),
-          verifyStateParam: sinon.fake.resolves({})
-        }
-        const authorizationUrl = 'https://dev.slack.com/oauth/v2/authorize';
-        const installer = new InstallProvider({ clientId, clientSecret, stateStore: fakeStateStore, authorizationUrl });
-        const scopes = ['channels:read'];
-        const teamId = '1234Team';
-        const redirectUri = 'https://mysite.com/slack/redirect';
-        const userScopes = ['chat:write:user']
-        const installUrlOptions = {
-          scopes,
-          metadata: 'some_metadata',
-          teamId,
-          redirectUri,
-          userScopes,
-        }
-        try {
-            const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
-            assert.exists(generatedUrl);
-            assert.equal(fakeStateStore.generateStateParam.callCount, 1);
-            assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
-            assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
-
-            const parsedUrl = url.parse(generatedUrl, true);
-            assert.equal(parsedUrl.query.state, 'fakeState');
-            assert.equal(parsedUrl.pathname, '/oauth/v2/authorize');
-            assert.equal(parsedUrl.host, 'dev.slack.com')
-            assert.equal(scopes.join(','), parsedUrl.query.scope);
-            assert.equal(redirectUri, parsedUrl.query.redirect_uri);
-            assert.equal(teamId, parsedUrl.query.team);
-            assert.equal(userScopes.join(','), parsedUrl.query.user_scope);
-        } catch (error) {
-            assert.fail(error.message);
-        }
+        const parsedUrl = url.parse(generatedUrl, true);
+        assert.equal(parsedUrl.query.state, 'fakeState');
+        assert.equal(parsedUrl.pathname, '/oauth/v2/authorize');
+        assert.equal(scopes.join(','), parsedUrl.query.scope);
+        assert.equal(redirectUri, parsedUrl.query.redirect_uri);
+        assert.equal(teamId, parsedUrl.query.team);
+        assert.equal(userScopes.join(','), parsedUrl.query.user_scope);
+      } catch (error) {
+        assert.fail(error.message);
+      }
     });
-      it('should return a generated v1 url', async () => {
-          const fakeStateStore = {
-            generateStateParam: sinon.fake.resolves('fakeState'),
-            verifyStateParam: sinon.fake.resolves({})
-          }
-          const installer = new InstallProvider({clientId, clientSecret, 'stateStore': fakeStateStore, authVersion: 'v1'});
-          const scopes = ['bot'];
-          const teamId = '1234Team';
-          const redirectUri = 'https://mysite.com/slack/redirect';
-          const installUrlOptions = {
-            scopes,
-            metadata: 'some_metadata',
-            teamId,
-            redirectUri,
-        }
-          try {
-              const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
-              assert.exists(generatedUrl);
-              const parsedUrl = url.parse(generatedUrl, true);
-              assert.equal(fakeStateStore.generateStateParam.callCount, 1);
-              assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
-              assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
-              assert.equal(parsedUrl.pathname, '/oauth/authorize');
-              assert.equal(parsedUrl.query.state, 'fakeState');
-              assert.equal(scopes.join(','), parsedUrl.query.scope);
-              assert.equal(redirectUri, parsedUrl.query.redirect_uri);
-              assert.equal(teamId, parsedUrl.query.team);
-          } catch (error) {
-              assert.fail(error.message);
-          }
-      });
-      it('should fail if missing scopes', async () => {
-          const installer = new InstallProvider({clientId, clientSecret, stateSecret});
-          try {
-              const generatedUrl = await installer.generateInstallUrl({})
-              assert.exists(generatedUrl);
-          } catch (error) {
-              assert.equal(error.message, 'You must provide a scope parameter when calling generateInstallUrl');
-              assert.equal(error.code, ErrorCode.GenerateInstallUrlError);
-          }
-      });
+    it('should return a generated url when passed a custom authorizationUrl', async () => {
+      const fakeStateStore = {
+        generateStateParam: sinon.fake.resolves('fakeState'),
+        verifyStateParam: sinon.fake.resolves({})
+      }
+      const authorizationUrl = 'https://dev.slack.com/oauth/v2/authorize';
+      const installer = new InstallProvider({ clientId, clientSecret, stateStore: fakeStateStore, authorizationUrl });
+      const scopes = ['channels:read'];
+      const teamId = '1234Team';
+      const redirectUri = 'https://mysite.com/slack/redirect';
+      const userScopes = ['chat:write:user']
+      const installUrlOptions = {
+        scopes,
+        metadata: 'some_metadata',
+        teamId,
+        redirectUri,
+        userScopes,
+      }
+      try {
+        const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
+        assert.exists(generatedUrl);
+        assert.equal(fakeStateStore.generateStateParam.callCount, 1);
+        assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
+        assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
+
+        const parsedUrl = url.parse(generatedUrl, true);
+        assert.equal(parsedUrl.query.state, 'fakeState');
+        assert.equal(parsedUrl.pathname, '/oauth/v2/authorize');
+        assert.equal(parsedUrl.host, 'dev.slack.com')
+        assert.equal(scopes.join(','), parsedUrl.query.scope);
+        assert.equal(redirectUri, parsedUrl.query.redirect_uri);
+        assert.equal(teamId, parsedUrl.query.team);
+        assert.equal(userScopes.join(','), parsedUrl.query.user_scope);
+      } catch (error) {
+        assert.fail(error.message);
+      }
+    });
+    it('should return a generated v1 url', async () => {
+      const fakeStateStore = {
+        generateStateParam: sinon.fake.resolves('fakeState'),
+        verifyStateParam: sinon.fake.resolves({})
+      }
+      const installer = new InstallProvider({ clientId, clientSecret, 'stateStore': fakeStateStore, authVersion: 'v1' });
+      const scopes = ['bot'];
+      const teamId = '1234Team';
+      const redirectUri = 'https://mysite.com/slack/redirect';
+      const installUrlOptions = {
+        scopes,
+        metadata: 'some_metadata',
+        teamId,
+        redirectUri,
+      }
+      try {
+        const generatedUrl = await installer.generateInstallUrl(installUrlOptions)
+        assert.exists(generatedUrl);
+        const parsedUrl = url.parse(generatedUrl, true);
+        assert.equal(fakeStateStore.generateStateParam.callCount, 1);
+        assert.equal(fakeStateStore.verifyStateParam.callCount, 0);
+        assert.equal(fakeStateStore.generateStateParam.calledWith(installUrlOptions), true);
+        assert.equal(parsedUrl.pathname, '/oauth/authorize');
+        assert.equal(parsedUrl.query.state, 'fakeState');
+        assert.equal(scopes.join(','), parsedUrl.query.scope);
+        assert.equal(redirectUri, parsedUrl.query.redirect_uri);
+        assert.equal(teamId, parsedUrl.query.team);
+      } catch (error) {
+        assert.fail(error.message);
+      }
+    });
+    it('should fail if missing scopes', async () => {
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret });
+      try {
+        const generatedUrl = await installer.generateInstallUrl({})
+        assert.exists(generatedUrl);
+      } catch (error) {
+        assert.equal(error.message, 'You must provide a scope parameter when calling generateInstallUrl');
+        assert.equal(error.code, ErrorCode.GenerateInstallUrlError);
+      }
+    });
   });
   describe('installer.authorize', async () => {
     it('should fail if database does not have an entry for authorize query', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
       try {
-          const authResult = await installer.authorize({teamId:'non_existing_team_id'});
-          assert.fail('Should have failed');
-      } catch(error) {
-          assert.equal(error.code, ErrorCode.AuthorizationError);
-          assert.equal(error.message, 'Failed fetching data from the Installation Store');
+        const authResult = await installer.authorize({ teamId: 'non_existing_team_id' });
+        assert.fail('Should have failed');
+      } catch (error) {
+        assert.equal(error.code, ErrorCode.AuthorizationError);
+        assert.equal(error.message, 'Failed fetching data from the Installation Store');
       }
     });
 
     it('should successfully return the Installation Object from the database', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
       const fakeAuthResult = {
         userToken: 'userToken',
         botToken: 'botToken',
@@ -355,12 +357,12 @@ describe('OAuth', async () => {
       };
 
       try {
-        const authResult = await installer.authorize({teamId:'test-team-id'});
+        const authResult = await installer.authorize({ teamId: 'test-team-id' });
         assert.equal(authResult.userToken, fakeAuthResult.userToken);
         assert.equal(authResult.botToken, fakeAuthResult.botToken);
         assert.equal(authResult.botId, fakeAuthResult.botId);
         assert.equal(authResult.botUserId, fakeAuthResult.botUserId);
-      } catch(error) {
+      } catch (error) {
         assert.fail(error.message);
       }
     });
@@ -384,12 +386,12 @@ describe('OAuth', async () => {
           res.send('successful!');
           assert.fail('should have failed');
         },
-        failure: async (error, installOptions , req, res) => {
+        failure: async (error, installOptions, req, res) => {
           assert.equal(error.code, ErrorCode.MissingStateError)
           res.send('failure');
         },
       }
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore, logger: noopLogger});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, logger: noopLogger });
       await installer.handleCallback(req, res, callbackOptions);
 
       assert.isTrue(sent);
@@ -403,12 +405,12 @@ describe('OAuth', async () => {
           res.send('successful!');
           assert.fail('should have failed');
         },
-        failure: async (error, installOptions , req, res) => {
+        failure: async (error, installOptions, req, res) => {
           assert.equal(error.code, ErrorCode.MissingStateError)
           res.send('failure');
         },
       }
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore, logger: noopLogger});
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, logger: noopLogger });
       await installer.handleCallback(req, res, callbackOptions);
 
       assert.isTrue(sent);
@@ -420,13 +422,13 @@ describe('OAuth', async () => {
         success: async (installation, installOptions, req, res) => {
           res.send('successful!');
         },
-        failure: async (error, installOptions , req, res) => {
+        failure: async (error, installOptions, req, res) => {
           assert.fail(error.message);
           res.send('failure');
         },
       }
-      
-      const installer = new InstallProvider({clientId, clientSecret, installationStore, stateStore: fakeStateStore});
+
+      const installer = new InstallProvider({ clientId, clientSecret, installationStore, stateStore: fakeStateStore });
       const fakeState = 'fakeState';
       const fakeCode = 'fakeCode';
       const req = { url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
@@ -441,13 +443,13 @@ describe('OAuth', async () => {
         success: async (installation, installOptions, req, res) => {
           res.send('successful!');
         },
-        failure: async (error, installOptions , req, res) => {
+        failure: async (error, installOptions, req, res) => {
           assert.fail(error.message);
           res.send('failure');
         },
       }
-      
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret, installationStore, stateStore: fakeStateStore, authVersion: 'v1'});
+
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, stateStore: fakeStateStore, authVersion: 'v1' });
       const fakeState = 'fakeState';
       const fakeCode = 'fakeCode';
       const req = { url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
@@ -459,31 +461,115 @@ describe('OAuth', async () => {
 
   describe('MemoryInstallationStore', async () => {
     it('should store and fetch an installation', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret});
+      const installationStore = new MemoryInstallationStore();
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
       const fakeTeamId = storedInstallation.team.id;
+
       assert.deepEqual({}, installer.installationStore.devDB);
+
       await installer.installationStore.storeInstallation(storedInstallation);
-      const fetchedResult = await installer.installationStore.fetchInstallation({teamId:fakeTeamId});
+      const fetchedResult = await installer.installationStore.fetchInstallation({ teamId: fakeTeamId });
       assert.deepEqual(fetchedResult, storedInstallation);
       assert.deepEqual(storedInstallation, installer.installationStore.devDB[fakeTeamId]);
     });
 
     it('should delete a stored installation', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret});
+      const installationStore = new MemoryInstallationStore();
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
       const fakeTeamId = storedInstallation.team.id;
 
       await installer.installationStore.storeInstallation(storedInstallation);
       assert.isNotEmpty(installer.installationStore.devDB);
-      
-      await installer.installationStore.deleteInstallation({ teamId:fakeTeamId }); 
+
+      await installer.installationStore.deleteInstallation({ teamId: fakeTeamId });
       assert.isEmpty(installer.installationStore.devDB);
+    });
+  });
+
+  describe('FileInstallationStore', async () => {
+    let fsMakeDir, fsWriteFile, fsReadFileSync, unlink;
+
+    beforeEach(() => {
+      fsMakeDir = sinon.stub(fs, 'mkdir').returns({});
+      fsWriteFile = sinon.stub(fs, 'writeFile').returns({});
+      fsReadFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from(JSON.stringify(storedInstallation)));
+      fsUnlink = sinon.stub(fs, 'unlink').returns({});
+      fsReaddirSync = sinon.stub(fs, 'readdirSync').returns([]);
+    });
+
+    afterEach(() => {
+      fsMakeDir.restore();
+      fsWriteFile.restore();
+      fsReadFileSync.restore();
+      fsUnlink.restore();
+      fsReaddirSync.restore();
+    });
+
+    it('should store the latest installation', async () => {
+      const installationStore = new FileInstallationStore({ baseDir: '.' });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
+      const { enterprise, team, user } = storedInstallation;
+      const fakeInstallDir = `./${enterprise.id}-${team.id}`;
+      const installationJSON = JSON.stringify(storedInstallation);
+
+      installer.installationStore.storeInstallation(storedInstallation);
+      assert.equal(fsWriteFile.calledWith(`${fakeInstallDir}/app-latest`, installationJSON), true);
+      assert.equal(fsWriteFile.calledWith(sinon.match(`${fakeInstallDir}/user-${user.id}-latest`), installationJSON), true);
+    });
+
+    it('should store additional records for each installation with historicalDataEnabled', async () => {
+      const installationStore = new FileInstallationStore({ baseDir: '.', historicalDataEnabled: true });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
+      const { enterprise, team, user } = storedInstallation;
+      const fakeInstallDir = `./${enterprise.id}-${team.id}`;
+      const installationJSON = JSON.stringify(storedInstallation);
+
+      installer.installationStore.storeInstallation(storedInstallation);
+
+      assert.equal(fsWriteFile.calledWith(sinon.match(`${fakeInstallDir}/app-`), installationJSON), true);
+      assert.equal(fsWriteFile.calledWith(sinon.match(`${fakeInstallDir}/user-${user.id}-`), installationJSON), true);
+
+      // 1 store = 4 files = 2 latest + 2 timestamps
+      expect(fsWriteFile.callCount).equals(4);
+    });
+
+    it('should fetch a stored installation', async () => {
+      const installationStore = new FileInstallationStore({ baseDir: '.' });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
+      const { enterprise, team, user } = storedInstallation;
+      const fakeInstallDir = `/${enterprise.id}-${team.id}`;
+      const query = { enterpriseId: enterprise.id, teamId: team.id };
+
+      installer.installationStore.storeInstallation(storedInstallation);
+      const installation = await installer.installationStore.fetchInstallation(query);
+
+      assert.equal(fsReadFileSync.calledWith(sinon.match(`${fakeInstallDir}/app-latest`)), true);
+      assert.deepEqual(installation, storedInstallation);
+    });
+
+    it('should delete a stored installation', async () => {
+      const installationStore = new FileInstallationStore({ baseDir: '.' });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore });
+      const { enterprise, team } = storedInstallation;
+      const fakeInstallDir = `/${enterprise.id}-${team.id}`;
+      const query = { enterpriseId: enterprise.id, teamId: team.id };
+
+      installer.installationStore.storeInstallation(storedInstallation);
+      installer.installationStore.storeInstallation(storedInstallation);
+      installer.installationStore.storeInstallation(storedInstallation);
+      await installer.installationStore.deleteInstallation(query);
+
+      assert.equal(fsUnlink.calledWith(sinon.match(`${fakeInstallDir}/app-latest`)), true);
+
+      // 1 store = 4 files = 2 latest + 2 timestamps
+      expect(fsWriteFile.callCount).equals(12);
     });
   });
 
   describe('ClearStateStore', async () => {
     it('should generate a state and return install options once verified', async () => {
-      const installer = new InstallProvider({clientId, clientSecret, stateSecret});
-      const installUrlOptions = { scopes: [ 'channels:read' ] };
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret });
+      const installUrlOptions = { scopes: ['channels:read'] };
       const state = await installer.stateStore.generateStateParam(installUrlOptions, new Date());
       const returnedInstallUrlOptions = await installer.stateStore.verifyStateParam(new Date(), state);
       assert.deepEqual(installUrlOptions, returnedInstallUrlOptions);

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from './errors';
 import { parse as parseUrl, URLSearchParams, URL } from 'url';
 import { Logger, LogLevel, getLogger } from './logger';
+import { MemoryInstallationStore } from './stores';
 
 /**
  * InstallProvider Class.
@@ -455,93 +456,9 @@ export interface InstallationStore {
     installation: Installation<AuthVersion, boolean>,
     logger?: Logger): Promise<void>;
   fetchInstallation:
-    (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
+  (query: InstallationQuery<boolean>, logger?: Logger) => Promise<Installation<'v1' | 'v2', boolean>>;
   deleteInstallation:
-    (query: InstallationQuery<boolean>, logger?: Logger) => Promise<void>;
-}
-
-// using a javascript object as a makeshift database for development
-// storing user tokens is not supported
-interface DevDatabase {
-  [teamIdOrEnterpriseId: string]: Installation;
-}
-
-// Default Install Store. Should only be used for development
-class MemoryInstallationStore implements InstallationStore {
-  public devDB: DevDatabase = {};
-
-  public async storeInstallation(installation: Installation, logger?: Logger): Promise<void> {
-    // NOTE: installations on a single workspace that happen to be within an enterprise organization are stored by
-    // the team ID as the key
-    // TODO: what about installations on an enterprise (acting as a single workspace) with `admin` scope, which is not
-    // an org install?
-    if (logger !== undefined) {
-      logger.warn('Storing Access Token. Please use a real Installation Store for production!');
-    }
-
-    if (isOrgInstall(installation)) {
-      if (logger !== undefined) {
-        logger.debug('storing org installation');
-      }
-      this.devDB[installation.enterprise.id] = installation;
-    } else if (isNotOrgInstall(installation)) {
-      if (logger !== undefined) {
-        logger.debug('storing single team installation');
-      }
-      this.devDB[installation.team.id] = installation;
-    } else {
-      throw new Error('Failed saving installation data to installationStore');
-    }
-  }
-
-  public async fetchInstallation(
-    query: InstallationQuery<boolean>,
-    logger?: Logger): Promise<Installation<'v1' | 'v2'>> {
-    if (logger !== undefined) {
-      logger.warn('Retrieving Access Token from DB. Please use a real Installation Store for production!');
-    }
-    if (query.isEnterpriseInstall) {
-      if (query.enterpriseId !== undefined) {
-        if (logger !== undefined) {
-          logger.debug('fetching org installation');
-        }
-        return this.devDB[query.enterpriseId] as OrgInstallation;
-      }
-    }
-    if (query.teamId !== undefined) {
-      if (logger !== undefined) {
-        logger.debug('fetching single team installation');
-      }
-      return this.devDB[query.teamId] as Installation<'v1' | 'v2', false>;
-    }
-    throw new Error('Failed fetching installation');
-  }
-
-  public async deleteInstallation(query: InstallationQuery<boolean>, logger?: Logger): Promise<void> {
-    if (logger !== undefined) {
-      logger.warn('Deleting Access Token from DB. Please use a real Installation Store for production!');
-    }
-
-    if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
-      if (logger !== undefined) {
-        logger.debug('deleting org installation');
-      }
-
-      const { [query.enterpriseId]: _, ...devDB } = this.devDB;
-      this.devDB = devDB;
-
-    } else if (query.teamId !== undefined) {
-      if (logger !== undefined) {
-        logger.debug('deleting single team installation');
-      }
-
-      const { [query.teamId]: _, ...devDB } = this.devDB;
-      this.devDB = devDB;
-
-    } else {
-      throw new Error('Failed to delete installation');
-    }
-  }
+  (query: InstallationQuery<boolean>, logger?: Logger) => Promise<void>;
 }
 
 /**
@@ -782,3 +699,4 @@ interface AuthTestResult extends WebAPICallResult {
 }
 
 export { Logger, LogLevel } from './logger';
+export { MemoryInstallationStore, FileInstallationStore } from './stores';

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -699,4 +699,4 @@ interface AuthTestResult extends WebAPICallResult {
 }
 
 export { Logger, LogLevel } from './logger';
-export { MemoryInstallationStore, FileInstallationStore } from './stores';
+export * from './stores';

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -1,0 +1,116 @@
+import { Installation, InstallationStore, InstallationQuery } from '../index';
+import { Logger } from '../logger';
+import fs from 'fs';
+import path from 'path';
+import { homedir } from 'os';
+
+export interface FileInstallationOptions {
+  baseDir?: string;
+  historicalDataEnabled?: boolean;
+  clientId?: string;
+}
+
+export class FileInstallationStore implements InstallationStore {
+
+  private baseDir: string;
+  private historicalDataEnabled: boolean;
+
+  constructor({
+    baseDir = `${homedir()}/.bolt-app-installation`,
+    clientId,
+    historicalDataEnabled = true,
+  }: FileInstallationOptions = {}) {
+    this.baseDir = clientId !== undefined ? `${baseDir}/${clientId}` : baseDir;
+    this.historicalDataEnabled = historicalDataEnabled;
+  }
+
+  public async storeInstallation(installation: Installation, logger?: Logger): Promise<void> {
+    const { enterprise, team, user } = installation;
+    const installationData = JSON.stringify(installation);
+    const installationDir = this.getInstallationDir(enterprise?.id, team?.id);
+
+    if (logger !== undefined) { logger.warn('Storing installation in FileInstallationStore'); }
+
+    // Create Installation Directory
+    fs.mkdir(installationDir, { recursive: true }, (err) => {
+      if (err !== null) { return console.error(err); }
+    });
+
+    try {
+      writeToFile(`${installationDir}/app-latest`, installationData);
+      writeToFile(`${installationDir}/user-${user.id}-latest`, installationData);
+
+      if (this.historicalDataEnabled) {
+        const currentUTC = Date.now();
+        writeToFile(`${installationDir}/app-${currentUTC}`, installationData);
+        writeToFile(`${installationDir}/user-${user.id}-${currentUTC}`, installationData);
+      }
+    } catch (err) {
+      throw new Error('Failed to save installation to FileInstallationStore');
+    }
+  }
+
+  public async fetchInstallation(query: InstallationQuery<boolean>, logger?: Logger): Promise<Installation> {
+    const { enterpriseId, teamId } = query;
+    const installationDir = this.getInstallationDir(enterpriseId, teamId);
+
+    if (logger !== undefined) { logger.warn('Retrieving installation from FileInstallationStore'); }
+
+    try {
+      const data = fs.readFileSync(path.resolve(`${installationDir}/app-latest`));
+      const installation: Installation = JSON.parse(data.toString());
+      return installation;
+    } catch (err) {
+      throw new Error('Failed to fetch data from FileInstallationStore');
+    }
+  }
+
+  public async deleteInstallation(query: InstallationQuery<boolean>, logger?: Logger): Promise<void> {
+    const { enterpriseId, teamId, userId } = query;
+    const installationDir = this.getInstallationDir(enterpriseId, teamId);
+
+    if (logger !== undefined) { logger.warn('Deleting installation from FileInstallationStore'); }
+
+    let filesToDelete: string[] = ['app-latest'];
+
+    const appFiles = fs.readdirSync(installationDir).filter(file => file.includes('app-'));
+    filesToDelete = filesToDelete.concat(appFiles);
+
+    if (userId !== undefined) {
+      const userFiles = fs.readdirSync(installationDir).filter(file => file.includes(`user-${userId}-`));
+      filesToDelete = filesToDelete.concat(userFiles);
+    }
+
+    try {
+      filesToDelete.map(filePath => deleteFile(path.resolve(`${installationDir}/${filePath}`)));
+    } catch (err) {
+      throw new Error('Failed to delete installation from FileInstallationStore');
+    }
+  }
+
+  private getInstallationDir(enterpriseId = '', teamId = ''): string {
+    let installDir = `${this.baseDir}/${enterpriseId}`;
+
+    if (teamId !== '') {
+      installDir += (enterpriseId !== '') ? `-${teamId}` : `${teamId}`;
+    }
+
+    return installDir;
+  }
+}
+
+function writeToFile(filePath: string, data: string): void {
+  fs.writeFile(filePath, data, (err) => {
+    if (err !== null) {
+      throw new Error('There was an error writing to the InstallationStore');
+    }
+  });
+}
+
+function deleteFile(filePath: string): void {
+  fs.unlink(path.resolve(filePath), (err) => {
+    if (err !== null) {
+      throw new Error('Failed to delete installation from FileInstallationStore');
+    }
+  });
+}

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -16,7 +16,7 @@ export class FileInstallationStore implements InstallationStore {
   private historicalDataEnabled: boolean;
 
   constructor({
-    baseDir = `${homedir()}/.bolt-app-installation`,
+    baseDir = `${homedir()}/.bolt-js-app-installation`,
     clientId,
     historicalDataEnabled = true,
   }: FileInstallationOptions = {}) {

--- a/packages/oauth/src/stores/index.ts
+++ b/packages/oauth/src/stores/index.ts
@@ -1,0 +1,2 @@
+export { MemoryInstallationStore } from './memory-store';
+export { FileInstallationStore } from './file-store';

--- a/packages/oauth/src/stores/memory-store.ts
+++ b/packages/oauth/src/stores/memory-store.ts
@@ -1,0 +1,88 @@
+import { Installation, InstallationStore, InstallationQuery, OrgInstallation } from '../index';
+import { Logger } from '../logger';
+
+// using a javascript object as a makeshift database for development
+// storing user tokens is not supported
+interface DevDatabase {
+  [teamIdOrEnterpriseId: string]: Installation;
+}
+
+// Default Install Store. Should only be used for development
+export class MemoryInstallationStore implements InstallationStore {
+  public devDB: DevDatabase = {};
+
+  public async storeInstallation(installation: Installation, logger?: Logger): Promise<void> {
+    // NOTE: installations on a single workspace that happen to be within an enterprise organization are stored by
+    // the team ID as the key
+    // TODO: what about installations on an enterprise (acting as a single workspace) with `admin` scope, which is not
+    // an org install?
+    if (logger !== undefined) {
+      logger.warn('Storing Access Token. Please use a real Installation Store for production!');
+    }
+
+    if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('storing org installation');
+      }
+      this.devDB[installation.enterprise.id] = installation;
+    } else if (!installation.isEnterpriseInstall && installation.team !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('storing single team installation');
+      }
+      this.devDB[installation.team.id] = installation;
+    } else {
+      throw new Error('Failed saving installation data to installationStore');
+    }
+  }
+
+  public async fetchInstallation(
+    query: InstallationQuery<boolean>,
+    logger?: Logger): Promise<Installation<'v1' | 'v2'>> {
+    if (logger !== undefined) {
+      logger.warn('Retrieving Access Token from DB. Please use a real Installation Store for production!');
+    }
+    if (query.isEnterpriseInstall) {
+      if (query.enterpriseId !== undefined) {
+        if (logger !== undefined) {
+          logger.debug('fetching org installation');
+        }
+        return this.devDB[query.enterpriseId] as OrgInstallation;
+      }
+    }
+    if (query.teamId !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('fetching single team installation');
+      }
+      return this.devDB[query.teamId] as Installation<'v1' | 'v2', false>;
+    }
+    throw new Error('Failed fetching installation');
+  }
+
+  public async deleteInstallation(query: InstallationQuery<boolean>, logger?: Logger): Promise<void> {
+    if (logger !== undefined) {
+      logger.warn('Deleting Access Token from DB. Please use a real Installation Store for production!');
+    }
+
+    if (query.isEnterpriseInstall && query.enterpriseId !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('deleting org installation');
+      }
+
+      // Separate out installation from rest of database
+      const { [query.enterpriseId]: _, ...devDB } = this.devDB;
+      this.devDB = devDB;
+
+    } else if (query.teamId !== undefined) {
+      if (logger !== undefined) {
+        logger.debug('deleting single team installation');
+      }
+
+      // Separate out installation from rest of database
+      const { [query.teamId]: _, ...devDB } = this.devDB;
+      this.devDB = devDB;
+
+    } else {
+      throw new Error('Failed to delete installation');
+    }
+  }
+}


### PR DESCRIPTION
###  Summary

Fixes #1278:

> Currently, the default (and only) InstallationStore made available to developers out of the box is the MemoryInstallationStore. This store isn't ideal for all development scenarios, as data is stored in memory and thus cleared out when the server is restarted.
>
> We should introduce a FileInstallationStore, reasonably following the existing pattern(s) found on the Python and Java SDK side of things.

___

#### Exportability for Choice
Though `MemoryInstallationStore` remains the default if not otherwise specified, to allow developers the choice between using `MemoryInstallationStore` and `FileInstallationStore`, both are now exported for direct use in their projects (set to the `installationStore` constructor option):

```
const { InstallProvider, MemoryInstallationStore, FileInstallationStore } = require('@slack/oauth');

const installer = new InstallProvider({
  clientId: process.env.SLACK_CLIENT_ID,
  clientSecret: process.env.SLACK_CLIENT_SECRET,
  authVersion: 'v2',
  stateSecret: 'my-state-secret',
  // installationStore: new MemoryInstallationStore(),
  installationStore: new FileInstallationStore({ baseDir: '.', historicalDataEnabled: false }),
});
```

Options include: `baseDir`, `clientId`, and `historicalDataEnabled`. Developers can go with the defaults, or override to suit their needs.

#### Installation Directory + File Pattern
For the most part, implementation has stayed true to what is found in Python, but some differences are detailed below:
1. The `enterprise_id` and `team_id` are used to create the installation directory. If both present, the pattern is `enterprise_id-team_id`. If only one of the two are present, _only_ that ID is used for the directory. This differs slightly from Python's use of `none` in the directory name if one is not passed.
2. When `storeInstallation` is called, if `historicalDataEnabled` is enabled (which it is by default), 4 records will be created: an `app-latest`, `user-[user_id]-latest`, `app-[currentUTC]` and `user-[user_id]-[currentUTC]`. Every subsequent install will overwrite the data in latest and save two additional `currentUTC` records. If set to `false` by the developer, only `*-latest` records will be saved.

 > ![Screen Shot 2021-06-30 at 6 40 03 PM](https://user-images.githubusercontent.com/7788242/124202550-6d11e580-da8f-11eb-885c-1f8563d144f9.png)

3. Python goes a step further by saving the same information into both `installer-latest` / `installer-[currentUTC]` _and_ the `user-[user_id]-*` records. I omitted the former records because it wasn't clear to me how the duplication was value-adding, but am open to introducing it if folks feel it's important or if I've misunderstood its purpose.
4. Python also makes use of a `to_bot()` method to shape the data prior to writing it to file, but for a similar reason to the above, I forwent that. Also equally happy to introduce it if it's the better (or necessary) approach.

**Directory/File Restructuring**
1. **New `/stores` directory.**  Since we now have two stores, I've pulled out the `MemoryInstallationStore` class into a `stores` directory, alongside the new `FileInstallationStore`. These two are then made available in a dedicated `index.js` so that the `import` is cleaner (both importable directly from `/stores`).

> ![Screen Shot 2021-07-01 at 5 12 57 PM](https://user-images.githubusercontent.com/7788242/124202630-9af72a00-da8f-11eb-9610-c0afc3098c67.png)

> ![Screen Shot 2021-07-01 at 5 14 01 PM](https://user-images.githubusercontent.com/7788242/124202689-be21d980-da8f-11eb-882b-93896cd9c937.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
