### PR TITLE
Make FileStoreInstallation installation directory creation synchronous

### DIFF
--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -35,9 +35,7 @@ export class FileInstallationStore implements InstallationStore {
     }
 
     // Create Installation Directory
-    fs.mkdir(installationDir, { recursive: true }, (err) => {
-      if (err !== null) { return console.error(err); }
-    });
+    fs.mkdirSync(installationDir, { recursive: true });
 
     try {
       writeToFile(`${installationDir}/app-latest`, installationData);


### PR DESCRIPTION
###  Summary

Fixes issue with error occurring on initial creation of installation directory with `FileInstallationStore` due to asynchronous nature.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
