### PR TITLE
Fix #1214 by adding more info in the ratelimited error exception message

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -344,11 +344,11 @@ export class WebClient extends Methods {
             await delay(retrySec * 1000);
             // resume the request queue and throw a non-abort error to signal a retry
             this.requestQueue.start();
-            // NOTE: we may want to have more detailed info such as team_id, params except tokens, and so on.
+            // TODO: We may want to have more detailed info such as team_id, params except tokens, and so on.
             throw Error(`A rate limit was exceeded (url: ${url}, retry-after: ${retrySec})`);
           } else {
             // TODO: turn this into some CodedError
-            throw new AbortError(new Error('Retry header did not contain a valid timeout.'));
+            throw new AbortError(new Error(`Retry header did not contain a valid timeout (url: ${url})`));
           }
         }
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -344,7 +344,8 @@ export class WebClient extends Methods {
             await delay(retrySec * 1000);
             // resume the request queue and throw a non-abort error to signal a retry
             this.requestQueue.start();
-            throw Error('A rate limit was exceeded.');
+            // NOTE: we may want to have more detailed info such as team_id, params except tokens, and so on.
+            throw Error(`A rate limit was exceeded (url: ${url}, retry-after: ${retrySec})`);
           } else {
             // TODO: turn this into some CodedError
             throw new AbortError(new Error('Retry header did not contain a valid timeout.'));


### PR DESCRIPTION
###  Summary

This pull request fixes #1214 by updating the Error thrown in the case where the WebClient receives a ratelimited error rom the server-side.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
