### PR TITLE
Publish

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/types",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Shared type definitions for the Node Slack SDK",
   "author": "Slack Technologies, Inc.",
   "license": "MIT",


### PR DESCRIPTION
- @slack/web-api@6.4.0
- @slack/types@2.2.0

###  Summary

- web-api@6.4.0 was bumped separately from this PR, but the release wasn't completed. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
