### PR TITLE
Add type for thumb_360_gif file property

### DIFF
--- a/packages/web-api/src/response/FilesInfoResponse.ts
+++ b/packages/web-api/src/response/FilesInfoResponse.ts
@@ -63,9 +63,10 @@ export interface File {
   thumb_64?:             string;
   thumb_80?:             string;
   thumb_360?:            string;
+  thumb_160?:            string;
   thumb_360_w?:          number;
   thumb_360_h?:          number;
-  thumb_160?:            string;
+  thumb_360_gif?:        string;
   original_w?:           number;
   original_h?:           number;
   thumb_tiny?:           string;

--- a/packages/web-api/src/response/FilesListResponse.ts
+++ b/packages/web-api/src/response/FilesListResponse.ts
@@ -31,19 +31,27 @@ export interface File {
   url_private?:          string;
   thumb_64?:             string;
   thumb_80?:             string;
+  thumb_160?:            string;
   thumb_360?:            string;
   thumb_360_w?:          number;
   thumb_360_h?:          number;
   thumb_480?:            string;
   thumb_480_w?:          number;
   thumb_480_h?:          number;
-  thumb_160?:            string;
   thumb_720?:            string;
   thumb_720_w?:          number;
   thumb_720_h?:          number;
   thumb_800?:            string;
   thumb_800_w?:          number;
   thumb_800_h?:          number;
+  thumb_960?:            string;
+  thumb_960_w?:          number;
+  thumb_960_h?:          number;
+  thumb_1024?:           string;
+  thumb_1024_w?:         number;
+  thumb_1024_h?:         number;
+  thumb_video?:          string;
+  thumb_360_gif?:        string;
   original_w?:           number;
   original_h?:           number;
   thumb_tiny?:           string;
@@ -61,13 +69,6 @@ export interface File {
   lines?:                number;
   lines_more?:           number;
   preview_is_truncated?: boolean;
-  thumb_960?:            string;
-  thumb_960_w?:          number;
-  thumb_960_h?:          number;
-  thumb_1024?:           string;
-  thumb_1024_w?:         number;
-  thumb_1024_h?:         number;
-  thumb_video?:          string;
   media_display_type?:   string;
 }
 


### PR DESCRIPTION
###  Summary

Add missing type for `thumb_360_gif`. This type is described here https://api.slack.com/types/file#thumbnails.
Also, I've ordered thumb types alphabetically.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
