### PR TITLE
Add more event data to event listener arguments; fix #1205 too

### DIFF
--- a/packages/socket-mode/.mocharc.json
+++ b/packages/socket-mode/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": ["ts-node/register", "source-map-support/register"],
+  "timeout": 3000
+}

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -40,7 +40,7 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist",
     "lint": "tslint --project .",
-    "test": "npm run build && echo \"Tests are not implemented.\" && exit 0",
+    "test": "npm run build && nyc mocha --config .mocharc.json src/*.spec.js",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
@@ -56,7 +56,15 @@
     "ws": "^7.3.1"
   },
   "devDependencies": {
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.6",
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.1",
     "shx": "^0.3.2",
+    "ts-node": "^8.2.0",
+    "sinon": "^7.3.2",
+    "source-map-support": "^0.5.12",
     "tslint": "^5.13.1",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^4.1.0"

--- a/packages/socket-mode/src/SocketModeClient.spec.js
+++ b/packages/socket-mode/src/SocketModeClient.spec.js
@@ -1,0 +1,184 @@
+const { assert } = require('chai');
+const { SocketModeClient } = require('./SocketModeClient');
+
+describe('SocketModeClient', () => {
+  describe('onWebsocketMessage', () => {
+    beforeEach(() => {
+    });
+
+    afterEach(() => {
+    });
+
+    describe('slash_commands messages', () => {
+      it('should be sent to two listeners', async () => {
+        const message = {
+          "envelope_id": "1d3c79ab-0ffb-41f3-a080-d19e85f53649",
+          "payload": {
+            "token": "verification-token",
+            "team_id": "T111",
+            "team_domain": "xxx",
+            "channel_id": "C111",
+            "channel_name": "random",
+            "user_id": "U111",
+            "user_name": "seratch",
+            "command": "/hello-socket-mode",
+            "text": "",
+            "api_app_id": "A111",
+            "response_url": "https://hooks.slack.com/commands/T111/111/xxx",
+            "trigger_id": "111.222.xxx"
+          },
+          "type": "slash_commands",
+          "accepts_response_payload": true
+        };
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let commandListenerCalled = false;
+        client.on("slash_commands", async (args) => {
+          commandListenerCalled = args.ack !== undefined && args.body !== undefined;
+        });
+        let slackEventListenerCalled = false;
+        client.on("slack_event", async (args) => {
+          slackEventListenerCalled = args.ack !== undefined && args.body !== undefined
+            && args.type === 'slash_commands'
+            && args.retry_num === undefined
+            && args.retry_reason === undefined;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.isTrue(commandListenerCalled);
+        assert.isTrue(slackEventListenerCalled);
+      });
+    });
+
+    describe('events_api messages', () => {
+      it('should be sent to two listeners', async () => {
+        const message = {
+          "envelope_id": "cda4159a-72a5-4744-aba3-4d66eb52682b",
+          "payload": {
+            "token": "verification-token",
+            "team_id": "T111",
+            "api_app_id": "A111",
+            "event": {
+              "client_msg_id": "f0582a78-72db-4feb-b2f3-1e47d66365c8",
+              "type": "app_mention",
+              "text": "<@U111>",
+              "user": "U222",
+              "ts": "1610241741.000200",
+              "team": "T111",
+              "blocks": [
+                {
+                  "type": "rich_text",
+                  "block_id": "Sesm",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "user",
+                          "user_id": "U111"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "channel": "C111",
+              "event_ts": "1610241741.000200"
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1610241741,
+            "authorizations": [
+              {
+                "enterprise_id": null,
+                "team_id": "T111",
+                "user_id": "U222",
+                "is_bot": true,
+                "is_enterprise_install": false
+              }
+            ],
+            "is_ext_shared_channel": false,
+            "event_context": "1-app_mention-T111-C111"
+          },
+          "type": "events_api",
+          "accepts_response_payload": false,
+          "retry_attempt": 2,
+          "retry_reason": "timeout"
+        };
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let otherListenerCalled = false;
+        client.on("app_home_opend", async () => {
+          otherListenerCalled = true;
+        });
+        let eventsApiListenerCalled = false;
+        client.on("app_mention", async (args) => {
+          eventsApiListenerCalled = args.ack !== undefined
+            && args.body !== undefined
+            && args.retry_num === 2
+            && args.retry_reason === 'timeout';
+        });
+        let slackEventListenerCalled = false;
+        client.on("slack_event", async (args) => {
+          slackEventListenerCalled = args.ack !== undefined && args.body !== undefined
+            && args.retry_num === 2
+            && args.retry_reason === 'timeout';
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.isFalse(otherListenerCalled);
+        assert.isTrue(eventsApiListenerCalled);
+        assert.isTrue(slackEventListenerCalled);
+      });
+    });
+
+    describe('interactivity messages', () => {
+      it('should be sent to two listeners', async () => {
+        const message = {
+          "envelope_id": "57d6a792-4d35-4d0b-b6aa-3361493e1caf",
+          "payload": {
+            "type": "shortcut",
+            "token": "verification-token",
+            "action_ts": "1610198080.300836",
+            "team": {
+              "id": "T111",
+              "domain": "seratch"
+            },
+            "user": {
+              "id": "U111",
+              "username": "seratch",
+              "team_id": "T111"
+            },
+            "is_enterprise_install": false,
+            "enterprise": null,
+            "callback_id": "do-something",
+            "trigger_id": "111.222.xxx"
+          },
+          "type": "interactive",
+          "accepts_response_payload": false
+        }
+          ;
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let otherListenerCalled = false;
+        client.on("slash_commands", async () => {
+          otherListenerCalled = true;
+        });
+        let interactiveListenerCalled = false;
+        client.on("interactive", async (args) => {
+          interactiveListenerCalled = args.ack !== undefined && args.body !== undefined;
+        });
+        let slackEventListenerCalled = false;
+        client.on("slack_event", async (args) => {
+          slackEventListenerCalled = args.ack !== undefined && args.body !== undefined;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.isFalse(otherListenerCalled);
+        assert.isTrue(interactiveListenerCalled);
+        assert.isTrue(slackEventListenerCalled);
+      });
+    });
+  });
+});
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/prod-server-integration-tests/scripts/socket-mode.js
+++ b/prod-server-integration-tests/scripts/socket-mode.js
@@ -1,6 +1,28 @@
 const { SocketModeClient } = require('@slack/socket-mode');
 const appToken = process.env.SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN;
 const socketModeClient = new SocketModeClient({ appToken, logLevel: 'debug' });
+
+// events_api's event.type
+socketModeClient.on('app_mention', async (args) => {
+  console.log(args);
+  await args.ack();
+});
+// interactivity: block_actions etc.
+socketModeClient.on('interactive', async (args) => {
+  console.log(args);
+  await args.ack();
+});
+// slash command invocations
+socketModeClient.on('slash_commands', async (args) => {
+  console.log(args);
+  await args.ack();
+});
+// events sent to bolt-js
+socketModeClient.on('slack_event', async (args) => {
+  console.log(args);
+  await args.ack();
+});
+
 (async () => {
   await socketModeClient.start();
 })();


### PR DESCRIPTION
###  Summary

This pull request adds more properties to the event listener arguments. The main motivation is to add retry num & retry reason to bolt-js's `ReceiverEvent` data as part of https://github.com/slackapi/bolt-js/issues/759

This pull request fixes #1205 as it adds the first-ever unit tests to socket-mode package project.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
