### PR TITLE
Fix #1302 Invalid JSON string causing "Cannot create property 'response_metadata' on string" error

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -607,7 +607,7 @@ describe('WebClient', function () {
       });
     });
 
-    describe('with string respnse body for some reason', function () {
+    describe('with string response body for some reason', function () {
       it('should try to parse the body', function () {
         const scope = nock('https://slack.com')
           .post(/api/)

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -462,7 +462,17 @@ export class WebClient extends Methods {
    * @param response - an http response
    */
   private buildResult(response: AxiosResponse): WebAPICallResult {
-    const data = response.data;
+    let data = response.data;
+
+    if (typeof data === 'string') {
+      // response.data can be a string, not an object for some reason
+      try {
+        data = JSON.parse(data);
+      } catch (_) {
+        // failed to parse the string value as JSON data
+        data = { ok: false, error: data};
+      }
+    }
 
     if (data.response_metadata === undefined) {
       data.response_metadata = {};

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -470,7 +470,7 @@ export class WebClient extends Methods {
         data = JSON.parse(data);
       } catch (_) {
         // failed to parse the string value as JSON data
-        data = { ok: false, error: data};
+        data = {ok: false, error: data};
       }
     }
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -470,7 +470,7 @@ export class WebClient extends Methods {
         data = JSON.parse(data);
       } catch (_) {
         // failed to parse the string value as JSON data
-        data = {ok: false, error: data};
+        data = { ok: false, error: data };
       }
     }
 


### PR DESCRIPTION
###  Summary

This pull request fixes #1302. Refer to the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
