### PR TITLE
Fix #1251 Upgrade the minimum version of "ws" package

### DIFF
--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -46,12 +46,12 @@
     "@slack/web-api": "^5.3.0",
     "@types/node": ">=12.0.0",
     "@types/p-queue": "^2.3.2",
-    "@types/ws": "^7.2.5",
+    "@types/ws": "^7.4.7",
     "eventemitter3": "^3.1.0",
     "finity": "^0.5.4",
     "p-cancelable": "^1.1.0",
     "p-queue": "^2.4.2",
-    "ws": "^5.2.0"
+    "ws": "^7.5.3"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.4",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -48,12 +48,12 @@
     "@slack/web-api": "^6.2.3",
     "@types/node": ">=12.0.0",
     "@types/p-queue": "^2.3.2",
-    "@types/ws": "^7.2.5",
+    "@types/ws": "^7.4.7",
     "eventemitter3": "^3.1.0",
     "finity": "^0.5.4",
     "p-cancelable": "^1.1.0",
     "p-queue": "^2.4.2",
-    "ws": "^7.3.1"
+    "ws": "^7.5.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
###  Summary

This pull request fixes #1251 by upgrading the minimum version of "ws" package in socket-mode / rtm-api packages. 

* https://github.com/websockets/ws/releases
* https://www.npmjs.com/package/ws

As you can see in the GitHub release page, a number of bug fixes have been applied in ws@7 series. As most of Socket Mode clients won't have version conflict issues on "ws" package with other parts of those apps, encouraging developers to use the latest patch version should be just safe enough. 

"ws" project recently released a new major version v8 (the latest minor is v8.2). We haven't received any reports about the compatibility. Just in case, I did some tests with ws@8 today but didn't detect any issues so far. For this reason, I think that we don't need to limit the upper to v7.x so far.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
