### PR TITLE
Add optional InstallProvider#stateValidation flag

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -290,9 +290,9 @@ const installer = new InstallProvider({
 
 ### State validation
 
-By default, this package handles generating and validating a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [CSRF attacks](https://auth0.com/docs/configure/attack-protection/state-parameters#csrf-attacks) and is strongly recommended. 
+By default, this package handles generating and validating a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
 
-In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state validation cannot be completed. In this case, you can disable validation via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. It will attempt to validate `state` only if it is provided in the request url parameters. 
+In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state validation cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` validation via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to validate `state` only if it is provided in the request url parameters. 
 
 ```javascript
 const installer = new InstallProvider({
@@ -303,6 +303,8 @@ const installer = new InstallProvider({
   },
 });
 ```
+
+Please note that while setting `stateValidation` false will allow installation to proceed when the `state` query parameter isn't provided, any metadata you provide via installation URL options will not be available.
 ---
 
 

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -288,11 +288,11 @@ const installer = new InstallProvider({
 ```
 ---
 
-### State validation
+### State verification
 
 By default, this package handles generating and verifying a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
 
-In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to verify `state` only if it is provided in the request url parameters. 
+In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to verify `state` only if it is provided in the request url parameters. 
 
 ```javascript
 const installer = new InstallProvider({
@@ -304,7 +304,7 @@ const installer = new InstallProvider({
 });
 ```
 
-Please note that while setting `stateValidation` false will allow installation to proceed when the `state` query parameter isn't provided, any metadata you provide via installation URL options will not be available.
+Please note that while setting `stateVerification` false will allow installation to proceed when the `state` query parameter isn't provided, any metadata you provide via installation URL options will not be available.
 ---
 
 

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -288,6 +288,24 @@ const installer = new InstallProvider({
 ```
 ---
 
+### State validation
+
+By default, this package handles generating and validating a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [CSRF attacks](https://auth0.com/docs/configure/attack-protection/state-parameters#csrf-attacks) and is strongly recommended. 
+
+In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state validation cannot be completed. In this case, you can disable validation via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. It will attempt to validate `state` only if it is provided in the request url parameters. 
+
+```javascript
+const installer = new InstallProvider({
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: 'my-state-secret',
+  stateValidation: false,
+  },
+});
+```
+---
+
+
 ### Setting the log level and using a custom logger
 
 The `InstallProvider` will log interesting information to the console by default. You can use the `logLevel` to decide how

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -288,26 +288,6 @@ const installer = new InstallProvider({
 ```
 ---
 
-### State verification
-
-By default, this package handles generating and verifying a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
-
-In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to verify `state` only if it is provided in the request url parameters. 
-
-```javascript
-const installer = new InstallProvider({
-  clientId: process.env.SLACK_CLIENT_ID,
-  clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
-  stateVerification: false,
-  },
-});
-```
-
-Please note that while setting `stateVerification` false will allow installation to proceed when the `state` query parameter isn't provided, any metadata you provide via installation URL options will not be available.
----
-
-
 ### Setting the log level and using a custom logger
 
 The `InstallProvider` will log interesting information to the console by default. You can use the `logLevel` to decide how

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -254,7 +254,7 @@ const result = await installer.installationStore.fetchInstallation({teamId:'my-t
 
 ### Using a custom state store
 
-A state store handles generating the OAuth `state` parameter in the installation URL for a given set of options, and verifying the `state` in the OAuth callback and returning those same options.
+A state store handles generating the OAuth `state` parameter in the installation URL for a given set of options, and validating the `state` in the OAuth callback and returning those same options.
 
 The default state store, `ClearStateStore`, does not use any storage. Instead, it signs the options (using the `stateSecret`) and encodes them along with a signature into `state`. Later during the OAuth callback, it verifies the signature.
 
@@ -290,16 +290,16 @@ const installer = new InstallProvider({
 
 ### State validation
 
-By default, this package handles generating and validating a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
+By default, this package handles generating and verifying a `state` parameter during OAuth installation. The state parameter helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
 
-In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state validation cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` validation via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to validate `state` only if it is provided in the request url parameters. 
+In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateValidation` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. However, it will attempt to verify `state` only if it is provided in the request url parameters. 
 
 ```javascript
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: 'my-state-secret',
-  stateValidation: false,
+  stateVerification: false,
   },
 });
 ```

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -254,7 +254,7 @@ const result = await installer.installationStore.fetchInstallation({teamId:'my-t
 
 ### Using a custom state store
 
-A state store handles generating the OAuth `state` parameter in the installation URL for a given set of options, and validating the `state` in the OAuth callback and returning those same options.
+A state store handles generating the OAuth `state` parameter in the installation URL for a given set of options, and verifying the `state` in the OAuth callback and returning those same options.
 
 The default state store, `ClearStateStore`, does not use any storage. Instead, it signs the options (using the `stateSecret`) and encodes them along with a signature into `state`. Later during the OAuth callback, it verifies the signature.
 

--- a/packages/oauth/src/errors.ts
+++ b/packages/oauth/src/errors.ts
@@ -6,13 +6,13 @@ export interface CodedError extends Error {
  * A dictionary of codes for errors produced by this package.
  */
 export enum ErrorCode {
-    InstallerInitializationError = 'slack_oauth_installer_initialization_error',
-    AuthorizationError = 'slack_oauth_installer_authorization_error',
-    GenerateInstallUrlError = 'slack_oauth_generate_url_error',
-    MissingStateError = 'slack_oauth_missing_state',
-    MissingCodeError = 'slack_oauth_missing_code',
-    UnknownError = 'slack_oauth_unknown_error',
-  }
+  InstallerInitializationError = 'slack_oauth_installer_initialization_error',
+  AuthorizationError = 'slack_oauth_installer_authorization_error',
+  GenerateInstallUrlError = 'slack_oauth_generate_url_error',
+  MissingStateError = 'slack_oauth_missing_state',
+  MissingCodeError = 'slack_oauth_missing_code',
+  UnknownError = 'slack_oauth_unknown_error',
+}
 
 export class InstallerInitializationError extends Error implements CodedError {
   public code = ErrorCode.InstallerInitializationError;

--- a/packages/oauth/src/errors.ts
+++ b/packages/oauth/src/errors.ts
@@ -6,12 +6,13 @@ export interface CodedError extends Error {
  * A dictionary of codes for errors produced by this package.
  */
 export enum ErrorCode {
-  InstallerInitializationError = 'slack_oauth_installer_initialization_error',
-  AuthorizationError = 'slack_oauth_installer_authorization_error',
-  GenerateInstallUrlError = 'slack_oauth_generate_url_error',
-  MissingStateError = 'slack_oauth_missing_state',
-  UnknownError = 'slack_oauth_unknown_error',
-}
+    InstallerInitializationError = 'slack_oauth_installer_initialization_error',
+    AuthorizationError = 'slack_oauth_installer_authorization_error',
+    GenerateInstallUrlError = 'slack_oauth_generate_url_error',
+    MissingStateError = 'slack_oauth_missing_state',
+    MissingCodeError = 'slack_oauth_missing_code',
+    UnknownError = 'slack_oauth_unknown_error',
+  }
 
 export class InstallerInitializationError extends Error implements CodedError {
   public code = ErrorCode.InstallerInitializationError;
@@ -23,6 +24,10 @@ export class GenerateInstallUrlError extends Error implements CodedError {
 
 export class MissingStateError extends Error implements CodedError {
   public code = ErrorCode.MissingStateError;
+}
+
+export class MissingCodeError extends Error implements CodedError {
+  public code = ErrorCode.MissingCodeError;
 }
 
 export class UnknownError extends Error implements CodedError {

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -444,7 +444,6 @@ describe('OAuth', async () => {
         },
         failure: async (error, installOptions, req, res) => {
           assert.fail(error.message);
-          res.send('failure');
         },
       }
 

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -398,7 +398,7 @@ describe('OAuth', async () => {
     });
 
     it('should call the failure callback due to missing state query parameter on the URL', async () => {
-      const req = { url: 'http://example.com' };
+      const req = { url: 'http://example.com?code=1234' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
@@ -417,21 +417,19 @@ describe('OAuth', async () => {
       assert.isTrue(sent);
     });
 
-    it('should call the failure callback due to missing code query parameter on the URL', async () => {
-      const req = { url: 'http://example.com' };
+    it('should call the success callback when state query param is missing but stateValidation disabled', async () => {
+      const req = { url: 'http://example.com?code=1234' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
         success: async (installation, installOptions, req, res) => {
           res.send('successful!');
-          assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
-          assert.equal(error.code, ErrorCode.MissingStateError)
-          res.send('failure');
+          assert.fail('should have succeeded');
         },
       }
-      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, logger: noopLogger });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, stateValidation: false, installationStore, logger: noopLogger });
       await installer.handleCallback(req, res, callbackOptions);
 
       assert.isTrue(sent);

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -396,7 +396,25 @@ describe('OAuth', async () => {
         verifyStateParam: sinon.fake.resolves({})
       }
     });
+    it('should call the failure callback due to missing code query parameter on the URL', async () => {
+      const req = { headers: { host: 'example.com'},  url: 'http://example.com' };
+      let sent = false;
+      const res = { send: () => { sent = true; } };
+      const callbackOptions = {
+        success: async (installation, installOptions, req, res) => {
+          res.send('successful!');
+          assert.fail('should have failed');
+        },
+        failure: async (error, installOptions, req, res) => {
+          assert.equal(error.code, ErrorCode.MissingCodeError)
+          res.send('failure');
+        },
+      }
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, logger: noopLogger });
+      await installer.handleCallback(req, res, callbackOptions);
 
+      assert.isTrue(sent);
+    });
     it('should call the failure callback due to missing state query parameter on the URL', async () => {
       const req = { headers: { host: 'example.com'},  url: 'http://example.com?code=1234' };
       let sent = false;

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -398,7 +398,7 @@ describe('OAuth', async () => {
     });
 
     it('should call the failure callback due to missing state query parameter on the URL', async () => {
-      const req = { url: 'http://example.com?code=1234' };
+      const req = { headers: { host: 'example.com'},  url: 'http://example.com?code=1234' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
@@ -418,7 +418,7 @@ describe('OAuth', async () => {
     });
 
     it('should call the success callback when state query param is missing but stateVerification disabled', async () => {
-      const req = { url: 'http://example.com?code=1234' };
+      const req = { headers: { host: 'example.com'}, url: 'http://example.com?code=1234' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
@@ -436,7 +436,7 @@ describe('OAuth', async () => {
     });
 
     it('should call the failure callback if an access_denied error query parameter was returned on the URL', async () => {
-      const req = { url: 'http://example.com?error=access_denied' };
+      const req = { headers: { host: 'example.com'}, url: 'http://example.com?error=access_denied' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
@@ -470,7 +470,7 @@ describe('OAuth', async () => {
       const installer = new InstallProvider({ clientId, clientSecret, installationStore, stateStore: fakeStateStore });
       const fakeState = 'fakeState';
       const fakeCode = 'fakeCode';
-      const req = { url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
+      const req = { headers: { host: 'example.com'}, url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
       await installer.handleCallback(req, res, callbackOptions);
       assert.isTrue(sent);
       assert.equal(fakeStateStore.verifyStateParam.callCount, 1);
@@ -491,7 +491,7 @@ describe('OAuth', async () => {
       const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, stateStore: fakeStateStore, authVersion: 'v1' });
       const fakeState = 'fakeState';
       const fakeCode = 'fakeCode';
-      const req = { url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
+      const req = { headers: { host: 'example.com'}, url: `http://example.com?state=${fakeState}&code=${fakeCode}` };
       await installer.handleCallback(req, res, callbackOptions);
       assert.isTrue(sent);
       assert.equal(fakeStateStore.verifyStateParam.callCount, 1);

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -429,7 +429,7 @@ describe('OAuth', async () => {
           assert.fail('should have succeeded');
         },
       }
-      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, stateValidation: false, installationStore, logger: noopLogger });
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, stateVerification: false, installationStore, logger: noopLogger });
       await installer.handleCallback(req, res, callbackOptions);
 
       assert.isTrue(sent);

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -417,7 +417,7 @@ describe('OAuth', async () => {
       assert.isTrue(sent);
     });
 
-    it('should call the success callback when state query param is missing but stateValidation disabled', async () => {
+    it('should call the success callback when state query param is missing but stateVerification disabled', async () => {
       const req = { url: 'http://example.com?code=1234' };
       let sent = false;
       const res = { send: () => { sent = true; } };

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -95,7 +95,7 @@ export class InstallProvider {
     }
     this.stateValidation = stateValidation;
     if (!stateValidation) {
-      this.logger.info("You\'ve disabled state parameter validation by setting InstallProvider#stateValidation to false. The state parameter is intended to be used for org-wide app installations from admin pages. When state is provided as a query param we will attempt to validate, when it is omitted, we will ignore validation. Custom metadata options will not be available when state is not supplied. If this isn't the intended behavior, we recommend setting the flag to true and starting your ");
+      this.logger.info("You've set InstallProvider#stateValidation to false. This flag is intended to enable org-wide app installations from admin pages. If this isn't your scenario, we recommend setting stateValidation to true and starting your OAuth flow from the provided `/slack/install` or your own starting endpoint.");
     }
     // Setup stateStore
     if (stateStore !== undefined) {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -256,6 +256,15 @@ export class InstallProvider {
   }
 
   /**
+   * Returns search params from a URL and ignores protocol / hostname as those
+   * aren't guaranteed to be accurate e.g. in x-forwarded- scenarios
+   */
+  private static extractSearchParams(req: IncomingMessage): URLSearchParams {
+    const { searchParams } = new URL(req.url as string, `https://${req.headers.host}`);
+    return searchParams;
+  }
+
+  /**
    * Returns a URL that is suitable for including in an Add to Slack button
    * Uses stateStore to generate a value for the state query param.
    */
@@ -329,7 +338,7 @@ export class InstallProvider {
         // Note: Protocol/ host of object are not necessarily accurate
         // and shouldn't be relied on
         // intended only for accessing searchParams only
-        const { searchParams } = new URL(req.url, `https://${req.headers.host}`);
+        const searchParams = InstallProvider.extractSearchParams(req);
         flowError = searchParams.get('error') as string;
         if (flowError === 'access_denied') {
           throw new AuthorizationError('User cancelled the OAuth installation flow!');

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -95,11 +95,16 @@ export class InstallProvider {
 
     // SJ - If stateValidation = false, then no stateSecret is needed
     this.stateValidation = stateValidation;
+    if (this.stateValidation === false) {
+      this.logger.info('You\'ve disabled state validation during oauth. This means any custom metadata passed along as options will be ignored during the installation flow.'); 
+    }
 
     // Setup stateStore
-    if (stateStore !== undefined) {
-      this.stateStore = stateStore;
+    if (stateStore !== undefined) { // SJ they passed in a custom state store
+      this.stateStore = stateStore; // SJ with the custom store state secret is option
     } else if (stateSecret === undefined) {
+      // SJ could optionally make it so that when stateValidation is disabled, 
+      // SJ avoid this error, but that means state secret is req'd. poor experience?
       throw new InstallerInitializationError('You must provide a State Secret to use the built-in state store');
     } else {
       this.stateStore = new ClearStateStore(stateSecret);

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -95,7 +95,7 @@ export class InstallProvider {
     }
     this.stateVerification = stateVerification;
     if (!stateVerification) {
-      this.logger.info("You've set InstallProvider#stateVerification to false. This flag is intended to enable org-wide app installations from admin pages. If this isn't your scenario, we recommend setting stateVerification to true and starting your OAuth flow from the provided `/slack/install` or your own starting endpoint.");
+      this.logger.warn("You've set InstallProvider#stateVerification to false. This flag is intended to enable org-wide app installations from admin pages. If this isn't your scenario, we recommend setting stateVerification to true and starting your OAuth flow from the provided `/slack/install` or your own starting endpoint.");
     }
     // Setup stateStore
     if (stateStore !== undefined) {
@@ -564,6 +564,7 @@ export interface CallbackOptions {
 export interface StateStore {
   // Returned Promise resolves for a string which can be used as an
   // OAuth state param.
+  // TODO: Revisit design. Does installOptions need to be encoded in state if metadata is static?
   generateStateParam: (installOptions: InstallURLOptions, now: Date) => Promise<string>;
 
   // Returned Promise resolves for InstallURLOptions that were stored in the state

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -64,6 +64,7 @@ export class InstallProvider {
   private clientOptions: WebClientOptions;
 
   private authorizationUrl: string;
+
   private stateValidation: boolean;
 
   public constructor({
@@ -324,16 +325,13 @@ export class InstallProvider {
     let code: string;
     let state: string;
     let installOptions: InstallURLOptions | undefined;
-
     try {
       if (req.url !== undefined) {
-
         parsedUrl = new URL(req.url);
         code = parsedUrl.searchParams.get('code') as string;
         state = parsedUrl.searchParams.get('state') as string;
         if (!code) {
           throw new MissingCodeError('Redirect url is missing the required code query parameter');
-
         }
         if (this.stateValidation && !state) {
           throw new MissingStateError('Redirect url is missing the state query parameter. If this is intentional, see options for disabling default state validation.');
@@ -341,11 +339,9 @@ export class InstallProvider {
       } else {
         throw new UnknownError('Something went wrong');
       }
-
       // If state validation is enabled OR state exists, attempt to validate, otherwise ignore validation
-      installOptions =  (this.stateValidation || state)
-        ? await this.stateStore.verifyStateParam(new Date(), state)
-        : undefined;
+      installOptions = this.stateValidation || state ?
+        await this.stateStore.verifyStateParam(new Date(), state) : undefined;
 
       const client = new WebClient(undefined, this.clientOptions);
 
@@ -359,7 +355,7 @@ export class InstallProvider {
           code,
           client_id: this.clientId,
           client_secret: this.clientSecret,
-          redirect_uri: installOptions ? installOptions.redirectUri: undefined,
+          redirect_uri: installOptions ? installOptions.redirectUri : undefined,
         }) as OAuthV1Response;
 
         // resp obj for v1 - https://api.slack.com/methods/oauth.access#response
@@ -400,7 +396,7 @@ export class InstallProvider {
           code,
           client_id: this.clientId,
           client_secret: this.clientSecret,
-          redirect_uri: installOptions? installOptions.redirectUri : undefined,
+          redirect_uri: installOptions ? installOptions.redirectUri : undefined,
         }) as OAuthV2Response;
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -324,7 +324,7 @@ export class InstallProvider {
     let parsedUrl;
     let code: string;
     let state: string;
-    let installOptions: InstallURLOptions | undefined;
+    let installOptions: InstallURLOptions;
     try {
       if (req.url !== undefined) {
         parsedUrl = new URL(req.url);
@@ -340,8 +340,12 @@ export class InstallProvider {
         throw new UnknownError('Something went wrong');
       }
       // If state validation is enabled OR state exists, attempt to validate, otherwise ignore validation
-      installOptions = this.stateValidation || state ?
-        await this.stateStore.verifyStateParam(new Date(), state) : undefined;
+      if (this.stateValidation || state) {
+        installOptions = await this.stateStore.verifyStateParam(new Date(), state);
+      } else {
+        const emptyOptions: InstallURLOptions = { scopes: [] };
+        installOptions = emptyOptions;
+      }
 
       const client = new WebClient(undefined, this.clientOptions);
 
@@ -533,7 +537,7 @@ export interface CallbackOptions {
   // callbackRes.
   success?: (
     installation: Installation | OrgInstallation,
-    options: InstallURLOptions | undefined,
+    options: InstallURLOptions,
     callbackReq: IncomingMessage,
     callbackRes: ServerResponse,
   ) => void;
@@ -544,7 +548,7 @@ export interface CallbackOptions {
   // serve a generic "Error" web page (show detailed cause in development)
   failure?: (
     error: CodedError,
-    options: InstallURLOptions | undefined,
+    options: InstallURLOptions,
     callbackReq: IncomingMessage,
     callbackRes: ServerResponse,
   ) => void;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -95,7 +95,7 @@ export class InstallProvider {
     }
     this.stateValidation = stateValidation;
     if (!stateValidation) {
-      this.logger.info('You\'ve disabled mandatory state validation during oauth. When state is provided as a query param we will attempt to validate, when it is omitted, with this flag set to true, we will ignore validation. Custom metadata options will not be available when state is not supplied.');
+      this.logger.info("You\'ve disabled state parameter validation by setting InstallProvider#stateValidation to false. The state parameter is intended to be used for org-wide app installations from admin pages. When state is provided as a query param we will attempt to validate, when it is omitted, we will ignore validation. Custom metadata options will not be available when state is not supplied. If this isn't the intended behavior, we recommend setting the flag to true and starting your ");
     }
     // Setup stateStore
     if (stateStore !== undefined) {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -327,7 +327,7 @@ export class InstallProvider {
     let state: string;
     try {
       if (req.url !== undefined) {
-        parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+        parsedUrl = new URL(req.url, `https://${req.headers.host}`);
         flowError = parsedUrl.searchParams.get('error') as string;
         if (flowError === 'access_denied') {
           throw new AuthorizationError('User cancelled the OAuth installation flow!');

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -327,23 +327,13 @@ export class InstallProvider {
 
     try {
       if (req.url !== undefined) {
-<<<<<<< HEAD
+
         parsedUrl = new URL(req.url);
         code = parsedUrl.searchParams.get('code') as string;
         state = parsedUrl.searchParams.get('state') as string;
-        // SJ This section checks for a state field or a code query, split?
-        // if (state === undefined || state === '' || code === undefined) {
-        //   throw new MissingStateError('redirect url is missing state or code query parameters');
-        // }
-        if ((state === undefined || state === '') && this.stateValidation === true) {
-          throw new MissingStateError('Redirect url is missing the state query parameter')
-=======
-        parsedUrl = parseUrl(req.url, true);
-        code = parsedUrl.query.code as string;
-        state = parsedUrl.query.state as string;
         if (!code) {
           throw new MissingCodeError('Redirect url is missing the required code query parameter');
->>>>>>> e03d4fb (Add stateValidation)
+
         }
         if (this.stateValidation && !state) {
           throw new MissingStateError('Redirect url is missing the state query parameter. If this is intentional, see options for disabling default state validation.');
@@ -369,11 +359,7 @@ export class InstallProvider {
           code,
           client_id: this.clientId,
           client_secret: this.clientSecret,
-<<<<<<< HEAD
           redirect_uri: installOptions ? installOptions.redirectUri: undefined,
-=======
-          redirect_uri: installOptions ? installOptions.redirectUri : undefined,
->>>>>>> e03d4fb (Add stateValidation)
         }) as OAuthV1Response;
 
         // resp obj for v1 - https://api.slack.com/methods/oauth.access#response
@@ -414,15 +400,7 @@ export class InstallProvider {
           code,
           client_id: this.clientId,
           client_secret: this.clientSecret,
-<<<<<<< HEAD
-<<<<<<< HEAD
           redirect_uri: installOptions? installOptions.redirectUri : undefined,
-=======
-          redirect_uri: installOptions ? installOptions.redirectUri : null,
->>>>>>> f1660e5 (Add type fixes)
-=======
-          redirect_uri: installOptions ? installOptions.redirectUri : undefined,
->>>>>>> e03d4fb (Add stateValidation)
         }) as OAuthV2Response;
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response
@@ -494,12 +472,7 @@ export class InstallProvider {
           configurationUrl: resp.incoming_webhook.configuration_url,
         };
       }
-<<<<<<< HEAD
-      // SJ Does this need to be handled if there's no metadata? 
       if (installOptions && installOptions.metadata !== undefined) {
-=======
-      if (installOptions !== undefined && installOptions.metadata !== undefined) {
->>>>>>> f1660e5 (Add type fixes)
         // Pass the metadata in state parameter if exists.
         // Developers can use the value for additional/custom data associated with the installation.
         installation.metadata = installOptions.metadata;
@@ -597,28 +570,6 @@ interface StateObj {
   installOptions: InstallURLOptions;
 }
 
-<<<<<<< HEAD
-=======
-// default implementation of StateStore
-class ClearStateStore implements StateStore {
-  private stateSecret: string;
-  public constructor(stateSecret: string) {
-    this.stateSecret = stateSecret;
-  }
-
-  public async generateStateParam(installOptions: InstallURLOptions, now: Date): Promise<string> {
-    const state = sign({ installOptions, now: now.toJSON() }, this.stateSecret);
-    return state;
-  }
-  public async verifyStateParam(_now: Date, state: string): Promise<InstallURLOptions> {
-    // decode the state using the secret
-    const decoded: StateObj = verify(state, this.stateSecret) as StateObj;
-    // return installOptions
-    return decoded.installOptions;
-  }
-}
-
->>>>>>> e03d4fb (Add stateValidation)
 export interface InstallationStore {
   storeInstallation<AuthVersion extends 'v1' | 'v2'>(
     installation: Installation<AuthVersion, boolean>,

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -334,9 +334,6 @@ export class InstallProvider {
         }
         code = parsedUrl.searchParams.get('code') as string;
         state = parsedUrl.searchParams.get('state') as string;
-        if (flowError === 'access_denied') {
-          throw new AuthorizationError('User cancelled the OAuth installation flow!');
-        }
         if (!code) {
           throw new MissingCodeError('Redirect url is missing the required code query parameter');
         }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -348,11 +348,8 @@ export class InstallProvider {
         throw new UnknownError('Something went wrong');
       }
 
-      if (this.stateValidation === true) {
-        installOptions = await this.stateStore.verifyStateParam(new Date(), state);
-      } else {
-        installOptions = undefined;
-      }
+      installOptions =  this.stateValidation ? await this.stateStore.verifyStateParam(new Date(), state) : undefined;
+      
       const client = new WebClient(undefined, this.clientOptions);
 
       // Start: Build the installation object
@@ -406,7 +403,11 @@ export class InstallProvider {
           code,
           client_id: this.clientId,
           client_secret: this.clientSecret,
+<<<<<<< HEAD
           redirect_uri: installOptions? installOptions.redirectUri : undefined,
+=======
+          redirect_uri: installOptions ? installOptions.redirectUri : null,
+>>>>>>> f1660e5 (Add type fixes)
         }) as OAuthV2Response;
 
         // resp obj for v2 - https://api.slack.com/methods/oauth.v2.access#response
@@ -478,8 +479,12 @@ export class InstallProvider {
           configurationUrl: resp.incoming_webhook.configuration_url,
         };
       }
+<<<<<<< HEAD
       // SJ Does this need to be handled if there's no metadata? 
       if (installOptions && installOptions.metadata !== undefined) {
+=======
+      if (installOptions !== undefined && installOptions.metadata !== undefined) {
+>>>>>>> f1660e5 (Add type fixes)
         // Pass the metadata in state parameter if exists.
         // Developers can use the value for additional/custom data associated with the installation.
         installation.metadata = installOptions.metadata;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -347,7 +347,8 @@ export class InstallProvider {
       if (this.stateVerification || state) {
         // eslint-disable-next-line no-param-reassign
         installOptions = await this.stateStore.verifyStateParam(new Date(), state);
-      } else if (!installOptions) {
+      }
+      if (!installOptions) {
         const emptyInstallOptions: InstallURLOptions = { scopes: [] };
         // eslint-disable-next-line no-param-reassign
         installOptions = emptyInstallOptions;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -321,19 +321,21 @@ export class InstallProvider {
     options?: CallbackOptions,
     installOptions?: InstallURLOptions,
   ): Promise<void> {
-    let parsedUrl;
     let code: string;
     let flowError: string;
     let state: string;
     try {
       if (req.url !== undefined) {
-        parsedUrl = new URL(req.url, `https://${req.headers.host}`);
-        flowError = parsedUrl.searchParams.get('error') as string;
+        // Note: Protocol/ host of object are not necessarily accurate
+        // and shouldn't be relied on
+        // intended only for accessing searchParams only
+        const { searchParams } = new URL(req.url, `https://${req.headers.host}`);
+        flowError = searchParams.get('error') as string;
         if (flowError === 'access_denied') {
           throw new AuthorizationError('User cancelled the OAuth installation flow!');
         }
-        code = parsedUrl.searchParams.get('code') as string;
-        state = parsedUrl.searchParams.get('state') as string;
+        code = searchParams.get('code') as string;
+        state = searchParams.get('state') as string;
         if (!code) {
           throw new MissingCodeError('Redirect url is missing the required code query parameter');
         }


### PR DESCRIPTION
###  Summary
This PR is first part of addressing [bolt-js/#1101](https://github.com/slackapi/bolt-js/issues/1101). It adds the option to disable state verification during OAuth flow via a `stateVerification` flag in the InstallProvider. By default this will be true. 

Because state verification is a highly recommended security feature of Oauth, we opt to verify when state exists but when it doesn't fall back on whether stateVerification is on to determine what to do next. 

When `stateVerification` is set as false, in the event that state is not supplied in request params, the client will ignore the absence of state which is our desired behavior. But if state is supplied, the client presumes that is because this state param was generated on our side, and will attempt to verify as usual.

Another change here is that `handleCallback` will now optionally accept installOptions per Kaz's suggestion (there are some changes also on the receiver side that need to happen). 

Notes
- [x] I have not touched the URL generation / state generation flow.`stateSecret` is still required even with stateValidation disabled. So when Bolt is in charge of generating the URL it will still do so regardless of what the flag is set as. 
- [x] `package.json` isn't being found causing build to fail, need to come back to this. 
- [x] This should land after #1325 
- [ ] [bolt-js/pull/1116](https://github.com/slackapi/bolt-js/pull/1116) has a draft of the related changes needed receiver side once this lands

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
