### PR TITLE
Disable running tests for deprecated packages in CI

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,12 @@
 {
   "packages": [
-    "packages/*",
+    "packages/logger",
+    "packages/oauth",
+    "packages/rtm-api",
+    "packages/socket-mode",
+    "packages/types",
+    "packages/web-api",
+    "packages/webhook",
     "support/*",
     "examples/*"
   ],


### PR DESCRIPTION
This is for the events-api, interactive-messages and client packages, which are all deprecated packages, so that tests will not run against these packages. Fixes #1327.