### PR TITLE
Explicitly catch an error querystring with value access_denied

### DIFF
--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -417,6 +417,26 @@ describe('OAuth', async () => {
       assert.isTrue(sent);
     });
 
+    it('should call the failure callback due to missing code query parameter on the URL', async () => {
+      const req = { url: 'http://example.com' };
+      let sent = false;
+      const res = { send: () => { sent = true; } };
+      const callbackOptions = {
+        success: async (installation, installOptions, req, res) => {
+          res.send('successful!');
+          assert.fail('should have failed');
+        },
+        failure: async (error, installOptions, req, res) => {
+          assert.equal(error.code, ErrorCode.MissingStateError)
+          res.send('failure');
+        },
+      }
+      const installer = new InstallProvider({ clientId, clientSecret, stateSecret, installationStore, logger: noopLogger });
+      await installer.handleCallback(req, res, callbackOptions);
+
+      assert.isTrue(sent);
+    });
+
     it('should call the failure callback if an access_denied error query parameter was returned on the URL', async () => {
       const req = { url: 'http://example.com?error=access_denied' };
       let sent = false;

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -417,8 +417,8 @@ describe('OAuth', async () => {
       assert.isTrue(sent);
     });
 
-    it('should call the failure callback due to missing code query parameter on the URL', async () => {
-      const req = { url: 'http://example.com' };
+    it('should call the failure callback if an access_denied error query parameter was returned on the URL', async () => {
+      const req = { url: 'http://example.com?error=access_denied' };
       let sent = false;
       const res = { send: () => { sent = true; } };
       const callbackOptions = {
@@ -427,7 +427,7 @@ describe('OAuth', async () => {
           assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
-          assert.equal(error.code, ErrorCode.MissingStateError)
+          assert.equal(error.code, ErrorCode.AuthorizationError)
           res.send('failure');
         },
       }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -315,12 +315,17 @@ export class InstallProvider {
   ): Promise<void> {
     let parsedUrl;
     let code: string;
+    let flowError: string;
     let state: string;
     let installOptions: InstallURLOptions;
 
     try {
       if (req.url !== undefined) {
         parsedUrl = new URL(req.url);
+        flowError = parsedUrl.searchParams.get('error') as string;
+        if (flowError === 'access_denied') {
+          throw new AuthorizationError('User cancelled the OAuth installation flow!');
+        }
         code = parsedUrl.searchParams.get('code') as string;
         state = parsedUrl.searchParams.get('state') as string;
         if (!state || !code) {


### PR DESCRIPTION
###  Summary

An `error` querystring on the oauth redirect URL with a value of `access_denied` signifies that the user canceled out of the installation flow.

This PR fixes #1186 / #824

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
