### PR TITLE
Fix #1326 Add admin.conversations.{get|set|remove}CustomRetention API

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -34,6 +34,9 @@ import {
   AdminConversationsSetConversationPrefsResponse,
   AdminConversationsSetTeamsResponse,
   AdminConversationsUnarchiveResponse,
+  AdminConversationsGetCustomRetentionResponse,
+  AdminConversationsSetCustomRetentionResponse,
+  AdminConversationsRemoveCustomRetentionResponse,
   AdminEmojiAddAliasResponse,
   AdminEmojiAddResponse,
   AdminEmojiListResponse,
@@ -309,6 +312,18 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
             this, 'admin.conversations.restrictAccess.removeGroup',
           ),
       },
+      getCustomRetention:
+        bindApiCall<AdminConversationsGetCustomRetentionArguments, AdminConversationsGetCustomRetentionResponse>(
+          this, 'admin.conversations.getCustomRetention',
+        ),
+      setCustomRetention:
+        bindApiCall<AdminConversationsSetCustomRetentionArguments, AdminConversationsSetCustomRetentionResponse>(
+          this, 'admin.conversations.setCustomRetention',
+        ),
+      removeCustomRetention:
+        bindApiCall<AdminConversationsRemoveCustomRetentionArguments, AdminConversationsRemoveCustomRetentionResponse>(
+          this, 'admin.conversations.removeCustomRetention',
+        ),
       search: bindApiCall<AdminConversationsSearchArguments, AdminConversationsSearchResponse>(this, 'admin.conversations.search'),
       setConversationPrefs:
         bindApiCall<AdminConversationsSetConversationPrefsArguments, AdminConversationsSetConversationPrefsResponse>(
@@ -927,6 +942,16 @@ export interface AdminConversationsRestrictAccessRemoveGroupArguments extends We
   channel_id: string;
   group_id: string;
   team_id: string;
+}
+export interface AdminConversationsGetCustomRetentionArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+}
+export interface AdminConversationsSetCustomRetentionArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  duration_days: number;
+}
+export interface AdminConversationsRemoveCustomRetentionArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
 }
 export interface AdminConversationsSearchArguments
   extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {

--- a/packages/web-api/src/response/AdminAppsApprovedListResponse.ts
+++ b/packages/web-api/src/response/AdminAppsApprovedListResponse.ts
@@ -11,11 +11,12 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsApprovedListResponse = WebAPICallResult & {
   ok?:                boolean;
+  warning?:           string;
   error?:             string;
-  approved_apps?:     ApprovedApp[];
-  response_metadata?: ResponseMetadata;
   needed?:            string;
   provided?:          string;
+  approved_apps?:     ApprovedApp[];
+  response_metadata?: ResponseMetadata;
 };
 
 export interface ApprovedApp {
@@ -35,8 +36,8 @@ export interface App {
   app_directory_url?:         string;
   is_app_directory_approved?: boolean;
   is_internal?:               boolean;
-  icons?:                     Icons;
   additional_info?:           string;
+  icons?:                     Icons;
 }
 
 export interface Icons {
@@ -67,4 +68,6 @@ export interface Scope {
 
 export interface ResponseMetadata {
   next_cursor?: string;
+  messages?:    string[];
+  warnings?:    string[];
 }

--- a/packages/web-api/src/response/AdminAppsClearResolutionResponse.ts
+++ b/packages/web-api/src/response/AdminAppsClearResolutionResponse.ts
@@ -11,6 +11,7 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsClearResolutionResponse = WebAPICallResult & {
   ok?:       boolean;
+  warning?:  string;
   error?:    string;
   needed?:   string;
   provided?: string;

--- a/packages/web-api/src/response/AdminAppsRequestsListResponse.ts
+++ b/packages/web-api/src/response/AdminAppsRequestsListResponse.ts
@@ -11,21 +11,23 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsRequestsListResponse = WebAPICallResult & {
   ok?:                boolean;
-  app_requests?:      AppRequest[];
-  response_metadata?: ResponseMetadata;
+  warning?:           string;
   error?:             string;
   needed?:            string;
   provided?:          string;
+  app_requests?:      AppRequest[];
+  response_metadata?: ResponseMetadata;
 };
 
 export interface AppRequest {
-  id?:                  string;
-  app?:                 App;
-  user?:                User;
-  team?:                Team;
-  previous_resolution?: PreviousResolution;
-  message?:             string;
-  date_created?:        number;
+  id?:                       string;
+  app?:                      App;
+  user?:                     User;
+  team?:                     Team;
+  previous_resolution?:      PreviousResolution;
+  is_user_app_collaborator?: boolean;
+  message?:                  string;
+  date_created?:             number;
 }
 
 export interface App {
@@ -74,4 +76,6 @@ export interface User {
 
 export interface ResponseMetadata {
   next_cursor?: string;
+  messages?:    string[];
+  warnings?:    string[];
 }

--- a/packages/web-api/src/response/AdminAppsRestrictResponse.ts
+++ b/packages/web-api/src/response/AdminAppsRestrictResponse.ts
@@ -11,6 +11,7 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsRestrictResponse = WebAPICallResult & {
   ok?:       boolean;
+  warning?:  string;
   error?:    string;
   needed?:   string;
   provided?: string;

--- a/packages/web-api/src/response/AdminAppsRestrictedListResponse.ts
+++ b/packages/web-api/src/response/AdminAppsRestrictedListResponse.ts
@@ -11,15 +11,18 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsRestrictedListResponse = WebAPICallResult & {
   ok?:                boolean;
-  restricted_apps?:   RestrictedApp[];
-  response_metadata?: ResponseMetadata;
+  warning?:           string;
   error?:             string;
   needed?:            string;
   provided?:          string;
+  restricted_apps?:   RestrictedApp[];
+  response_metadata?: ResponseMetadata;
 };
 
 export interface ResponseMetadata {
   next_cursor?: string;
+  messages?:    string[];
+  warnings?:    string[];
 }
 
 export interface RestrictedApp {
@@ -39,21 +42,22 @@ export interface App {
   app_directory_url?:         string;
   is_app_directory_approved?: boolean;
   is_internal?:               boolean;
-  icons?:                     Icons;
   additional_info?:           string;
+  icons?:                     Icons;
 }
 
 export interface Icons {
-  image_32?:   string;
-  image_36?:   string;
-  image_48?:   string;
-  image_64?:   string;
-  image_72?:   string;
-  image_96?:   string;
-  image_128?:  string;
-  image_192?:  string;
-  image_512?:  string;
-  image_1024?: string;
+  image_32?:       string;
+  image_36?:       string;
+  image_48?:       string;
+  image_64?:       string;
+  image_72?:       string;
+  image_96?:       string;
+  image_128?:      string;
+  image_192?:      string;
+  image_512?:      string;
+  image_1024?:     string;
+  image_original?: string;
 }
 
 export interface LastResolvedBy {

--- a/packages/web-api/src/response/AdminAppsUninstallResponse.ts
+++ b/packages/web-api/src/response/AdminAppsUninstallResponse.ts
@@ -11,6 +11,7 @@
 import { WebAPICallResult } from '../WebClient';
 export type AdminAppsUninstallResponse = WebAPICallResult & {
   ok?:       boolean;
+  warning?:  string;
   error?:    string;
   needed?:   string;
   provided?: string;

--- a/packages/web-api/src/response/AdminConversationsGetCustomRetentionResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsGetCustomRetentionResponse.ts
@@ -9,10 +9,11 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type AdminAppsApproveResponse = WebAPICallResult & {
-  ok?:       boolean;
-  warning?:  string;
-  error?:    string;
-  needed?:   string;
-  provided?: string;
+export type AdminConversationsGetCustomRetentionResponse = WebAPICallResult & {
+  ok?:                boolean;
+  error?:             string;
+  needed?:            string;
+  provided?:          string;
+  is_policy_enabled?: boolean;
+  duration_days?:     number;
 };

--- a/packages/web-api/src/response/AdminConversationsRemoveCustomRetentionResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsRemoveCustomRetentionResponse.ts
@@ -9,9 +9,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type AdminAppsApproveResponse = WebAPICallResult & {
+export type AdminConversationsRemoveCustomRetentionResponse = WebAPICallResult & {
   ok?:       boolean;
-  warning?:  string;
   error?:    string;
   needed?:   string;
   provided?: string;

--- a/packages/web-api/src/response/AdminConversationsSetCustomRetentionResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsSetCustomRetentionResponse.ts
@@ -9,9 +9,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type AdminAppsApproveResponse = WebAPICallResult & {
+export type AdminConversationsSetCustomRetentionResponse = WebAPICallResult & {
   ok?:       boolean;
-  warning?:  string;
   error?:    string;
   needed?:   string;
   provided?: string;

--- a/packages/web-api/src/response/AdminUsersSessionListResponse.ts
+++ b/packages/web-api/src/response/AdminUsersSessionListResponse.ts
@@ -23,6 +23,7 @@ export interface ActiveSession {
   session_id?: number;
   team_id?:    string;
   created?:    Created;
+  recent?:     Created;
 }
 
 export interface Created {

--- a/packages/web-api/src/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/response/ConversationsRepliesResponse.ts
@@ -35,6 +35,193 @@ export interface Message {
   subscribed?:        boolean;
   parent_user_id?:    string;
   is_locked?:         boolean;
+  blocks?:            Block[];
+  attachments?:       Attachment[];
+}
+
+export interface Attachment {
+  msg_subtype?:           string;
+  fallback?:              string;
+  callback_id?:           string;
+  color?:                 string;
+  pretext?:               string;
+  service_url?:           string;
+  service_name?:          string;
+  service_icon?:          string;
+  author_id?:             string;
+  author_name?:           string;
+  author_link?:           string;
+  author_icon?:           string;
+  from_url?:              string;
+  original_url?:          string;
+  author_subname?:        string;
+  channel_id?:            string;
+  channel_name?:          string;
+  id?:                    number;
+  bot_id?:                string;
+  indent?:                boolean;
+  is_msg_unfurl?:         boolean;
+  is_reply_unfurl?:       boolean;
+  is_thread_root_unfurl?: boolean;
+  is_app_unfurl?:         boolean;
+  app_unfurl_url?:        string;
+  title?:                 string;
+  title_link?:            string;
+  text?:                  string;
+  fields?:                Field[];
+  image_url?:             string;
+  image_width?:           number;
+  image_height?:          number;
+  image_bytes?:           number;
+  thumb_url?:             string;
+  thumb_width?:           number;
+  thumb_height?:          number;
+  video_url?:             string;
+  video_html?:            string;
+  video_html_width?:      number;
+  video_html_height?:     number;
+  footer?:                string;
+  footer_icon?:           string;
+  ts?:                    string;
+  mrkdwn_in?:             string[];
+  actions?:               Action[];
+  filename?:              string;
+  size?:                  number;
+  mimetype?:              string;
+  url?:                   string;
+  metadata?:              Metadata;
+}
+
+export interface Action {
+  id?:               string;
+  name?:             string;
+  text?:             string;
+  style?:            string;
+  type?:             string;
+  value?:            string;
+  confirm?:          ActionConfirm;
+  options?:          Option[];
+  selected_options?: Option[];
+  data_source?:      string;
+  min_query_length?: number;
+  option_groups?:    OptionGroup[];
+  url?:              string;
+}
+
+export interface ActionConfirm {
+  title?:        string;
+  text?:         string;
+  ok_text?:      string;
+  dismiss_text?: string;
+}
+
+export interface OptionGroup {
+  text?: string;
+}
+
+export interface Option {
+  text?:  string;
+  value?: string;
+}
+
+export interface Field {
+  title?: string;
+  value?: string;
+  short?: boolean;
+}
+
+export interface Metadata {
+  thumb_64?:    boolean;
+  thumb_80?:    boolean;
+  thumb_160?:   boolean;
+  original_w?:  number;
+  original_h?:  number;
+  thumb_360_w?: number;
+  thumb_360_h?: number;
+  format?:      string;
+  extension?:   string;
+  rotation?:    number;
+  thumb_tiny?:  string;
+}
+
+export interface Block {
+  type?:         string;
+  block_id?:     string;
+  text?:         Text;
+  elements?:     Element[];
+  fallback?:     string;
+  image_url?:    string;
+  image_width?:  number;
+  image_height?: number;
+  image_bytes?:  number;
+  alt_text?:     string;
+  title?:        Text;
+  fields?:       Text[];
+  accessory?:    Accessory;
+}
+
+export interface Accessory {
+  type?:         string;
+  image_url?:    string;
+  alt_text?:     string;
+  fallback?:     string;
+  image_width?:  number;
+  image_height?: number;
+  image_bytes?:  number;
+}
+
+export interface Element {
+  type?:                            string;
+  text?:                            Text;
+  action_id?:                       string;
+  url?:                             string;
+  value?:                           string;
+  style?:                           string;
+  confirm?:                         ElementConfirm;
+  placeholder?:                     Text;
+  initial_channel?:                 string;
+  response_url_enabled?:            boolean;
+  initial_conversation?:            string;
+  default_to_current_conversation?: boolean;
+  filter?:                          Filter;
+  initial_date?:                    string;
+  initial_time?:                    string;
+  initial_option?:                  InitialOption;
+  min_query_length?:                number;
+  image_url?:                       string;
+  alt_text?:                        string;
+  fallback?:                        string;
+  image_width?:                     number;
+  image_height?:                    number;
+  image_bytes?:                     number;
+  initial_user?:                    string;
+}
+
+export interface ElementConfirm {
+  title?:   Text;
+  text?:    Text;
+  confirm?: Text;
+  deny?:    Text;
+  style?:   string;
+}
+
+export interface Text {
+  type?:     string;
+  text?:     string;
+  emoji?:    boolean;
+  verbatim?: boolean;
+}
+
+export interface Filter {
+  exclude_external_shared_channels?: boolean;
+  exclude_bot_users?:                boolean;
+}
+
+export interface InitialOption {
+  text?:        Text;
+  value?:       string;
+  description?: Text;
+  url?:         string;
 }
 
 export interface BotProfile {

--- a/packages/web-api/src/response/RemindersAddResponse.ts
+++ b/packages/web-api/src/response/RemindersAddResponse.ts
@@ -10,11 +10,12 @@
 
 import { WebAPICallResult } from '../WebClient';
 export type RemindersAddResponse = WebAPICallResult & {
-  ok?:       boolean;
-  reminder?: Reminder;
-  error?:    string;
-  needed?:   string;
-  provided?: string;
+  ok?:                boolean;
+  reminder?:          Reminder;
+  error?:             string;
+  response_metadata?: ResponseMetadata;
+  needed?:            string;
+  provided?:          string;
 };
 
 export interface Reminder {
@@ -25,4 +26,8 @@ export interface Reminder {
   recurring?:   boolean;
   time?:        number;
   complete_ts?: number;
+}
+
+export interface ResponseMetadata {
+  messages?: string[];
 }

--- a/packages/web-api/src/response/RemindersListResponse.ts
+++ b/packages/web-api/src/response/RemindersListResponse.ts
@@ -26,4 +26,10 @@ export interface Reminder {
   time?:        number;
   complete_ts?: number;
   channel?:     string;
+  recurrence?:  Recurrence;
+}
+
+export interface Recurrence {
+  frequency?: string;
+  weekdays?:  string[];
 }

--- a/packages/web-api/src/response/index.ts
+++ b/packages/web-api/src/response/index.ts
@@ -20,14 +20,17 @@ export { AdminConversationsDeleteResponse } from './AdminConversationsDeleteResp
 export { AdminConversationsDisconnectSharedResponse } from './AdminConversationsDisconnectSharedResponse';
 export { AdminConversationsEkmListOriginalConnectedChannelInfoResponse } from './AdminConversationsEkmListOriginalConnectedChannelInfoResponse';
 export { AdminConversationsGetConversationPrefsResponse } from './AdminConversationsGetConversationPrefsResponse';
+export { AdminConversationsGetCustomRetentionResponse } from './AdminConversationsGetCustomRetentionResponse';
 export { AdminConversationsGetTeamsResponse } from './AdminConversationsGetTeamsResponse';
 export { AdminConversationsInviteResponse } from './AdminConversationsInviteResponse';
+export { AdminConversationsRemoveCustomRetentionResponse } from './AdminConversationsRemoveCustomRetentionResponse';
 export { AdminConversationsRenameResponse } from './AdminConversationsRenameResponse';
 export { AdminConversationsRestrictAccessAddGroupResponse } from './AdminConversationsRestrictAccessAddGroupResponse';
 export { AdminConversationsRestrictAccessListGroupsResponse } from './AdminConversationsRestrictAccessListGroupsResponse';
 export { AdminConversationsRestrictAccessRemoveGroupResponse } from './AdminConversationsRestrictAccessRemoveGroupResponse';
 export { AdminConversationsSearchResponse } from './AdminConversationsSearchResponse';
 export { AdminConversationsSetConversationPrefsResponse } from './AdminConversationsSetConversationPrefsResponse';
+export { AdminConversationsSetCustomRetentionResponse } from './AdminConversationsSetCustomRetentionResponse';
 export { AdminConversationsSetTeamsResponse } from './AdminConversationsSetTeamsResponse';
 export { AdminConversationsUnarchiveResponse } from './AdminConversationsUnarchiveResponse';
 export { AdminConversationsWhitelistAddResponse } from './AdminConversationsWhitelistAddResponse';

--- a/prod-server-integration-tests/test/admin-web-api-custom-retention.js
+++ b/prod-server-integration-tests/test/admin-web-api-custom-retention.js
@@ -1,0 +1,69 @@
+// npx mocha --timeout 10000 test/admin-web-api-custom-retention.js
+// tail -f logs/console.log | jq
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+describe('admin.* Web APIs', function () {
+  // admin user's token for a workspace in an Enterprise Grid org
+  const teamAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, { logger, });
+  // org-level admin user's token
+  const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
+
+  describe('admin.conversations.{get|set|remove}CustomRetention', function () {
+    it('should work', async function () {
+      const crewation = await teamAdminClient.conversations.create({
+        name: `test-channel-${new Date().getTime()}`,
+      });
+      const channelId = crewation.channel.id;
+      try {
+        let get = await orgAdminClient.admin.conversations.getCustomRetention({
+          channel_id: channelId
+        });
+        logger.info(get);
+        assert.isUndefined(get.error);
+        assert.equal(get.duration_days, 0);
+
+        const set = await orgAdminClient.admin.conversations.setCustomRetention({
+          channel_id: channelId,
+          duration_days: 700,
+        });
+        logger.info(set);
+        assert.isUndefined(set.error);
+
+        get = await orgAdminClient.admin.conversations.getCustomRetention({
+          channel_id: channelId
+        });
+        logger.info(get);
+        assert.isUndefined(get.error);
+        assert.equal(get.duration_days, 700);
+
+        const remove = await orgAdminClient.admin.conversations.removeCustomRetention({
+          channel_id: channelId
+        });
+        logger.info(remove);
+        assert.isUndefined(remove.error);
+
+        get = await orgAdminClient.admin.conversations.getCustomRetention({
+          channel_id: channelId
+        });
+        logger.info(get);
+        assert.isUndefined(get.error);
+        assert.equal(get.duration_days, 0);
+
+      } finally {
+        await orgAdminClient.admin.conversations.delete({
+          channel_id: channelId,
+        })
+      }
+    });
+  });
+});


### PR DESCRIPTION
###  Summary

This pull request fixes #1326 by adding missing admin APIs to the web-api package.

You can run the integration tests after configuring your sandbox org.

```bash
cd ./prod-server-integration-tests
./link.sh
npx mocha --timeout 10000 test/admin-web-api-custom-retention.js
tail -f logs/console.log | jq
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
