### PR TITLE
Add stateVerification option to documentation

### DIFF
--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -292,7 +292,7 @@ const installer = new InstallProvider({
 
 By default, this package handles generating and verifying a `state` parameter during OAuth installation. This added measure helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
 
-In specific installation scenarios, such as when an Org-wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation.
+In specific installation scenarios with Enterprise Grid organizations, such as when an Org-wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. Now, the installer will no longer require that `state` be present to proceed with installation.
 
 ```javascript
 const installer = new InstallProvider({

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -299,7 +299,7 @@ const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateVerification: false,
-  },
+  }
 });
 ```
 ---

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -292,13 +292,12 @@ const installer = new InstallProvider({
 
 By default, this package handles generating and verifying a `state` parameter during OAuth installation. This added measure helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
 
-In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. If `state` is provided in the request url parameters, it will still be verified.
+In specific installation scenarios, such as when an Org-wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation.
 
 ```javascript
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
   stateVerification: false,
   },
 });

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -299,7 +299,6 @@ const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateVerification: false,
-  }
 });
 ```
 ---

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -288,6 +288,23 @@ const installer = new InstallProvider({
 ```
 ---
 
+### State verification
+
+By default, this package handles generating and verifying a `state` parameter during OAuth installation. This added measure helps to mitigate the risk of [Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12) and is strongly recommended. 
+
+In specific installation scenarios, such as when an Org-Wide app is installed from an admin page, state verification cannot be completed because a `state` parameter isn't provided. In this case, you can disable `state` verification via setting the `InstallProvider#stateVerification` option to `false`. In this case, the installer will no longer require that `state` be present to proceed with installation. If `state` is provided in the request url parameters, it will still be verified.
+
+```javascript
+const installer = new InstallProvider({
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: 'my-state-secret',
+  stateVerification: false,
+  },
+});
+```
+---
+
 ### Setting the log level and using a custom logger
 
 The `InstallProvider` will log interesting information to the console by default. You can use the `logLevel` to decide how


### PR DESCRIPTION
###  Summary

Adds documentation for stateVerification option. Re: [node-slack-sdk/pull/1329](https://github.com/slackapi/node-slack-sdk/pull/1329).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
