### PR TITLE
Add new properties to web-api responses (2021-09-20)

### DIFF
--- a/packages/web-api/src/response/ConversationsJoinResponse.ts
+++ b/packages/web-api/src/response/ConversationsJoinResponse.ts
@@ -48,6 +48,7 @@ export interface Channel {
   priority?:                   number;
   is_moved?:                   number;
   internal_team_ids?:          string[];
+  is_starred?:                 boolean;
 }
 
 export interface Purpose {

--- a/packages/web-api/src/response/UsersInfoResponse.ts
+++ b/packages/web-api/src/response/UsersInfoResponse.ts
@@ -82,4 +82,5 @@ export interface Profile {
   first_name?:              string;
   last_name?:               string;
   image_1024?:              string;
+  status_emoji_url?:        string;
 }

--- a/packages/web-api/src/response/UsersLookupByEmailResponse.ts
+++ b/packages/web-api/src/response/UsersLookupByEmailResponse.ts
@@ -67,4 +67,5 @@ export interface Profile {
   image_1024?:              string;
   status_text_canonical?:   string;
   team?:                    string;
+  status_emoji_url?:        string;
 }

--- a/packages/web-api/src/response/UsersProfileGetResponse.ts
+++ b/packages/web-api/src/response/UsersProfileGetResponse.ts
@@ -43,6 +43,7 @@ export interface Profile {
   image_512?:               string;
   image_1024?:              string;
   status_text_canonical?:   string;
+  status_emoji_url?:        string;
 }
 
 export interface Field {

--- a/packages/web-api/src/response/UsersProfileSetResponse.ts
+++ b/packages/web-api/src/response/UsersProfileSetResponse.ts
@@ -44,6 +44,7 @@ export interface Profile {
   image_512?:               string;
   image_1024?:              string;
   status_text_canonical?:   string;
+  status_emoji_url?:        string;
 }
 
 export interface Field {


### PR DESCRIPTION
###  Summary

This pull request adds new properties added by `./scripts/generate-web-api-types.sh` using the latest Java SDK's outputs.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
