### PR TITLE
Fix #1349: Export Individual View Interfaces

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,7 +31,7 @@ export interface Dialog {
   state?: string;
 }
 
-interface HomeView {
+export interface HomeView {
   type: 'home';
   blocks: (KnownBlock | Block)[];
   private_metadata?: string;
@@ -39,7 +39,7 @@ interface HomeView {
   external_id?: string;
 }
 
-interface ModalView {
+export interface ModalView {
   type: 'modal';
   title: PlainTextElement;
   blocks: (KnownBlock | Block)[];
@@ -52,7 +52,7 @@ interface ModalView {
   external_id?: string;
 }
 
-interface WorkflowStepView {
+export interface WorkflowStepView {
   type: 'workflow_step';
   blocks: (KnownBlock | Block)[];
   private_metadata?: string;


### PR DESCRIPTION
###  Summary

Fixes #1349 

A recent change that made `View` a union type has resulted in compilation errors. This PR exports the individual interfaces that make up the union to allow developers the ability to pick and choose for their specific use case.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
