### PR TITLE
Adding tests to oauth package to ensure clientOptions get passed to WebClient

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -468,10 +468,8 @@ export class InstallProvider {
 
         // Installation has User Token
         if (v2Resp.authed_user !== undefined && v2Resp.authed_user.access_token !== undefined) {
-          // TODO: confirm if it is possible to do an org enterprise install without a bot user
-          const authResult = await runAuthTest(v2Resp.authed_user.access_token, this.clientOptions);
-
           if (v2Resp.is_enterprise_install && v2Installation.enterpriseUrl === undefined) {
+            const authResult = await runAuthTest(v2Resp.authed_user.access_token, this.clientOptions);
             v2Installation.enterpriseUrl = authResult.url;
           }
 


### PR DESCRIPTION
###  Summary

This PR fixes #1083. It ensures that any `clientOptions` passed into `InstallProvider` propagate down to the underlying `WebClient` instance from the `@slack/web-api` package that the `@slack/oauth` creates.

Since we are testing second-order effects, I could not come up with a clean way of testing this, and instead had to expose the `WebClient`-specific options as a global from inside the test code to be able to assert on its state.

As an aside, I think if we can be sure that the `@slack/web-api` package has tests that ensure any `options` passed to it get leveraged in any invocations of the `oauth.*` or `auth.test` methods would be sufficient in terms of test coverage. I feel like these particular tests in this PR within the `oauth` package are kind of doing the job that unit tests within the `web-api` package should be doing. But, more test coverage the better I guess! I believe the branch coverage for the `oauth` package's `index.ts` is increased by about a half percent via this PR.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
