### PR TITLE
Add explicit check for enterprise id

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -158,7 +158,7 @@ export class InstallProvider {
         authResult.teamId = source.teamId;
       }
 
-      if (queryResult?.enterprise?.id || source?.enterpriseId ) {
+      if (queryResult?.enterprise?.id || source?.enterpriseId) {
         authResult.enterpriseId = queryResult?.enterprise?.id || source?.enterpriseId;
       }
 


### PR DESCRIPTION
###  Summary
This PR adds a more robust check for the existence of the enterprise id. 

Background: In my case I used MongoDB as the installation store which, by default,  transformed `undefined` values to `null` in the DB (This is obviously not a great idea, but that's another issue.). When I later retrieved the values and tried to authenticate the Slack App it would fail without a proper error message. (B/c the value ended up being `enterprise: null`. This PR solves the issue by explicitly checking if the value for enterprise id exists. 

Let me know if I can further improve/assist.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
