### PR TITLE
Add new web-api response properties (as of 2021-10-25)

### DIFF
--- a/packages/web-api/src/response/ConversationsAcceptSharedInviteResponse.ts
+++ b/packages/web-api/src/response/ConversationsAcceptSharedInviteResponse.ts
@@ -15,6 +15,7 @@ export type ConversationsAcceptSharedInviteResponse = WebAPICallResult & {
   implicit_approval?: boolean;
   channel_id?:        string;
   invite_id?:         string;
+  can_open_scdm?:     boolean;
   needed?:            string;
   provided?:          string;
 };

--- a/packages/web-api/src/response/OauthTokenResponse.ts
+++ b/packages/web-api/src/response/OauthTokenResponse.ts
@@ -10,8 +10,9 @@
 
 import { WebAPICallResult } from '../WebClient';
 export type OauthTokenResponse = WebAPICallResult & {
-  ok?:       boolean;
-  error?:    string;
-  needed?:   string;
-  provided?: string;
+  ok?:         boolean;
+  error?:      string;
+  req_method?: string;
+  needed?:     string;
+  provided?:   string;
 };

--- a/packages/web-api/src/response/SearchAllResponse.ts
+++ b/packages/web-api/src/response/SearchAllResponse.ts
@@ -93,6 +93,7 @@ export interface FilesMatch {
   non_owner_editable?:   boolean;
   updated?:              number;
   thumb_video?:          string;
+  comments_count?:       number;
 }
 
 export interface MatchShares {

--- a/packages/web-api/src/response/SearchFilesResponse.ts
+++ b/packages/web-api/src/response/SearchFilesResponse.ts
@@ -92,6 +92,7 @@ export interface Match {
   updated?:              number;
   thumb_video?:          string;
   media_display_type?:   string;
+  comments_count?:       number;
 }
 
 export interface Shares {

--- a/packages/web-api/src/response/UsersInfoResponse.ts
+++ b/packages/web-api/src/response/UsersInfoResponse.ts
@@ -54,34 +54,41 @@ export interface EnterpriseUser {
 }
 
 export interface Profile {
-  title?:                   string;
-  phone?:                   string;
-  skype?:                   string;
-  real_name?:               string;
-  real_name_normalized?:    string;
-  display_name?:            string;
-  display_name_normalized?: string;
-  status_text?:             string;
-  status_emoji?:            string;
-  status_expiration?:       number;
-  avatar_hash?:             string;
-  api_app_id?:              string;
-  always_active?:           boolean;
-  bot_id?:                  string;
-  image_24?:                string;
-  image_32?:                string;
-  image_48?:                string;
-  image_72?:                string;
-  image_192?:               string;
-  image_512?:               string;
-  status_text_canonical?:   string;
-  team?:                    string;
-  image_original?:          string;
-  is_custom_image?:         boolean;
-  email?:                   string;
-  first_name?:              string;
-  last_name?:               string;
-  image_1024?:              string;
-  status_emoji_url?:        string;
-  pronouns?:                string;
+  title?:                     string;
+  phone?:                     string;
+  skype?:                     string;
+  real_name?:                 string;
+  real_name_normalized?:      string;
+  display_name?:              string;
+  display_name_normalized?:   string;
+  status_text?:               string;
+  status_emoji?:              string;
+  status_expiration?:         number;
+  avatar_hash?:               string;
+  api_app_id?:                string;
+  always_active?:             boolean;
+  bot_id?:                    string;
+  image_24?:                  string;
+  image_32?:                  string;
+  image_48?:                  string;
+  image_72?:                  string;
+  image_192?:                 string;
+  image_512?:                 string;
+  status_text_canonical?:     string;
+  team?:                      string;
+  image_original?:            string;
+  is_custom_image?:           boolean;
+  email?:                     string;
+  first_name?:                string;
+  last_name?:                 string;
+  image_1024?:                string;
+  status_emoji_url?:          string;
+  pronouns?:                  string;
+  status_emoji_display_info?: StatusEmojiDisplayInfo[];
+}
+
+export interface StatusEmojiDisplayInfo {
+  emoji_name?:    string;
+  display_alias?: string;
+  display_url?:   string;
 }

--- a/packages/web-api/src/response/UsersLookupByEmailResponse.ts
+++ b/packages/web-api/src/response/UsersLookupByEmailResponse.ts
@@ -42,31 +42,38 @@ export interface User {
 }
 
 export interface Profile {
-  title?:                   string;
-  phone?:                   string;
-  skype?:                   string;
-  real_name?:               string;
-  real_name_normalized?:    string;
-  display_name?:            string;
-  display_name_normalized?: string;
-  status_text?:             string;
-  status_emoji?:            string;
-  status_expiration?:       number;
-  avatar_hash?:             string;
-  image_original?:          string;
-  is_custom_image?:         boolean;
-  email?:                   string;
-  first_name?:              string;
-  last_name?:               string;
-  image_24?:                string;
-  image_32?:                string;
-  image_48?:                string;
-  image_72?:                string;
-  image_192?:               string;
-  image_512?:               string;
-  image_1024?:              string;
-  status_text_canonical?:   string;
-  team?:                    string;
-  status_emoji_url?:        string;
-  pronouns?:                string;
+  title?:                     string;
+  phone?:                     string;
+  skype?:                     string;
+  real_name?:                 string;
+  real_name_normalized?:      string;
+  display_name?:              string;
+  display_name_normalized?:   string;
+  status_text?:               string;
+  status_emoji?:              string;
+  status_expiration?:         number;
+  avatar_hash?:               string;
+  image_original?:            string;
+  is_custom_image?:           boolean;
+  email?:                     string;
+  first_name?:                string;
+  last_name?:                 string;
+  image_24?:                  string;
+  image_32?:                  string;
+  image_48?:                  string;
+  image_72?:                  string;
+  image_192?:                 string;
+  image_512?:                 string;
+  image_1024?:                string;
+  status_text_canonical?:     string;
+  team?:                      string;
+  status_emoji_url?:          string;
+  pronouns?:                  string;
+  status_emoji_display_info?: StatusEmojiDisplayInfo[];
+}
+
+export interface StatusEmojiDisplayInfo {
+  emoji_name?:    string;
+  display_alias?: string;
+  display_url?:   string;
 }

--- a/packages/web-api/src/response/UsersProfileGetResponse.ts
+++ b/packages/web-api/src/response/UsersProfileGetResponse.ts
@@ -18,36 +18,43 @@ export type UsersProfileGetResponse = WebAPICallResult & {
 };
 
 export interface Profile {
-  title?:                   string;
-  phone?:                   string;
-  skype?:                   string;
-  real_name?:               string;
-  real_name_normalized?:    string;
-  display_name?:            string;
-  display_name_normalized?: string;
-  fields?:                  { [key: string]: Field };
-  status_text?:             string;
-  status_emoji?:            string;
-  status_expiration?:       number;
-  avatar_hash?:             string;
-  image_original?:          string;
-  is_custom_image?:         boolean;
-  email?:                   string;
-  first_name?:              string;
-  last_name?:               string;
-  image_24?:                string;
-  image_32?:                string;
-  image_48?:                string;
-  image_72?:                string;
-  image_192?:               string;
-  image_512?:               string;
-  image_1024?:              string;
-  status_text_canonical?:   string;
-  status_emoji_url?:        string;
-  pronouns?:                string;
+  title?:                     string;
+  phone?:                     string;
+  skype?:                     string;
+  real_name?:                 string;
+  real_name_normalized?:      string;
+  display_name?:              string;
+  display_name_normalized?:   string;
+  fields?:                    { [key: string]: Field };
+  status_text?:               string;
+  status_emoji?:              string;
+  status_expiration?:         number;
+  avatar_hash?:               string;
+  image_original?:            string;
+  is_custom_image?:           boolean;
+  email?:                     string;
+  first_name?:                string;
+  last_name?:                 string;
+  image_24?:                  string;
+  image_32?:                  string;
+  image_48?:                  string;
+  image_72?:                  string;
+  image_192?:                 string;
+  image_512?:                 string;
+  image_1024?:                string;
+  status_text_canonical?:     string;
+  status_emoji_url?:          string;
+  pronouns?:                  string;
+  status_emoji_display_info?: StatusEmojiDisplayInfo[];
 }
 
 export interface Field {
   value?: string;
   alt?:   string;
+}
+
+export interface StatusEmojiDisplayInfo {
+  emoji_name?:    string;
+  display_alias?: string;
+  display_url?:   string;
 }

--- a/packages/web-api/src/response/UsersProfileSetResponse.ts
+++ b/packages/web-api/src/response/UsersProfileSetResponse.ts
@@ -19,36 +19,43 @@ export type UsersProfileSetResponse = WebAPICallResult & {
 };
 
 export interface Profile {
-  title?:                   string;
-  phone?:                   string;
-  skype?:                   string;
-  real_name?:               string;
-  real_name_normalized?:    string;
-  display_name?:            string;
-  display_name_normalized?: string;
-  fields?:                  { [key: string]: Field };
-  status_text?:             string;
-  status_emoji?:            string;
-  status_expiration?:       number;
-  avatar_hash?:             string;
-  image_original?:          string;
-  is_custom_image?:         boolean;
-  email?:                   string;
-  first_name?:              string;
-  last_name?:               string;
-  image_24?:                string;
-  image_32?:                string;
-  image_48?:                string;
-  image_72?:                string;
-  image_192?:               string;
-  image_512?:               string;
-  image_1024?:              string;
-  status_text_canonical?:   string;
-  status_emoji_url?:        string;
-  pronouns?:                string;
+  title?:                     string;
+  phone?:                     string;
+  skype?:                     string;
+  real_name?:                 string;
+  real_name_normalized?:      string;
+  display_name?:              string;
+  display_name_normalized?:   string;
+  fields?:                    { [key: string]: Field };
+  status_text?:               string;
+  status_emoji?:              string;
+  status_expiration?:         number;
+  avatar_hash?:               string;
+  image_original?:            string;
+  is_custom_image?:           boolean;
+  email?:                     string;
+  first_name?:                string;
+  last_name?:                 string;
+  image_24?:                  string;
+  image_32?:                  string;
+  image_48?:                  string;
+  image_72?:                  string;
+  image_192?:                 string;
+  image_512?:                 string;
+  image_1024?:                string;
+  status_text_canonical?:     string;
+  status_emoji_url?:          string;
+  pronouns?:                  string;
+  status_emoji_display_info?: StatusEmojiDisplayInfo[];
 }
 
 export interface Field {
   value?: string;
   alt?:   string;
+}
+
+export interface StatusEmojiDisplayInfo {
+  emoji_name?:    string;
+  display_alias?: string;
+  display_url?:   string;
 }


### PR DESCRIPTION
###  Summary

This pull request adds new properties detected by Java SDK tests to the web-api responses.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
