### PR TITLE
NPM Audit fix: https://github.com/advisories/GHSA-cph5-m8f7-6c5x

### DIFF
--- a/examples/express-all-interactions/package.json
+++ b/examples/express-all-interactions/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@slack/interactive-messages": "^1.1.1",
     "@slack/web-api": "^5.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "body-parser": "^1.18.2",
     "dotenv": "^5.0.1",
     "express": "^4.16.3"

--- a/packages/interactive-messages/package.json
+++ b/packages/interactive-messages/package.json
@@ -58,7 +58,7 @@
     "@types/lodash.isregexp": "^4.0.6",
     "@types/lodash.isstring": "^4.0.6",
     "@types/node": ">=12.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "debug": "^3.1.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isplainobject": "^4.0.6",

--- a/packages/web-api/.gitignore
+++ b/packages/web-api/.gitignore
@@ -1,6 +1,5 @@
 # node / npm stuff
 /node_modules
-package-lock.json
 
 # build products
 /dist

--- a/packages/web-api/.gitignore
+++ b/packages/web-api/.gitignore
@@ -1,5 +1,6 @@
 # node / npm stuff
 /node_modules
+package-lock.json
 
 # build products
 /dist

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@slack/types": "^1.2.1",
     "@types/node": ">=12.0.0",
-    "axios": "^0.21.1"
+    "axios": "^0.21.4"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.4",


### PR DESCRIPTION
Hi team,

once again, very sorry to reopen this PR again and close the other ones, it seems my git got broken because I now use github and gitlab. Emails in git config are different...

 ref PRs #1358 and #1367

NPM audit is throwing a high severity vulnerability in node-slack-sdk and with bolt-js dependency packages.

And in the way, I made the .gitignore the same for all packages. One of the packages didn't have package-lock in it. (I don't know if it was on purpose).

I hope it helps.

GHSA-cph5-m8f7-6c5x