### PR TITLE
Remove invalid arguments from oauth.v2.exchange API method

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1772,8 +1772,6 @@ export interface OAuthV2AccessArguments extends WebAPICallOptions {
 export interface OAuthV2ExchangeArguments extends WebAPICallOptions {
   client_id: string;
   client_secret: string;
-  grant_type: string;
-  refresh_token: string;
 }
 
 /*


### PR DESCRIPTION
###  Summary

It seems that there is no reason to have the two arguments. We should remove them in the next minor release (not a breaking change -- no one has been using them).

See also:

* https://api.slack.com/authentication/rotation#exchange
* https://api.slack.com/methods/oauth.v2.exchange

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
