### PR TITLE
Disable typescript-eslint/no-explicit-any in internal code of web-api

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -80,6 +80,7 @@ export interface PaginatePredicate {
   (page: WebAPICallResult): boolean | undefined | void;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface PageReducer<A = any> {
   (accumulator: A | undefined, page: WebAPICallResult, index: number): A;
 }
@@ -378,6 +379,7 @@ export class WebClient extends Methods {
   /**
    * Low-level function to make a single API request. handles queuing, retries, and http-level errors
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async makeRequest(url: string, body: any, headers: any = {}): Promise<AxiosResponse> {
     // TODO: better input types - remove any
     const task = () => this.requestQueue.add(async () => {
@@ -424,6 +426,7 @@ export class WebClient extends Methods {
         return response;
       } catch (error) {
         // To make this compatible with tsd, casting here instead of `catch (error: any)`
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const e = error as any;
         this.logger.warn('http request failed', e.message);
         if (e.request) {
@@ -445,10 +448,12 @@ export class WebClient extends Methods {
    * @param options - arguments for the Web API method
    * @param headers - a mutable object representing the HTTP headers for the outgoing request
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private serializeApiCallOptions(options: WebAPICallOptions, headers?: any): string | Readable {
     // The following operation both flattens complex objects into a JSON-encoded strings and searches the values for
     // binary content
     let containsBinaryData: boolean = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const flattened = Object.entries(options).map<[string, any] | []>(([key, value]) => {
       if (value === undefined || value === null) {
         return [];
@@ -479,6 +484,7 @@ export class WebClient extends Methods {
               // https://github.com/form-data/form-data/blob/028c21e0f93c5fefa46a7bbf1ba753e4f627ab7a/lib/form_data.js#L227-L230
               // formidable and the browser add a name property
               // fs- and request- streams have path property
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const streamOrBuffer: any = (value as any);
               if (typeof streamOrBuffer.name === 'string') {
                 return basename(streamOrBuffer.name);
@@ -508,6 +514,7 @@ export class WebClient extends Methods {
     // Otherwise, a simple key-value object is returned
     // eslint-disable-next-line no-param-reassign
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const initialValue: { [key: string]: any; } = {};
     return qsStringify(flattened.reduce(
       (accumulator, [key, value]) => {

--- a/packages/web-api/src/errors.ts
+++ b/packages/web-api/src/errors.ts
@@ -38,6 +38,7 @@ export interface WebAPIHTTPError extends CodedError {
   statusCode: number;
   statusMessage: string;
   headers: IncomingHttpHeaders;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;
 }
 

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -2075,9 +2075,11 @@ export interface WorkflowsUpdateStepArguments extends WebAPICallOptions, TokenOv
   step_name?: string;
   inputs?: {
     [name: string]: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       value: any;
       skip_variable_replacement?: boolean;
       variables?: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         [key: string]: any;
       };
     },


### PR DESCRIPTION
###  Summary

This pull request disables eslint warnings about the usage of `any` type in the internal code of `web-api` package. I think that disabling these should be safe enough.

```
> @slack/web-api@6.4.0 lint /Users/ksera/github/node-slack-sdk/packages/web-api
> eslint --ext .ts src


/Users/ksera/github/node-slack-sdk/packages/web-api/src/WebClient.ts
   83:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  381:48  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  381:62  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  427:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  448:73  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  452:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  482:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  482:53  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  511:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/ksera/github/node-slack-sdk/packages/web-api/src/errors.ts
  41:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/ksera/github/node-slack-sdk/packages/web-api/src/methods.ts
  2078:14  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2081:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 12 problems (0 errors, 12 warnings)
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
