### PR TITLE
Update the web-api response types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tmp/
 # npm pack outputs
 *.tgz
 *.bk
+
+.DS_Store

--- a/packages/web-api/src/response/UsersListResponse.ts
+++ b/packages/web-api/src/response/UsersListResponse.ts
@@ -13,37 +13,39 @@ export type UsersListResponse = WebAPICallResult & {
   ok?:                boolean;
   members?:           Member[];
   cache_ts?:          number;
-  response_metadata?: ResponseMetadata;
   offset?:            string;
+  response_metadata?: ResponseMetadata;
   error?:             string;
   needed?:            string;
   provided?:          string;
 };
 
 export interface Member {
-  id?:                  string;
-  team_id?:             string;
-  name?:                string;
-  deleted?:             boolean;
-  color?:               string;
-  real_name?:           string;
-  tz?:                  string;
-  tz_label?:            string;
-  tz_offset?:           number;
-  profile?:             Profile;
-  is_admin?:            boolean;
-  is_owner?:            boolean;
-  is_primary_owner?:    boolean;
-  is_restricted?:       boolean;
-  is_ultra_restricted?: boolean;
-  is_bot?:              boolean;
-  is_app_user?:         boolean;
-  updated?:             number;
-  has_2fa?:             boolean;
-  is_workflow_bot?:     boolean;
-  enterprise_user?:     EnterpriseUser;
-  is_invited_user?:     boolean;
-  locale?:              string;
+  id?:                         string;
+  team_id?:                    string;
+  name?:                       string;
+  deleted?:                    boolean;
+  color?:                      string;
+  real_name?:                  string;
+  tz?:                         string;
+  tz_label?:                   string;
+  tz_offset?:                  number;
+  profile?:                    Profile;
+  is_admin?:                   boolean;
+  is_owner?:                   boolean;
+  is_primary_owner?:           boolean;
+  is_restricted?:              boolean;
+  is_ultra_restricted?:        boolean;
+  is_bot?:                     boolean;
+  is_app_user?:                boolean;
+  updated?:                    number;
+  is_email_confirmed?:         boolean;
+  who_can_share_contact_card?: string;
+  is_workflow_bot?:            boolean;
+  has_2fa?:                    boolean;
+  locale?:                     string;
+  enterprise_user?:            EnterpriseUser;
+  is_invited_user?:            boolean;
 }
 
 export interface EnterpriseUser {
@@ -56,36 +58,44 @@ export interface EnterpriseUser {
 }
 
 export interface Profile {
-  title?:                   string;
-  phone?:                   string;
-  skype?:                   string;
-  real_name?:               string;
-  real_name_normalized?:    string;
-  display_name?:            string;
-  display_name_normalized?: string;
-  status_text?:             string;
-  status_emoji?:            string;
-  status_expiration?:       number;
-  avatar_hash?:             string;
-  image_original?:          string;
-  is_custom_image?:         boolean;
-  email?:                   string;
-  first_name?:              string;
-  last_name?:               string;
-  image_24?:                string;
-  image_32?:                string;
-  image_48?:                string;
-  image_72?:                string;
-  image_192?:               string;
-  image_512?:               string;
-  image_1024?:              string;
-  status_text_canonical?:   string;
-  team?:                    string;
-  api_app_id?:              string;
-  bot_id?:                  string;
-  always_active?:           boolean;
-  guest_invited_by?:        string;
-  guest_expiration_ts?:     number;
+  title?:                     string;
+  phone?:                     string;
+  skype?:                     string;
+  real_name?:                 string;
+  real_name_normalized?:      string;
+  display_name?:              string;
+  display_name_normalized?:   string;
+  status_text?:               string;
+  status_emoji?:              string;
+  status_emoji_display_info?: StatusEmojiDisplayInfo[];
+  status_expiration?:         number;
+  avatar_hash?:               string;
+  image_original?:            string;
+  is_custom_image?:           boolean;
+  email?:                     string;
+  pronouns?:                  string;
+  first_name?:                string;
+  last_name?:                 string;
+  image_24?:                  string;
+  image_32?:                  string;
+  image_48?:                  string;
+  image_72?:                  string;
+  image_192?:                 string;
+  image_512?:                 string;
+  image_1024?:                string;
+  status_text_canonical?:     string;
+  team?:                      string;
+  api_app_id?:                string;
+  bot_id?:                    string;
+  always_active?:             boolean;
+  guest_invited_by?:          string;
+  guest_expiration_ts?:       number;
+}
+
+export interface StatusEmojiDisplayInfo {
+  emoji_name?:    string;
+  display_alias?: string;
+  display_url?:   string;
 }
 
 export interface ResponseMetadata {


### PR DESCRIPTION
###  Summary

This pull request updates the web-api response types. `status_emoji_display_info` was added to the users.list API response as well.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
