### PR TITLE
deno.land continuous deployment

### DIFF
--- a/.github/workflows/deno-build.yml
+++ b/.github/workflows/deno-build.yml
@@ -41,6 +41,6 @@ jobs:
         git checkout deno-web-api
         mv ../../mod.js .
         git add mod.js
-        git commit -m 'Adding transpiled deno release artifact.'
+        git commit -m "Adding transpiled deno ${GITHUB_REF_NAME} release artifact."
         git tag "deno/${GITHUB_REF_NAME}"
         git push --tags

--- a/.github/workflows/deno-build.yml
+++ b/.github/workflows/deno-build.yml
@@ -1,0 +1,46 @@
+name: deno.land Continuous Deployment
+
+on:
+  push:
+    tags:
+      - '@slack/web-api*'
+
+defaults:
+  run:
+    shell: bash
+    working-directory: packages/web-api
+
+jobs:
+  transpile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Echo Tag Name
+      run: echo "$GITHUB_REF_NAME"
+    - uses: actions/checkout@v2
+      with:
+        # pull all tags/branches with full history;
+        # need that to checkout different branch and push artifacts later
+        fetch-depth: 0
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16
+    - name: Inject browser field and add dependencies to package.json
+      run: |
+        perl -pi.bak -e 's/"tsd": {/"browser":{"os":"os-browserify","path":"path-browserify","querystring":".\/deno-shims\/qs-shim.js"},"tsd": {/g' package.json
+        perl -pi.bak -e 's/"axios": /"path-browserify":"1.0.1","os-browserify":"0.3.0","axios": /g' package.json
+    - run: npm install
+    - run: npm run build:deno
+    - run: mv mod.js ../../.
+    - name: Commit and tag built artifact to separate branch
+      run: |
+        git config user.name slack-cicd
+        git config user.email github-cicd@slack.com
+        git checkout -- package.json
+        git checkout deno-web-api
+        mv ../../mod.js .
+        git add mod.js
+        git commit -m 'Adding transpiled deno release artifact.'
+        git tag "deno/${GITHUB_REF_NAME}"
+        git push --tags

--- a/packages/web-api/deno-shims/buffer-shim.js
+++ b/packages/web-api/deno-shims/buffer-shim.js
@@ -1,0 +1,3 @@
+import { Buffer } from "https://deno.land/std@0.112.0/node/buffer.ts"
+
+export let dummy_buffer = Buffer

--- a/packages/web-api/deno-shims/qs-shim.js
+++ b/packages/web-api/deno-shims/qs-shim.js
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.112.0/node/querystring.ts"

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -42,7 +42,8 @@
     "test:types": "tsd",
     "coverage": "codecov -F webapi --root=$PWD",
     "ref-docs:model": "api-extractor run",
-    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
+    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build",
+    "build:deno": "esbuild --bundle --define:process.cwd=String --define:process.version='\"v16.0.0\"' --define:Buffer=dummy_buffer --inject:./deno-shims/buffer-shim.js --target=esnext --format=esm --outfile=./mod.js src/index.ts"
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
@@ -60,13 +61,14 @@
   "devDependencies": {
     "@aoberoi/capture-console": "^1.1.0",
     "@microsoft/api-extractor": "^7.3.4",
-    "@typescript-eslint/eslint-plugin": "^4.4.1",
-    "@typescript-eslint/parser": "^4.4.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
+    "@typescript-eslint/eslint-plugin": "^4.4.1",
+    "@typescript-eslint/parser": "^4.4.0",
     "busboy": "^0.3.0",
     "chai": "^4.2.0",
     "codecov": "^3.2.0",
+    "esbuild": "^0.13.15",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",


### PR DESCRIPTION
###  Summary

This PR adds a new GitHub CI workflow that aims to transpile the `@slack/web-api` package into a format compatible to run in deno. Flow:

- [x] Provide the tweaks necessary to the web-api package to run in deno
- [x] Add a new `npm run` script, `npm run build:deno`, that encapsulates the transpilation command using `esbuild`
- [x] Commit and push the artifact to a separate `deno-web-api` branch
- [x] Set up a deno.land/x webhook with both [version prefixing and sub-directory support](https://github.com/denoland/deno_registry2/blob/main/API.md#post-webhookghmodule) to publish to deno.land/x/slack_web_api
- [x] Add `git tag`ging to the CI workflow on the `deno-web-api` branch that matches the deno.land webhook version prefix to connect the GitHub CI/CD workflow to publishing to deno.land