### PR TITLE
Tweaking user-agent instrumentation for deno compatibility

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -43,7 +43,7 @@
     "coverage": "codecov -F webapi --root=$PWD",
     "ref-docs:model": "api-extractor run",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build",
-    "build:deno": "esbuild --bundle --define:process.cwd=String --define:process.version='\"v16.0.0\"' --define:Buffer=dummy_buffer --inject:./deno-shims/buffer-shim.js --inject:./deno-shims/xhr-shim.js --target=esnext --format=esm --outfile=./mod.js src/index.ts"
+    "build:deno": "esbuild --bundle --define:process.cwd=String --define:process.version='\"v1.15.2\"' --define:process.title='\"deno\"' --define:Buffer=dummy_buffer --inject:./deno-shims/buffer-shim.js --inject:./deno-shims/xhr-shim.js --target=esnext --format=esm --outfile=./mod.js src/index.ts"
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",

--- a/packages/web-api/src/instrument.ts
+++ b/packages/web-api/src/instrument.ts
@@ -1,4 +1,5 @@
 import * as os from 'os';
+import { basename } from 'path';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-commonjs
 const packageJson = require('../package.json');
@@ -10,8 +11,14 @@ function replaceSlashes(s: string): string {
   return s.replace('/', ':');
 }
 
+// TODO: for the deno build (see the `npm run build:deno` npm run script), we could replace the `os-browserify` npm
+// module shim with our own shim leveraging the deno beta compatibility layer for node's `os` module (for more info
+// see https://deno.land/std@0.116.0/node/os.ts). At the time of writing this TODO (2021/11/25), this required deno
+// v1.16.2 and use of the --unstable flag. Once support for this exists without the --unstable flag, we can improve
+// the `os` module deno shim to correctly report operating system from a deno runtime. Until then, the below `os`-
+// based code will report "browser/undefined" from a deno runtime.
 const baseUserAgent = `${replaceSlashes(packageJson.name)}/${packageJson.version} ` +
-                      `node/${process.version.replace('v', '')} ` +
+                      `${basename(process.title)}/${process.version.replace('v', '')} ` +
                       `${os.platform()}/${os.release()}`;
 
 const appMetadata: { [key: string]: string } = {};


### PR DESCRIPTION
###  Summary

- Injected `process.title` and a (slightly more correct) `process.version` when building via `esbuild` for deno
- Use `process.title` when instrumenting the user-agent; this should yield a slightly more correct user-agent header string when using in deno.

Before this PR, user agent would be the following when executing in different runtimes:

- in node v16.4.2 on a mac running 11.6.1: `'User-Agent': '@slack:web-api/6.5.1 node/16.4.2 darwin/20.6.0',`
- in deno: `"User-Agent": "@slack:web-api/6.5.1 node/16.0.0 browser/undefined",`

After this PR:

- in node v16.4.2 on a mac running 11.6.1: `'User-Agent': '@slack:web-api/6.5.1 node/16.4.2 darwin/20.6.0',`
- in deno: `"User-Agent": "@slack:web-api/6.5.1 deno/1.15.2 browser/undefined",`

These are all temporary compatibility / shim polyfills. Once the compatibility layer in deno for node matures, we should be able to slowly drop all of these small tweaks.