### PR TITLE
Add focus_on_load property to views.* API responses

### DIFF
--- a/packages/web-api/src/response/AdminTeamsSettingsInfoResponse.ts
+++ b/packages/web-api/src/response/AdminTeamsSettingsInfoResponse.ts
@@ -28,6 +28,7 @@ export interface Team {
   default_channels?:  string[];
   is_verified?:       boolean;
   enterprise_domain?: string;
+  url?:               string;
 }
 
 export interface Icon {

--- a/packages/web-api/src/response/ChatScheduleMessageResponse.ts
+++ b/packages/web-api/src/response/ChatScheduleMessageResponse.ts
@@ -68,6 +68,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/ChatUpdateResponse.ts
+++ b/packages/web-api/src/response/ChatUpdateResponse.ts
@@ -71,6 +71,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/ConversationsHistoryResponse.ts
+++ b/packages/web-api/src/response/ConversationsHistoryResponse.ts
@@ -196,6 +196,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/ConversationsOpenResponse.ts
+++ b/packages/web-api/src/response/ConversationsOpenResponse.ts
@@ -84,6 +84,7 @@ export interface BlockElement {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/response/ConversationsRepliesResponse.ts
@@ -181,6 +181,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/ReactionsListResponse.ts
+++ b/packages/web-api/src/response/ReactionsListResponse.ts
@@ -89,6 +89,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/SearchAllResponse.ts
+++ b/packages/web-api/src/response/SearchAllResponse.ts
@@ -295,6 +295,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/SearchMessagesResponse.ts
+++ b/packages/web-api/src/response/SearchMessagesResponse.ts
@@ -187,6 +187,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/StarsListResponse.ts
+++ b/packages/web-api/src/response/StarsListResponse.ts
@@ -328,6 +328,7 @@ export interface Element {
   placeholder?:                     Text;
   initial_channel?:                 string;
   response_url_enabled?:            boolean;
+  focus_on_load?:                   boolean;
   initial_conversation?:            string;
   default_to_current_conversation?: boolean;
   filter?:                          Filter;

--- a/packages/web-api/src/response/TeamInfoResponse.ts
+++ b/packages/web-api/src/response/TeamInfoResponse.ts
@@ -18,13 +18,17 @@ export type TeamInfoResponse = WebAPICallResult & {
 };
 
 export interface Team {
-  id?:           string;
-  name?:         string;
-  domain?:       string;
-  email_domain?: string;
-  icon?:         Icon;
-  is_verified?:  boolean;
-  url?:          string;
+  id?:                string;
+  name?:              string;
+  domain?:            string;
+  email_domain?:      string;
+  icon?:              Icon;
+  is_verified?:       boolean;
+  url?:               string;
+  enterprise_id?:     string;
+  enterprise_name?:   string;
+  enterprise_domain?: string;
+  discoverable?:      string;
 }
 
 export interface Icon {

--- a/packages/web-api/src/response/TeamInfoResponse.ts
+++ b/packages/web-api/src/response/TeamInfoResponse.ts
@@ -24,6 +24,7 @@ export interface Team {
   email_domain?: string;
   icon?:         Icon;
   is_verified?:  boolean;
+  url?:          string;
 }
 
 export interface Icon {

--- a/packages/web-api/src/response/ViewsOpenResponse.ts
+++ b/packages/web-api/src/response/ViewsOpenResponse.ts
@@ -86,6 +86,7 @@ export interface Element {
   min_length?:                      number;
   max_length?:                      number;
   dispatch_action_config?:          DispatchActionConfig;
+  focus_on_load?:                   boolean;
   options?:                         Option[];
   initial_option?:                  Option;
   confirm?:                         Confirm;

--- a/packages/web-api/src/response/ViewsPublishResponse.ts
+++ b/packages/web-api/src/response/ViewsPublishResponse.ts
@@ -86,6 +86,7 @@ export interface Element {
   min_length?:                      number;
   max_length?:                      number;
   dispatch_action_config?:          DispatchActionConfig;
+  focus_on_load?:                   boolean;
   options?:                         Option[];
   initial_option?:                  Option;
   confirm?:                         Confirm;

--- a/packages/web-api/src/response/ViewsPushResponse.ts
+++ b/packages/web-api/src/response/ViewsPushResponse.ts
@@ -86,6 +86,7 @@ export interface Element {
   min_length?:                      number;
   max_length?:                      number;
   dispatch_action_config?:          DispatchActionConfig;
+  focus_on_load?:                   boolean;
   options?:                         Option[];
   initial_option?:                  Option;
   confirm?:                         Confirm;

--- a/packages/web-api/src/response/ViewsUpdateResponse.ts
+++ b/packages/web-api/src/response/ViewsUpdateResponse.ts
@@ -86,6 +86,7 @@ export interface Element {
   min_length?:                      number;
   max_length?:                      number;
   dispatch_action_config?:          DispatchActionConfig;
+  focus_on_load?:                   boolean;
   options?:                         Option[];
   initial_option?:                  Option;
   confirm?:                         Confirm;


### PR DESCRIPTION
###  Summary

This pull request adds focus_on_load in the `views.*` API responses. Also, `url` was added to `team` data recently.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
