### PR TITLE
Add git stale action

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,0 +1,33 @@
+# This workflow uses the following github action to automate
+# management of stale issues and prs in this repo:
+# https://github.com/marketplace/actions/close-stale-issues
+
+name: Close stale issues and PRs
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+  
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 10
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: auto-triage-stale
+          stale-issue-message: 👋 It looks like this issue has been open for 30 days with no activity. We'll mark this as stale for now, and wait 10 days for an update or for further comment before closing this issue out.
+          close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thank you to all the participants! If you would like to raise a related issue, please create a new issue which includes your specific details and references this issue number.
+          exempt-issue-labels: auto-triage-skip
+          exempt-all-milestones: true
+          remove-stale-when-updated: true
+          enable-statistics: true
+          operations-per-run: 60


### PR DESCRIPTION
###  Summary

This PR adds an action which will automate stale-ing and closing inactive issues. This action does not impact:  

* open PRs
* issues attached to any release milestones, e.g. `3.x.`
* issues explicitly tagged with the label `auto-triage-skip`. 

_For inactive issues:_
* At 30-days old w/ no activity: The action will mark the issue with `auto-triage-stale` label and post a message in thread notifying all participants that after 10 further days w/out activity, the issue will be closed.
* At 10 days after marked stale w/ no activity: Action will close the issue

For maintainers, and for the wider community: 

👋  The goal with these changes is to make sure that issues are staying updated, as activity is the best indicator that it will be resolved! That means, if `more info` is needed and you need a bit more time to investigate, or if we need more time to investigate an issue internally, the best way to keep the issue updated is to post a comment! 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
