### PR TITLE
web-api deno build: tweaks and improvements for type hint support

### DIFF
--- a/.github/workflows/deno-build.yml
+++ b/.github/workflows/deno-build.yml
@@ -26,21 +26,22 @@ jobs:
         node-version: 16
     - name: Echo Tag Name
       run: echo "$GITHUB_REF_NAME"
-    - name: Inject browser field and add dependencies to package.json
-      run: |
-        perl -pi.bak -e 's/"tsd": {/"browser":{"os":"os-browserify","path":"path-browserify","querystring":".\/deno-shims\/qs-shim.js"},"tsd": {/g' package.json
-        perl -pi.bak -e 's/"axios": /"path-browserify":"1.0.1","os-browserify":"0.3.0","axios": /g' package.json
+    - name: Inject browser field to package.json
+      run: npm run prepare:deno
     - run: npm install
     - run: npm run build:deno
-    - run: mv mod.js ../../.
+    - name: Concatenate .d.ts files into one declaration file for use in Deno
+      run: |
+        find dist -type f -name '*.d.ts' -exec cat {} \; > mod.d.ts
+    - run: mv mod.js mod.d.ts ../../.
     - name: Commit and tag built artifact to separate branch
       run: |
         git config user.name slack-cicd
         git config user.email github-cicd@slack.com
         git checkout -- package.json
         git checkout deno-web-api
-        mv ../../mod.js .
-        git add mod.js
-        git commit -m "Adding transpiled deno ${GITHUB_REF_NAME} release artifact."
+        mv ../../mod.js ../../mod.d.ts .
+        git add mod.js mod.d.ts
+        git commit -m "Adding transpiled deno ${GITHUB_REF_NAME} release artifacts."
         git tag "deno/${GITHUB_REF_NAME}"
         git push --tags

--- a/packages/web-api/deno-shims/buffer-shim.js
+++ b/packages/web-api/deno-shims/buffer-shim.js
@@ -1,3 +1,2 @@
 import { Buffer } from "https://deno.land/std@0.112.0/node/buffer.ts"
-
 export let dummy_buffer = Buffer

--- a/packages/web-api/deno-shims/os-shim.js
+++ b/packages/web-api/deno-shims/os-shim.js
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.116.0/node/os.ts"

--- a/packages/web-api/deno-shims/path-shim.js
+++ b/packages/web-api/deno-shims/path-shim.js
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.116.0/node/path.ts"

--- a/packages/web-api/deno-shims/process-shim.js
+++ b/packages/web-api/deno-shims/process-shim.js
@@ -1,0 +1,9 @@
+import { cwd } from "https://deno.land/std@0.116.0/node/process.ts";
+const title = 'deno';
+const version = Deno.version.deno;
+let process = {
+  cwd,
+  title,
+  version,
+};
+export let dummy_process = process;

--- a/packages/web-api/deno-shims/qs-shim.js
+++ b/packages/web-api/deno-shims/qs-shim.js
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.112.0/node/querystring.ts"
+export * from "https://deno.land/std@0.116.0/node/querystring.ts"

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -34,16 +34,17 @@
   },
   "scripts": {
     "prepare": "npm run build",
+    "prepare:deno": "perl -pi.bak -e 's/\"tsd\": {/\"browser\":{\"os\":\".\\/deno-shims\\/os-shim.js\",\"path\":\".\\/deno-shims\\/path-shim.js\",\"querystring\":\".\\/deno-shims\\/qs-shim.js\"},\"tsd\": {/g' package.json",
     "build": "npm run build:clean && tsc",
-    "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
+    "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output mod.js",
+    "build:deno": "rm -f mod.js mod.d.ts && esbuild src/index.ts --bundle --define:Buffer=dummy_buffer --inject:./deno-shims/buffer-shim.js --inject:./deno-shims/xhr-shim.js --define:process=dummy_process --inject:./deno-shims/process-shim.js --target=esnext --format=esm --outfile=./mod.js",
     "lint": "eslint --ext .ts src",
     "test": "npm run lint && npm run build && npm run test:mocha && npm run test:types",
     "test:mocha": "nyc mocha --config .mocharc.json src/*.spec.js",
     "test:types": "tsd",
     "coverage": "codecov -F webapi --root=$PWD",
     "ref-docs:model": "api-extractor run",
-    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build",
-    "build:deno": "esbuild --bundle --define:process.cwd=String --define:process.version='\"v1.15.2\"' --define:process.title='\"deno\"' --define:Buffer=dummy_buffer --inject:./deno-shims/buffer-shim.js --inject:./deno-shims/xhr-shim.js --target=esnext --format=esm --outfile=./mod.js src/index.ts"
+    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",


### PR DESCRIPTION
###  Summary

- Reorganizing some of the package.json hax into `npm run` scripts for easier deno building locally.
- Removing the need to install additional dependencies and moving to custom-built deno+node shims for most built-in node modules.
- Using shim file approach for the `process` node module, rather than hard-coded strings and too-simplistic symbol substitution.
- Tweaking GitHub Actions workflow to concatenate all built web-api d.ts files into one for use with the deno build.

### Testing

To test this out, pull this branch in and run (NOTE: Linux/Mac only):

```
npm run prepare:deno # this command will mess with your package.json
npm install
npm run build:deno # use esbuild to build the deno artifact, which will be named mod.js
find dist -type f -name '*.d.ts' -exec cat {} \; > mod.d.ts # builds a mod.d.ts sidekick for mod.js
git checkout -- package.json # clean up your package.json from step 1
```

Then in vscode, create a new JS / Deno / TypeScript project and start with:

```
import { WebClient, /* whatever else from web-api */ } from './path/to/mod.js';
```

Then give the autocomplete bits a shot! It should be identical to the existing node build