### PR TITLE
[betaFeatures] Add Subscribe in Slack API methods

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -443,3 +443,9 @@ export interface CallUserExternal {
   display_name: string;
   avatar_url: string;
 }
+
+export interface Metadata {
+  event_type: string;
+  event_payload: object;
+  notification_subscription_id: string;
+}

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1,5 +1,5 @@
 import { Stream } from 'stream';
-import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser } from '@slack/types';
+import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser, Metadata } from '@slack/types';
 import { EventEmitter } from 'eventemitter3';
 import { WebAPICallOptions, WebAPICallResult, WebClient, WebClientEvent } from './WebClient';
 import {
@@ -458,6 +458,13 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         list: bindApiCall<AppsEventAuthorizationsListArguments, AppsEventAuthorizationsListResponse>(
           this, 'apps.event.authorizations.list',
         ),
+      },
+    },
+    notifications: {
+      subscriptions: {
+        create: bindApiCall<AppsNotificationsSubscriptionsCreateArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.create'),
+        delete: bindApiCall<AppsNotificationsSubscriptionsDeleteArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.delete'),
+        update: bindApiCall<AppsNotificationsSubscriptionsUpdateArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.update'),
       },
     },
     uninstall: bindApiCall<AppsUninstallArguments, AppsUninstallResponse>(this, 'apps.uninstall'),
@@ -1179,6 +1186,25 @@ export interface AppsEventAuthorizationsListArguments
   event_context: string;
 }
 cursorPaginationEnabledMethods.add('apps.event.authorizations.list');
+
+export interface AppsNotificationsSubscriptionsCreateArguments extends WebAPICallOptions {
+  trigger_id: string;
+  channel_id: string;
+  name: string;
+  type?: string;
+  resource_link?: string;
+}
+
+export interface AppsNotificationsSubscriptionsDeleteArguments extends WebAPICallOptions {
+  notification_subscription_id: string;
+}
+
+export interface AppsNotificationsSubscriptionsUpdateArguments extends WebAPICallOptions {
+  notification_subscription_id: string;
+  channel_id: string;
+  trigger_id: string;
+}
+
 export interface AppsUninstallArguments extends WebAPICallOptions {
   client_id: string;
   client_secret: string;
@@ -1361,6 +1387,7 @@ export interface ChatPostMessageArguments extends WebAPICallOptions, TokenOverri
   unfurl_links?: boolean;
   unfurl_media?: boolean;
   username?: string; // if specified, as_user must be false
+  metadata?: Metadata;
 }
 export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOverridable {
   channel: string;
@@ -1402,7 +1429,9 @@ export interface ChatUpdateArguments extends WebAPICallOptions, TokenOverridable
   blocks?: (KnownBlock | Block)[];
   link_names?: boolean;
   parse?: 'full' | 'none';
+  reply_broadcast?: boolean;
   text?: string;
+  metadata?: Metadata;
 }
 
 /*


### PR DESCRIPTION
###  Summary

These changes were previously released as part of hermesBeta.1 to support beta release of Message Metadata features but changes were lost, so re-adding: 
* @slack/types - `Metadata` types object with Metadata fields
* @slack/webapi - Adds `metadata` field to `chat.postMessage` and `chat.update` arguments

These new changes are added to support upcoming Subscribe in Slack feature:
* @slack/types - Adds `notification_subscription_id` field to `Metadata`
* @slack/webapi - Adds [apps.notifications.subscriptions.* methods](https://api.slack.com/partners/ez-subscribe#incoming). Once java-slack-sdk Response types are updated, we can run the auto-gen script to update these as well. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
