### PR TITLE
Update the web-api response types with the latest data source

### DIFF
--- a/packages/web-api/src/response/ConversationsHistoryResponse.ts
+++ b/packages/web-api/src/response/ConversationsHistoryResponse.ts
@@ -161,10 +161,8 @@ export interface Metadata {
 
 export interface Block {
   type?:         string;
-  block_id?:     string;
-  text?:         Text;
-  accessory?:    Accessory;
   elements?:     Element[];
+  block_id?:     string;
   fallback?:     string;
   image_url?:    string;
   image_width?:  number;
@@ -172,25 +170,27 @@ export interface Block {
   image_bytes?:  number;
   alt_text?:     string;
   title?:        Text;
+  text?:         Text;
   fields?:       Text[];
+  accessory?:    Accessory;
 }
 
 export interface Accessory {
-  fallback?:     string;
+  type?:         string;
   image_url?:    string;
+  alt_text?:     string;
+  fallback?:     string;
   image_width?:  number;
   image_height?: number;
   image_bytes?:  number;
-  type?:         string;
-  alt_text?:     string;
 }
 
 export interface Element {
   type?:                            string;
-  action_id?:                       string;
   text?:                            Text;
-  value?:                           string;
+  action_id?:                       string;
   url?:                             string;
+  value?:                           string;
   style?:                           string;
   confirm?:                         ElementConfirm;
   placeholder?:                     Text;

--- a/packages/web-api/src/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/response/ConversationsRepliesResponse.ts
@@ -37,6 +37,10 @@ export interface Message {
   is_locked?:         boolean;
   blocks?:            Block[];
   attachments?:       Attachment[];
+  last_read?:         string;
+  files?:             File[];
+  upload?:            boolean;
+  display_as_bot?:    boolean;
 }
 
 export interface Attachment {
@@ -239,6 +243,132 @@ export interface Icons {
   image_36?: string;
   image_48?: string;
   image_72?: string;
+}
+
+export interface File {
+  id?:                        string;
+  created?:                   number;
+  timestamp?:                 number;
+  name?:                      string;
+  title?:                     string;
+  subject?:                   string;
+  mimetype?:                  string;
+  filetype?:                  string;
+  pretty_type?:               string;
+  user?:                      string;
+  mode?:                      string;
+  editable?:                  boolean;
+  non_owner_editable?:        boolean;
+  editor?:                    string;
+  last_editor?:               string;
+  updated?:                   number;
+  original_attachment_count?: number;
+  is_external?:               boolean;
+  external_type?:             string;
+  external_id?:               string;
+  external_url?:              string;
+  username?:                  string;
+  size?:                      number;
+  url_private?:               string;
+  url_private_download?:      string;
+  app_id?:                    string;
+  app_name?:                  string;
+  thumb_64?:                  string;
+  thumb_64_gif?:              string;
+  thumb_64_w?:                string;
+  thumb_64_h?:                string;
+  thumb_80?:                  string;
+  thumb_80_gif?:              string;
+  thumb_80_w?:                string;
+  thumb_80_h?:                string;
+  thumb_160?:                 string;
+  thumb_160_gif?:             string;
+  thumb_160_w?:               string;
+  thumb_160_h?:               string;
+  thumb_360?:                 string;
+  thumb_360_gif?:             string;
+  thumb_360_w?:               string;
+  thumb_360_h?:               string;
+  thumb_480?:                 string;
+  thumb_480_gif?:             string;
+  thumb_480_w?:               string;
+  thumb_480_h?:               string;
+  thumb_720?:                 string;
+  thumb_720_gif?:             string;
+  thumb_720_w?:               string;
+  thumb_720_h?:               string;
+  thumb_800?:                 string;
+  thumb_800_gif?:             string;
+  thumb_800_w?:               string;
+  thumb_800_h?:               string;
+  thumb_960?:                 string;
+  thumb_960_gif?:             string;
+  thumb_960_w?:               string;
+  thumb_960_h?:               string;
+  thumb_1024?:                string;
+  thumb_1024_gif?:            string;
+  thumb_1024_w?:              string;
+  thumb_1024_h?:              string;
+  thumb_video?:               string;
+  thumb_gif?:                 string;
+  thumb_pdf?:                 string;
+  thumb_pdf_w?:               string;
+  thumb_pdf_h?:               string;
+  thumb_tiny?:                string;
+  converted_pdf?:             string;
+  image_exif_rotation?:       number;
+  original_w?:                string;
+  original_h?:                string;
+  deanimate?:                 string;
+  deanimate_gif?:             string;
+  pjpeg?:                     string;
+  permalink?:                 string;
+  permalink_public?:          string;
+  edit_link?:                 string;
+  has_rich_preview?:          boolean;
+  media_display_type?:        string;
+  preview_is_truncated?:      boolean;
+  preview?:                   string;
+  preview_highlight?:         string;
+  plain_text?:                string;
+  preview_plain_text?:        string;
+  has_more?:                  boolean;
+  sent_to_self?:              boolean;
+  lines?:                     number;
+  lines_more?:                number;
+  is_public?:                 boolean;
+  public_url_shared?:         boolean;
+  display_as_bot?:            boolean;
+  shares?:                    Shares;
+  channel_actions_ts?:        string;
+  channel_actions_count?:     number;
+  headers?:                   Headers;
+  simplified_html?:           string;
+  bot_id?:                    string;
+  initial_comment?:           InitialComment;
+  num_stars?:                 number;
+  is_starred?:                boolean;
+  comments_count?:            number;
+}
+
+export interface Headers {
+  date?:        string;
+  in_reply_to?: string;
+  reply_to?:    string;
+  message_id?:  string;
+}
+
+export interface InitialComment {
+  id?:        string;
+  created?:   number;
+  timestamp?: number;
+  user?:      string;
+  comment?:   string;
+  channel?:   string;
+  is_intro?:  boolean;
+}
+
+export interface Shares {
 }
 
 export interface ResponseMetadata {

--- a/packages/web-api/src/response/SearchAllResponse.ts
+++ b/packages/web-api/src/response/SearchAllResponse.ts
@@ -154,24 +154,30 @@ export interface MessagesMatch {
 }
 
 export interface Attachment {
-  msg_subtype?:           string;
+  service_name?:          string;
+  title?:                 string;
+  title_link?:            string;
+  text?:                  string;
   fallback?:              string;
+  thumb_url?:             string;
+  from_url?:              string;
+  thumb_width?:           number;
+  thumb_height?:          number;
+  service_icon?:          string;
+  id?:                    number;
+  original_url?:          string;
+  msg_subtype?:           string;
   callback_id?:           string;
   color?:                 string;
   pretext?:               string;
   service_url?:           string;
-  service_name?:          string;
-  service_icon?:          string;
   author_id?:             string;
   author_name?:           string;
   author_link?:           string;
   author_icon?:           string;
-  from_url?:              string;
-  original_url?:          string;
   author_subname?:        string;
   channel_id?:            string;
   channel_name?:          string;
-  id?:                    number;
   bot_id?:                string;
   indent?:                boolean;
   is_msg_unfurl?:         boolean;
@@ -179,17 +185,11 @@ export interface Attachment {
   is_thread_root_unfurl?: boolean;
   is_app_unfurl?:         boolean;
   app_unfurl_url?:        string;
-  title?:                 string;
-  title_link?:            string;
-  text?:                  string;
   fields?:                Field[];
   image_url?:             string;
   image_width?:           number;
   image_height?:          number;
   image_bytes?:           number;
-  thumb_url?:             string;
-  thumb_width?:           number;
-  thumb_height?:          number;
   video_url?:             string;
   video_html?:            string;
   video_html_width?:      number;


### PR DESCRIPTION
###  Summary

This pull request re-generates all the web-api response types. The main improvement is to have `files` and related properties in `conversations.replies` API responses.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
