### PR TITLE
Fix #1409 installerOptions.failure() options can be undefined

### DIFF
--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -447,6 +447,7 @@ describe('OAuth', async () => {
           assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
+          assert.isDefined(installOptions);
           assert.equal(error.code, ErrorCode.MissingCodeError)
           res.send('failure');
         },
@@ -466,6 +467,7 @@ describe('OAuth', async () => {
           assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
+          assert.isDefined(installOptions);
           assert.equal(error.code, ErrorCode.MissingStateError)
           res.send('failure');
         },
@@ -504,6 +506,7 @@ describe('OAuth', async () => {
           assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
+          assert.isDefined(installOptions);
           assert.equal(error.code, ErrorCode.AuthorizationError)
           res.send('failure');
         },
@@ -566,7 +569,6 @@ describe('OAuth', async () => {
         },
         failure: async (error, installOptions, req, res) => {
           assert.fail(error.message);
-          res.send('failure');
         },
       }
 
@@ -588,7 +590,6 @@ describe('OAuth', async () => {
         },
         failure: async (error, installOptions, req, res) => {
           assert.fail(error.message);
-          res.send('failure');
         },
       }
 

--- a/packages/oauth/src/index.spec.js
+++ b/packages/oauth/src/index.spec.js
@@ -437,7 +437,7 @@ describe('OAuth', async () => {
         verifyStateParam: sinon.fake.resolves({})
       }
     });
-    it('should call the failure callback due to missing code query parameter on the URL', async () => {
+    it('should call the failure callback with a valid installOptions due to missing code query parameter on the URL', async () => {
       const req = { headers: { host: 'example.com'},  url: 'http://example.com' };
       let sent = false;
       const res = { send: () => { sent = true; } };
@@ -447,8 +447,10 @@ describe('OAuth', async () => {
           assert.fail('should have failed');
         },
         failure: async (error, installOptions, req, res) => {
+          // To detect future regressions, we verify if there is a valid installOptions here
+          // Refer to https://github.com/slackapi/node-slack-sdk/pull/1410 for the context
           assert.isDefined(installOptions);
-          assert.equal(error.code, ErrorCode.MissingCodeError)
+          assert.equal(error.code, ErrorCode.MissingCodeError);
           res.send('failure');
         },
       }

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -515,13 +515,20 @@ export class InstallProvider {
     } catch (error: any) {
       this.logger.error(error);
 
+      if (!installOptions) {
+        // To make the `installOptions` type compatible with `CallbackOptions#failure` signature
+        const emptyInstallOptions: InstallURLOptions = { scopes: [] };
+        // eslint-disable-next-line no-param-reassign
+        installOptions = emptyInstallOptions;
+      }
+
       // Call the failure callback
       if (options !== undefined && options.failure !== undefined) {
         this.logger.debug('calling passed in options.failure');
-        options.failure(error, installOptions!, req, res);
+        options.failure(error, installOptions, req, res);
       } else {
         this.logger.debug('run built-in failure function');
-        callbackFailure(error, installOptions!, req, res);
+        callbackFailure(error, installOptions, req, res);
       }
     }
   }


### PR DESCRIPTION
###  Summary

This pull request resolves #1409 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
