### PR TITLE
Add admin.apps.requests.cancel API method support

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -201,6 +201,7 @@ import {
   WorkflowsStepCompletedResponse,
   WorkflowsStepFailedResponse,
   WorkflowsUpdateStepResponse,
+  AdminAppsRequestsCancelResponse,
 } from './response';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -249,6 +250,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       },
       clearResolution: bindApiCall<AdminAppsClearResolutionArguments, AdminAppsClearResolutionResponse>(this, 'admin.apps.clearResolution'),
       requests: {
+        cancel: bindApiCall<AdminAppsRequestsCancelArguments, AdminAppsRequestsCancelResponse>(this, 'admin.apps.requests.cancel'),
         list: bindApiCall<AdminAppsRequestsListArguments, AdminAppsRequestsListResponse>(this, 'admin.apps.requests.list'),
       },
       restrict: bindApiCall<AdminAppsRestrictArguments, AdminAppsRestrictResponse>(this, 'admin.apps.restrict'),
@@ -841,6 +843,11 @@ export interface AdminAppsClearResolutionArguments extends WebAPICallOptions {
   team_id?: string;
 }
 cursorPaginationEnabledMethods.add('admin.apps.approved.list');
+export interface AdminAppsRequestsCancelArguments extends WebAPICallOptions, TokenOverridable {
+  request_id: string;
+  enterprise_id?: string;
+  team_id?: string;
+}
 export interface AdminAppsRequestsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id?: string;
 }


### PR DESCRIPTION
###  Summary

This pull request adds [admin.apps.requests.cancel API method](https://api.slack.com/methods/admin.apps.requests.cancel) support to this SDK.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
