### PR TITLE
Add SubscriptionConfigureView

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,7 +61,17 @@ export interface WorkflowStepView {
   external_id?: string;
 }
 
-export type View = HomeView | ModalView | WorkflowStepView;
+export interface SubscriptionConfigureView {
+  type: 'app_notification_subscription_configuration';
+  title: PlainTextElement;
+  blocks: (KnownBlock | Block)[];
+  close?: PlainTextElement;
+  submit?: PlainTextElement;
+  callback_id?: string;
+  private_metadata?: string;
+}
+
+export type View = HomeView | ModalView | WorkflowStepView | SubscriptionConfigureView;
 
 /*
  * Block Elements


### PR DESCRIPTION
###  Summary

Adds a `SubscriptionConfigureView` type as part of Subscribe in Slack beta support. A `SubscriptionConfigureView` is a view payload of type `app_notification_subscription_configuration`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
