### PR TITLE
Upgrade lerna to fix npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-plugin-jsdoc": "^30.6.1",
-    "lerna": "^3.13.1"
+    "lerna": "^4.0.0"
   }
 }


### PR DESCRIPTION
###  Summary

This pull request upgrades lerna major version to fix high-level npm audit warnings:

```
$ npm audit
# npm audit report

ansi-regex  >2.1.1 <5.0.1
Severity: moderate
 Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
fix available via `npm audit fix --force`
Will install lerna@4.0.0, which is a breaking change
node_modules/cliui/node_modules/ansi-regex
node_modules/inquirer/node_modules/ansi-regex
node_modules/string-width/node_modules/ansi-regex
node_modules/wrap-ansi/node_modules/ansi-regex
node_modules/yargs/node_modules/ansi-regex
  strip-ansi  4.0.0 - 5.2.0
  Depends on vulnerable versions of ansi-regex
  node_modules/cliui/node_modules/strip-ansi
  node_modules/inquirer/node_modules/strip-ansi
  node_modules/string-width/node_modules/strip-ansi
  node_modules/wrap-ansi/node_modules/strip-ansi
  node_modules/yargs/node_modules/strip-ansi
    cliui  4.0.0 - 5.0.0
    Depends on vulnerable versions of strip-ansi
    Depends on vulnerable versions of wrap-ansi
    node_modules/cliui
      yargs  10.1.0 - 15.0.0
      Depends on vulnerable versions of cliui
      Depends on vulnerable versions of string-width
      node_modules/yargs
        @lerna/cli  3.18.0 - 3.18.5
        Depends on vulnerable versions of yargs
        node_modules/@lerna/cli
          lerna  3.2.0 - 3.22.1
          Depends on vulnerable versions of @lerna/cli
          Depends on vulnerable versions of @lerna/create
          Depends on vulnerable versions of @lerna/info
          node_modules/lerna
    inquirer  3.2.0 - 7.0.4
    Depends on vulnerable versions of string-width
    Depends on vulnerable versions of strip-ansi
    node_modules/inquirer
      @lerna/prompt  <=3.18.5
      Depends on vulnerable versions of inquirer
      node_modules/@lerna/prompt
        @lerna/clean  <=3.21.0
        Depends on vulnerable versions of @lerna/prompt
        node_modules/@lerna/clean
        @lerna/import  <=3.22.0
        Depends on vulnerable versions of @lerna/prompt
        node_modules/@lerna/import
        @lerna/otplease  <=3.18.5
        Depends on vulnerable versions of @lerna/prompt
        node_modules/@lerna/otplease
          @lerna/npm-dist-tag  3.14.0 - 3.18.5
          Depends on vulnerable versions of @lerna/otplease
          node_modules/@lerna/npm-dist-tag
            @lerna/publish  <=3.22.1
            Depends on vulnerable versions of @lerna/command
            Depends on vulnerable versions of @lerna/npm-dist-tag
            Depends on vulnerable versions of @lerna/otplease
            Depends on vulnerable versions of @lerna/prompt
            node_modules/@lerna/publish
          @lerna/npm-publish  3.14.0 - 3.18.5
          Depends on vulnerable versions of @lerna/otplease
          node_modules/@lerna/npm-publish
    string-width  2.1.0 - 4.1.0
    Depends on vulnerable versions of strip-ansi
    node_modules/cliui/node_modules/string-width
    node_modules/string-width
    node_modules/wrap-ansi/node_modules/string-width
    node_modules/yargs/node_modules/string-width
      wrap-ansi  3.0.0 - 6.1.0
      Depends on vulnerable versions of string-width
      Depends on vulnerable versions of strip-ansi
      node_modules/wrap-ansi

glob-parent  <5.1.2
Severity: high
Regular expression denial of service - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install lerna@4.0.0, which is a breaking change
node_modules/fast-glob/node_modules/glob-parent
  fast-glob  <=2.2.7
  Depends on vulnerable versions of glob-parent
  node_modules/fast-glob
    globby  8.0.0 - 9.2.0
    Depends on vulnerable versions of fast-glob
    node_modules/globby
      @lerna/create  <=3.22.0
      Depends on vulnerable versions of globby
      node_modules/@lerna/create
        lerna  3.2.0 - 3.22.1
        Depends on vulnerable versions of @lerna/cli
        Depends on vulnerable versions of @lerna/create
        Depends on vulnerable versions of @lerna/info
        node_modules/lerna
      @lerna/project  <=3.21.0
      Depends on vulnerable versions of globby
      node_modules/@lerna/project
        @lerna/command  <=3.21.0
        Depends on vulnerable versions of @lerna/project
        node_modules/@lerna/command
          @lerna/add  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/add
          @lerna/bootstrap  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/bootstrap
          @lerna/changed  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/changed
          @lerna/diff  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/diff
          @lerna/exec  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/exec
          @lerna/info  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/info
          @lerna/init  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/init
          @lerna/link  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/link
          @lerna/list  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/list
          @lerna/publish  <=3.22.1
          Depends on vulnerable versions of @lerna/command
          Depends on vulnerable versions of @lerna/npm-dist-tag
          Depends on vulnerable versions of @lerna/otplease
          Depends on vulnerable versions of @lerna/prompt
          node_modules/@lerna/publish
          @lerna/run  <=3.21.0
          Depends on vulnerable versions of @lerna/command
          node_modules/@lerna/run

trim-newlines  <3.0.1
Severity: high
Regular Expression Denial of Service in trim-newlines - https://github.com/advisories/GHSA-7p7h-4mm5-852v
fix available via `npm audit fix`
node_modules/conventional-recommended-bump/node_modules/trim-newlines
node_modules/get-pkg-repo/node_modules/trim-newlines
node_modules/git-raw-commits/node_modules/trim-newlines
node_modules/git-semver-tags/node_modules/trim-newlines
  meow  3.4.0 - 5.0.0
  Depends on vulnerable versions of trim-newlines
  node_modules/conventional-recommended-bump/node_modules/meow
  node_modules/get-pkg-repo/node_modules/meow
  node_modules/git-raw-commits/node_modules/meow
  node_modules/git-semver-tags/node_modules/meow
    conventional-recommended-bump  2.0.6 - 6.0.11
    Depends on vulnerable versions of git-raw-commits
    Depends on vulnerable versions of meow
    node_modules/conventional-recommended-bump
      @lerna/conventional-commits  <=3.22.0
      Depends on vulnerable versions of conventional-recommended-bump
      node_modules/@lerna/conventional-commits
        @lerna/version  <=3.22.1
        Depends on vulnerable versions of @lerna/conventional-commits
        node_modules/@lerna/version
    git-raw-commits  1.3.4 - 2.0.3
    Depends on vulnerable versions of meow
    node_modules/git-raw-commits
      conventional-changelog-core  2.0.5 - 4.2.1
      Depends on vulnerable versions of git-raw-commits
      Depends on vulnerable versions of git-semver-tags
      node_modules/conventional-changelog-core
    git-semver-tags  1.3.4 - 3.0.1
    Depends on vulnerable versions of meow
    node_modules/git-semver-tags

40 vulnerabilities (14 moderate, 26 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
