### PR TITLE
Fix eslint warnings and TODOs in OAuth module

### DIFF
--- a/examples/oauth-v2/link.sh
+++ b/examples/oauth-v2/link.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+current_dir=`dirname $0`
+cd ${current_dir}
+npm unlink @slack/oauth \
+  && npm i \
+  && cd ../../packages/oauth \
+  && npm link \
+  && cd - \
+  && npm i \
+  && npm link @slack/oauth
+

--- a/examples/oauth-v2/package.json
+++ b/examples/oauth-v2/package.json
@@ -11,7 +11,7 @@
   "repository": "slackapi/node-slack-sdk",
   "dependencies": {
     "@slack/events-api": "^2.3.2",
-    "@slack/oauth": "feat-org-apps",
+    "@slack/oauth": "^2.4.0",
     "@slack/web-api": "^5.8.0",
     "express": "^4.17.1",
     "keyv": "^4.0.0"

--- a/examples/oauth-v2/unlink.sh
+++ b/examples/oauth-v2/unlink.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf node_modules/
+npm i @slack/oauth

--- a/packages/oauth/src/install-provider.spec.js
+++ b/packages/oauth/src/install-provider.spec.js
@@ -403,7 +403,7 @@ describe('InstallProvider', async () => {
         assert.fail('Should have failed');
       } catch (error) {
         assert.equal(error.code, ErrorCode.AuthorizationError);
-        assert.equal(error.message, 'Failed fetching data from the Installation Store');
+        assert.equal(error.message, 'Failed fetching data from the Installation Store (source: {"teamId":"non_existing_team_id"})');
       }
     });
 


### PR DESCRIPTION
###  Summary

As a preparation before further development on the OAuth module, this pull request resolves the following issues and TODOs:

* eslint warnings (the following ones plus disabled ones)
* TODOs such as user token retrieval in FileInstallationStore

```
  200:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  241:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  521:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  797:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
