### PR TITLE
Add bookmarks.* API methods

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -203,6 +203,10 @@ import {
   WorkflowsStepFailedResponse,
   WorkflowsUpdateStepResponse,
   AdminAppsRequestsCancelResponse,
+  BookmarksAddResponse,
+  BookmarksEditResponse,
+  BookmarksListResponse,
+  BookmarksRemoveResponse,
 } from './response';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -481,6 +485,13 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
 
   public readonly bots = {
     info: bindApiCall<BotsInfoArguments, BotsInfoResponse>(this, 'bots.info'),
+  };
+
+  public readonly bookmarks = {
+    add: bindApiCall<BookmarksAddArguments, BookmarksAddResponse>(this, 'bookmarks.add'),
+    edit: bindApiCall<BookmarksEditArguments, BookmarksEditResponse>(this, 'bookmarks.edit'),
+    list: bindApiCall<BookmarksListArguments, BookmarksListResponse>(this, 'bookmarks.list'),
+    remove: bindApiCall<BookmarksRemoveArguments, BookmarksRemoveResponse>(this, 'bookmarks.remove'),
   };
 
   public readonly calls = {
@@ -1220,6 +1231,36 @@ export interface AuthTestArguments extends WebAPICallOptions, TokenOverridable {
 export interface BotsInfoArguments extends WebAPICallOptions, TokenOverridable {
   bot?: string;
   team_id?: string;
+}
+
+/*
+ * `bookmarks.*`
+ */
+export interface BookmarksAddArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+  title: string;
+  type: string;
+  emoji?: string;
+  entity_id?: string;
+  link?: string;
+  parent_id?: string;
+}
+
+export interface BookmarksEditArguments extends WebAPICallOptions, TokenOverridable {
+  bookmark_id: string;
+  channel_id: string;
+  emoji?: string;
+  link?: string;
+  title?: string;
+}
+
+export interface BookmarksListArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+}
+
+export interface BookmarksRemoveArguments extends WebAPICallOptions, TokenOverridable {
+  bookmark_id: string;
+  channel_id: string;
 }
 
 /*

--- a/prod-server-integration-tests/test/bookmarks-web-api.js
+++ b/prod-server-integration-tests/test/bookmarks-web-api.js
@@ -1,0 +1,68 @@
+// npx mocha --timeout 10000 test/bookmarks-web-api.js
+// run above from /prod-server-integration-tests
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+describe('bookmarks.* Web APIs', async function() {
+  // export SLACK_SDK_TEST_BOT_TOKEN=xoxb-<your token here>
+  // token used must have bookmarks:read, bookmarks:write scopes and channels:manage scopes to run tests properly
+
+  const client = new WebClient(process.env.SLACK_SDK_TEST_BOT_TOKEN, { logger, });
+
+  describe('bookmarks.{list|add|edit|remove}', async function () {
+    it('should work', async function () {
+      // prepare channel
+      const channelRes = await client.conversations.create({
+        name: `bookmarks-${Date.now()}`,
+      });
+      assert.isUndefined(channelRes.error);
+      const channelId = channelRes.channel.id;
+    
+      // get current bookmarks
+      const listRes = await client.bookmarks.list({
+        channel_id: channelId,
+      });
+      assert.isUndefined(listRes.error);
+  
+      // add new bookmark
+      const addRes = await client.bookmarks.add({
+        channel_id: channelId,
+        title: `${Date().now}`,
+        type: 'link',
+        link: 'https://www.example.com',
+      });
+      assert.isUndefined(addRes.error);
+      const bookmark_id = addRes.bookmark.id;
+  
+      assert.isNotNull(bookmark_id);
+  
+      // edit bookmark
+      const editRes = await client.bookmarks.edit({
+        channel_id: channelId,
+        bookmark_id,  
+      });
+      assert.isUndefined(editRes.error);
+  
+      // remove bookmark
+      const removeRes = await client.bookmarks.remove({
+        channel_id: channelId,
+        bookmark_id,  
+      });
+      assert.isUndefined(removeRes.error);
+  
+      // cleanup channel
+      client.conversations.archive({
+        channel: channelId,
+      });
+    });
+  });
+});


### PR DESCRIPTION
###  Summary

Adds support for bookmarks.{[list](https://api.slack.com/methods/bookmarks.list)|[add](https://api.slack.com/methods/bookmarks.add)|[edit](https://api.slack.com/methods/bookmarks.edit)|[remove](https://api.slack.com/methods/bookmarks.remove)} API methods. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
