### PR TITLE
Add error types to exposed ones from @slack/oauth

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,6 +1,4 @@
-// TODO: export CodedError and its implementations
-// export * from './errors';
-
+export * from './errors';
 export { Logger, LogLevel } from './logger';
 export { AuthorizeResult } from './authorize-result';
 export { CallbackOptions } from './callback-options';


### PR DESCRIPTION
###  Summary

This pull request adds error types to the exports from `index.ts`. With this change, developers can more easily access the error types.

```javascript
const { CodedError, AuthorizationError } = require('@slack/oauth');
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
