### PR TITLE
Fix #1435 Proper use of state parameter for the OAuth CSRF protection

### DIFF
--- a/packages/oauth/src/default-render-html-for-install-path.spec.js
+++ b/packages/oauth/src/default-render-html-for-install-path.spec.js
@@ -1,0 +1,11 @@
+require('mocha');
+const { assert } = require('chai');
+const { default: defaultRenderHtmlForInstallPath } = require('./default-render-html-for-install-path');
+
+describe('defaultRenderHtmlForInstallPath', async () => {
+  it('should render an HTML text with a given URL', async () => {
+    const url = 'https://expected-url';
+    const html = defaultRenderHtmlForInstallPath(url);
+    assert.isTrue(html.includes(`<a href="${url}">`));
+  });
+});

--- a/packages/oauth/src/default-render-html-for-install-path.ts
+++ b/packages/oauth/src/default-render-html-for-install-path.ts
@@ -1,0 +1,18 @@
+export default function defaultRenderHtmlForInstallPath(addToSlackUrl: string): string {
+  return `<html>
+<head>
+<link rel="icon" href="data:,">
+<style>
+body {
+  padding: 10px 15px;
+  font-family: verdana;
+  text-align: center;
+}
+</style>
+</head>
+<body>
+<h2>Slack App Installation</h2>
+<p><a href="${addToSlackUrl}"><img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
+</body>
+</html>`;
+}

--- a/packages/oauth/src/install-provider-options.ts
+++ b/packages/oauth/src/install-provider-options.ts
@@ -2,17 +2,99 @@ import { Logger, LogLevel } from '@slack/logger';
 import { WebClientOptions } from '@slack/web-api';
 import { StateStore } from './state-stores';
 import { InstallationStore } from './stores';
+import { InstallURLOptions } from './install-url-options';
 
 export interface InstallProviderOptions {
+
+  /**
+   * Client ID, which can be found under the Basic Information section of your application on https://api.slack.com/apps
+   */
   clientId: string;
+
+  /**
+   * Client Secret, which can be found under the Basic Information section of your application on https://api.slack.com/apps
+   */
   clientSecret: string;
-  stateStore?: StateStore; // default ClearStateStore
-  stateSecret?: string; // required with default ClearStateStore
-  stateVerification?: boolean; // default true, disables state verification when false
+
+  /**
+   * Manages installation data, which can be called by both the OAuth flow and authorize() in event handling
+   */
   installationStore?: InstallationStore; // default MemoryInstallationStore
-  authVersion?: 'v1' | 'v2'; // default 'v2'
-  logger?: Logger;
-  logLevel?: LogLevel;
-  clientOptions?: Omit<WebClientOptions, 'logLevel' | 'logger'>;
+
+  /**
+   * The slack.com authorize URL
+   */
   authorizationUrl?: string;
+
+  /**
+   * Stores state issued to authorization server
+   * and verifies the value returned at redirection during OAuth flow to prevent CSRF
+   */
+  stateStore?: StateStore; // default ClearStateStore
+
+  /**
+   * The secret value used for generating the state parameter value
+   */
+  stateSecret?: string; // required with default ClearStateStore
+
+  /**
+   * handleCallback() verifies the state parameter if true (default: true)
+   */
+  stateVerification?: boolean; // default true, disables state verification when false
+
+  /**
+   * handleCallback() skips checking browser cookies if true (default: false)
+   * Enabling this option is not recommended.
+   * This is supposed to be used only for backward-compatibility with v2.4 and olders.
+   */
+  legacyStateVerification?: boolean;
+
+  /**
+   * The cookie name used for setting state parameter value in cookies
+   */
+  stateCookieName?: string;
+
+  /**
+   * The expiration time in seconds for the state parameter value stored via cookies
+   */
+  stateCookieExpirationSeconds?: number;
+
+  /**
+   * The function for rendering the web page for the install path URL
+   */
+  renderHtmlForInstallPath?: (url: string) => string;
+
+  /**
+   * The install path web page rendering will be skipped if true (default: false)
+   */
+  directInstall?: boolean; // default false, disables rendering "Add to Slack" page for /slack/install when true
+
+  /**
+   * The default is "v2" (a.k.a. Granular Bot Permissions), different from "v1" (a.k.a. "Classic Apps").
+   * More details here:
+   * - https://medium.com/slack-developer-blog/more-precision-less-restrictions-a3550006f9c3
+   * - https://api.slack.com/authentication/migration
+   */
+  authVersion?: 'v1' | 'v2'; // default 'v2'
+
+  /**
+   * The initialization options for the OAuth flow
+   */
+  installUrlOptions?: InstallURLOptions;
+
+  /**
+   * @slack/logger logging used in this class
+   */
+  logger?: Logger;
+
+  /**
+   * @slack/logger logging level used in this class
+   */
+  logLevel?: LogLevel;
+
+  /**
+   * The customization options for WebClient
+   */
+  clientOptions?: Omit<WebClientOptions, 'logLevel' | 'logger'>;
+
 }

--- a/packages/oauth/src/state-stores/interface.ts
+++ b/packages/oauth/src/state-stores/interface.ts
@@ -1,19 +1,42 @@
 import { InstallURLOptions } from '../install-url-options';
 
-// State object structure
+/**
+ * The data structure represented by the state parameter.
+ */
 export interface StateObj {
+
+  /**
+   * The timestamp that the state object was generated.
+   */
   now: Date;
+
+  /**
+   * The passed InstallURLOptions object when generating this state parameter.
+   */
   installOptions: InstallURLOptions;
   random?: string | number;
 }
 
+/**
+ * Generates state parameter value in the OAuth flow.
+ * While the state parameter value works for the CSRF protection purpose,
+ * it can transfer the given InstallURLOptions value to the Redirect URL handler
+ * (Redirect URL: the default path is "/slack/oauth_redirect")
+ */
 export interface StateStore {
-  // Returned Promise resolves for a string which can be used as an
-  // OAuth state param.
-  // TODO: Revisit design. Does installOptions need to be encoded in state if metadata is static?
+
+  /**
+   * Generates a valid state parameter value, which can be decoded as a StateObj object
+   * by the verifyStateParam() method. This value may be stored on the server-side with expiration.
+   * The InstallProvider verifies if this value is set in the installer's browser session.
+   */
   generateStateParam: (installOptions: InstallURLOptions, now: Date) => Promise<string>;
 
-  // Returned Promise resolves for InstallURLOptions that were stored in the state
-  // param. The Promise rejects with a CodedError when the state is invalid.
+  /**
+   * Verifies the given state string value by trying to decode the value and
+   * build the passed InstallURLOptions object from the data.
+   * This method verifies if the state value is not too old to detect replay attacks.
+   * If the value is invalid, this method can throw InvalidStateError exception.
+   */
   verifyStateParam: (now: Date, state: string) => Promise<InstallURLOptions>;
 }

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -30,7 +30,13 @@ export default class FileInstallationStore implements InstallationStore {
     const installationDir = this.getInstallationDir(enterprise?.id, team?.id);
 
     if (logger !== undefined) {
-      logger.info(`Storing installation in ${installationDir} for ${JSON.stringify({ enterprise, team, user })}`);
+      const dataForLogging = {
+        enterprise,
+        team,
+        // user object can include token values
+        user: { id: user.id },
+      };
+      logger.info(`Storing installation in ${installationDir} for ${JSON.stringify(dataForLogging)}`);
       logger.warn('FileInstallationStore is not intended for production purposes.');
     }
 


### PR DESCRIPTION
###  Summary

This pull request resolves #1435. Refer to the issue for the context and the reason of the changes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
