### PR TITLE
Update FileInstallationStore to behave more consistently

### DIFF
--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -108,7 +108,7 @@ export default class FileInstallationStore implements InstallationStore {
     try {
       filesToDelete.forEach((filePath) => deleteFile(path.resolve(`${installationDir}/${filePath}`)));
     } catch (err) {
-      logger?.error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
+      throw new Error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
     }
   }
 

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -47,7 +47,7 @@ export default class FileInstallationStore implements InstallationStore {
         writeToFile(`${installationDir}/user-${user.id}-${currentUTC}`, installationData);
       }
     } catch (err) {
-      throw new Error('Failed to save installation to FileInstallationStore');
+      throw new Error(`Failed to save installation to FileInstallationStore (error: ${err})`);
     }
   }
 
@@ -83,7 +83,7 @@ export default class FileInstallationStore implements InstallationStore {
       }
       return installation;
     } catch (err) {
-      throw new Error('Failed to fetch data from FileInstallationStore');
+      throw new Error(`Failed to fetch data from FileInstallationStore (error: ${err})`);
     }
   }
 
@@ -108,7 +108,7 @@ export default class FileInstallationStore implements InstallationStore {
     try {
       filesToDelete.map((filePath) => deleteFile(path.resolve(`${installationDir}/${filePath}`)));
     } catch (err) {
-      throw new Error('Failed to delete installation from FileInstallationStore');
+      throw new Error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
     }
   }
 
@@ -126,7 +126,7 @@ export default class FileInstallationStore implements InstallationStore {
 function writeToFile(filePath: string, data: string): void {
   fs.writeFile(filePath, data, (err) => {
     if (err !== null) {
-      throw new Error('There was an error writing to the InstallationStore');
+      throw new Error(`There was an error writing to the InstallationStore (error: ${err})`);
     }
   });
 }
@@ -134,7 +134,7 @@ function writeToFile(filePath: string, data: string): void {
 function deleteFile(filePath: string): void {
   fs.unlink(path.resolve(filePath), (err) => {
     if (err !== null) {
-      throw new Error('Failed to delete installation from FileInstallationStore');
+      throw new Error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
     }
   });
 }

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -105,13 +105,11 @@ export default class FileInstallationStore implements InstallationStore {
       filesToDelete = filesToDelete.concat(userFiles);
     }
 
-    filesToDelete.forEach((filePath) => {
-      try {
-        deleteFile(path.resolve(`${installationDir}/${filePath}`));
-      } catch (err) {
-        logger?.error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
-      }
-    });
+    try {
+      filesToDelete.forEach((filePath) => deleteFile(path.resolve(`${installationDir}/${filePath}`)));
+    } catch (err) {
+      logger?.error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
+    }
   }
 
   private getInstallationDir(enterpriseId = '', teamId = '', isEnterpriseInstall = false): string {

--- a/packages/oauth/src/stores/file-store.ts
+++ b/packages/oauth/src/stores/file-store.ts
@@ -83,7 +83,7 @@ export default class FileInstallationStore implements InstallationStore {
       }
       return installation;
     } catch (err) {
-      throw new Error(`Failed to fetch data from FileInstallationStore (error: ${err})`);
+      throw new Error(`No installation data found (enterprise_id: ${query.enterpriseId}, team_id: ${query.teamId}, user_id: ${query.userId})`);
     }
   }
 
@@ -105,36 +105,28 @@ export default class FileInstallationStore implements InstallationStore {
       filesToDelete = filesToDelete.concat(userFiles);
     }
 
-    try {
-      filesToDelete.map((filePath) => deleteFile(path.resolve(`${installationDir}/${filePath}`)));
-    } catch (err) {
-      throw new Error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
-    }
+    filesToDelete.forEach((filePath) => {
+      try {
+        deleteFile(path.resolve(`${installationDir}/${filePath}`));
+      } catch (err) {
+        logger?.error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
+      }
+    });
   }
 
   private getInstallationDir(enterpriseId = '', teamId = '', isEnterpriseInstall = false): string {
     let installDir = `${this.baseDir}/${enterpriseId}`;
-
     if (teamId !== '' && !isEnterpriseInstall) {
       installDir += (enterpriseId !== '') ? `-${teamId}` : `${teamId}`;
     }
-
     return installDir;
   }
 }
 
 function writeToFile(filePath: string, data: string): void {
-  fs.writeFile(filePath, data, (err) => {
-    if (err !== null) {
-      throw new Error(`There was an error writing to the InstallationStore (error: ${err})`);
-    }
-  });
+  fs.writeFileSync(filePath, data);
 }
 
 function deleteFile(filePath: string): void {
-  fs.unlink(path.resolve(filePath), (err) => {
-    if (err !== null) {
-      throw new Error(`Failed to delete installation from FileInstallationStore (error: ${err})`);
-    }
-  });
+  fs.unlinkSync(path.resolve(filePath));
 }


### PR DESCRIPTION
###  Summary

This pull request improves the following points in the `@slack/oauth` package:

* Change all the write operations to use "sync" methods for atomicity
* Improve the exceptions coming from FileInstallationStore to include more details of the cause
* Add the corresponding tests for the above changes
* Simplify the rest in tests

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
