### PR TITLE
Fix #1438 Add more callbacks (beforeRedirection, before/afterInstallation, async success/failure) in InstallProvider

### DIFF
--- a/packages/oauth/src/callback-options.ts
+++ b/packages/oauth/src/callback-options.ts
@@ -9,10 +9,10 @@ export interface CallbackOptions {
    * An additional logic to run right before executing the Slack app installation with the given code parameter.
    *
    * When this method returns false, the InstallProvider skips the installation.
-   * You can set false when the visiting user is not eligible for proceeding the Slack app installation flow.
+   * You can set false when the visiting user is not eligible to proceed with the Slack app installation flow.
    *
-   * Also, when returning false, this method is responsible to call response#end() method
-   * to build complete HTTP response for end-users.
+   * Also, when returning false, this method is responsible for calling the response#end() method
+   * to build a complete HTTP response for end-users.
    */
   beforeInstallation?: (
     options: InstallURLOptions,

--- a/packages/oauth/src/callback-options.ts
+++ b/packages/oauth/src/callback-options.ts
@@ -4,6 +4,39 @@ import { InstallURLOptions } from './install-url-options';
 import { Installation, OrgInstallation } from './installation';
 
 export interface CallbackOptions {
+
+  /**
+   * An additional logic to run right before executing the Slack app installation with the given code parameter.
+   *
+   * When this method returns false, the InstallProvider skips the installation.
+   * You can set false when the visiting user is not eligible for proceeding the Slack app installation flow.
+   *
+   * Also, when returning false, this method is responsible to call response#end() method
+   * to build complete HTTP response for end-users.
+   */
+  beforeInstallation?: (
+    options: InstallURLOptions,
+    callbackReq: IncomingMessage,
+    callbackRes: ServerResponse,
+  ) => Promise<boolean>;
+
+  /**
+   * An additional logic to run right after executing the Slack app installation with the given code parameter.
+   *
+   * When this method returns false, the InstallProvider skips storing the installation in database.
+   * You can set false when your app needs to cancel the installation (you can call auth.revoke API method for it)
+   * and then, the app needs to display an error page to the installing user.
+   *
+   * Also, when returning false, this method is responsible to call response#end() method
+   * to build complete HTTP response for end-users.
+   */
+  afterInstallation?: (
+    installation: Installation | OrgInstallation,
+    options: InstallURLOptions,
+    callbackReq: IncomingMessage,
+    callbackRes: ServerResponse,
+  ) => Promise<boolean>;
+
   // success is given control after handleCallback() has stored the
   // installation. when provided, this function must complete the
   // callbackRes.
@@ -13,6 +46,15 @@ export interface CallbackOptions {
     callbackReq: IncomingMessage,
     callbackRes: ServerResponse,
   ) => void;
+
+  // async function version of success
+  // if both success and successAsync, both will be executed.
+  successAsync?: (
+    installation: Installation | OrgInstallation,
+    options: InstallURLOptions,
+    callbackReq: IncomingMessage,
+    callbackRes: ServerResponse,
+  ) => Promise<void>;
 
   // failure is given control when handleCallback() fails at any point.
   // when provided, this function must complete the callbackRes.
@@ -24,6 +66,15 @@ export interface CallbackOptions {
     callbackReq: IncomingMessage,
     callbackRes: ServerResponse,
   ) => void;
+
+  // async function version of failure
+  // if both failure and failureAsync, both will be executed.
+  failureAsync?: (
+    error: CodedError,
+    options: InstallURLOptions,
+    callbackReq: IncomingMessage,
+    callbackRes: ServerResponse,
+  ) => Promise<void>;
 }
 
 // Default function to call when OAuth flow is successful

--- a/packages/oauth/src/callback-options.ts
+++ b/packages/oauth/src/callback-options.ts
@@ -6,12 +6,12 @@ import { Installation, OrgInstallation } from './installation';
 export interface CallbackOptions {
 
   /**
-   * An additional logic to run right before executing the Slack app installation with the given code parameter.
+   * An additional logic to run right before executing the Slack app installation with the given OAuth code parameter.
    *
    * When this method returns false, the InstallProvider skips the installation.
    * You can set false when the visiting user is not eligible to proceed with the Slack app installation flow.
    *
-   * Also, when returning false, this method is responsible for calling the response#end() method
+   * Also, when returning false, this method is responsible for calling the callbackRes#end() method
    * to build a complete HTTP response for end-users.
    */
   beforeInstallation?: (
@@ -21,13 +21,13 @@ export interface CallbackOptions {
   ) => Promise<boolean>;
 
   /**
-   * An additional logic to run right after executing the Slack app installation with the given code parameter.
+   * An additional logic to run right after executing the Slack app installation with the given OAuth code parameter.
    *
    * When this method returns false, the InstallProvider skips storing the installation in database.
    * You can set false when your app needs to cancel the installation (you can call auth.revoke API method for it)
    * and then, the app needs to display an error page to the installing user.
    *
-   * Also, when returning false, this method is responsible to call response#end() method
+   * Also, when returning false, this method is responsible to call callbackRes#end() method
    * to build complete HTTP response for end-users.
    */
   afterInstallation?: (

--- a/packages/oauth/src/install-path-options.spec.ts
+++ b/packages/oauth/src/install-path-options.spec.ts
@@ -1,0 +1,25 @@
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { IncomingMessage, ServerResponse } from 'http';
+
+import { InstallPathOptions } from './install-path-options';
+
+describe('InstallPathOptions', async () => {
+  it('should have beforeRedirection', async () => {
+    const installPathOptions: InstallPathOptions = {
+      beforeRedirection: async (req, resp, options) => {
+        assert.isNotNull(req);
+        assert.isNotNull(resp);
+        assert.isNotNull(options);
+        return false;
+      },
+    };
+    assert.isNotNull(installPathOptions);
+    const req = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+    const resp = sinon.createStubInstance(ServerResponse) as ServerResponse;
+    const options = { scopes: ['commands', 'chat:write'] };
+    const result = await installPathOptions.beforeRedirection!(req, resp, options);
+    assert.isFalse(result);
+  });
+});

--- a/packages/oauth/src/install-path-options.ts
+++ b/packages/oauth/src/install-path-options.ts
@@ -13,10 +13,10 @@ export interface InstallPathOptions {
    *
    * When this method returns false, the InstallProvider skips
    * the following operations including the redirection to Slack authorize URL.
-   * You can set false when the visiting user is not eligible for proceeding the Slack app installation flow.
+   * You can set false when the visiting user is not eligible to proceed with the Slack app installation flow.
    *
-   * Also, when returning false, this method is responsible to call response#end() method
-   * to build complete HTTP response for end-users.
+   * Also, when returning false, this method is responsible for calling the response#end() method
+   * to build a complete HTTP response for end-users.
    */
   beforeRedirection?: (
     request: IncomingMessage,

--- a/packages/oauth/src/install-path-options.ts
+++ b/packages/oauth/src/install-path-options.ts
@@ -1,0 +1,26 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { InstallURLOptions } from './install-url-options';
+
+/**
+ * Customizable callbacks that are supposed to be called
+ * inside InstallProvider#handleInstallPath() method.
+ */
+export interface InstallPathOptions {
+
+  /**
+   * Customize the response headers and body data for
+   * additional user-specific data handling such as acccount mapping and activity tracking.
+   *
+   * When this method returns false, the InstallProvider skips
+   * the following operations including the redirection to Slack authorize URL.
+   * You can set false when the visiting user is not eligible for proceeding the Slack app installation flow.
+   *
+   * Also, when returning false, this method is responsible to call response#end() method
+   * to build complete HTTP response for end-users.
+   */
+  beforeRedirection?: (
+    request: IncomingMessage,
+    response: ServerResponse,
+    options?: InstallURLOptions,
+  ) => Promise<boolean>;
+}


### PR DESCRIPTION
###  Summary

This pull request resolves #1438  by adding more callback functions to the OAuth package. The branch depends on the changes in https://github.com/slackapi/node-slack-sdk/pull/1436 but the essential changes are in this commit: https://github.com/slackapi/node-slack-sdk/commit/0af89054f06e61879f820cfbb0bb880085b4e800

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
