### PR TITLE
Add more exports to oauth/index.ts

### DIFF
--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -29,5 +29,5 @@ export {
 
 // InstallationStore interface and built-in implementations
 export * from './installation-stores';
-// StateSTore interface and built-in implementations
+// StateStore interface and built-in implementations
 export * from './state-stores';

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,15 +1,33 @@
-export * from './errors';
 export { Logger, LogLevel } from './logger';
+
+// The inputs / outputs of the InstallProvider module
 export { AuthorizeResult } from './authorize-result';
-export { CallbackOptions } from './callback-options';
+export { Installation, OrgInstallation } from './installation';
+export { InstallationQuery, OrgInstallationQuery } from './installation-query';
+
+// The errors that can be returned by this module
+export * from './errors';
+
+// The core part of this library
 export {
   InstallProvider,
   OAuthV2TokenRefreshResponse,
   OAuthV2Response,
 } from './install-provider';
-export { Installation, OrgInstallation } from './installation';
-export { InstallationQuery, OrgInstallationQuery } from './installation-query';
+
 export { InstallProviderOptions } from './install-provider-options';
 export { InstallURLOptions } from './install-url-options';
+// the callback handlers for the `/slack/install` path
+export { InstallPathOptions } from './install-path-options';
+export { default as defaultRenderHtmlForInstallPath } from './default-render-html-for-install-path';
+// the callback handlers for the `/slack/oauth_redirect` path
+export {
+  CallbackOptions,
+  defaultCallbackFailure,
+  defaultCallbackSuccess,
+} from './callback-options';
+
+// InstallationStore interface and built-in implementations
 export * from './installation-stores';
+// StateSTore interface and built-in implementations
 export * from './state-stores';


### PR DESCRIPTION
###  Summary

This pull request adds more exported items in the `@slack/oauth` package next version. Specifically the following items were missing the RC version:

* `InstallPathOptions` interface (this is required for writing code in TypeScript)
* `defaultRenderHtmlForInstallPath` function (totally optional but some bolt-js receivers may want to access this)
* `defaultCallbackSuccess`, `defaultCallbackFailure` for `CallbackOptions`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
