### PR TITLE
Publish @slack/oauth@2.5.0

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

Apart from https://github.com/slackapi/node-slack-sdk/pull/1446, we haven't observed any issues with the rc1 version. Thus, the latest revision should be good to go now.

All the changes: https://github.com/slackapi/node-slack-sdk/milestone/13?closed=1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
