### PR TITLE
Fix #1452 fields[key].label is missing in users.profile.get responses

### DIFF
--- a/packages/web-api/src/response/UsersProfileGetResponse.ts
+++ b/packages/web-api/src/response/UsersProfileGetResponse.ts
@@ -52,6 +52,7 @@ export interface Profile {
 export interface Field {
   value?: string;
   alt?:   string;
+  label?: string;
 }
 
 export interface StatusEmojiDisplayInfo {


### PR DESCRIPTION
###  Summary

This pull request resolves #1452 by applying the code generation results with the revision https://github.com/slackapi/java-slack-sdk/commit/fa03fffd50ad6a1700a7930cc13f51176662760a

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
