### PR TITLE
Fix #1455 bolt-js's `ack(string)` does not work in Socket Mode

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -419,10 +419,11 @@ export class SocketModeClient extends EventEmitter {
    * Method for sending an outgoing message of an arbitrary type over the websocket connection.
    * Primarily used to send acknowledgements back to slack for incoming events
    * @param id the envelope id
-   * @param body the message body
+   * @param body the message body or string text
    */
   private send(id: string, body = {}): Promise<void> {
-    const message = { envelope_id: id, payload: { ...body } };
+    const _body = typeof body === 'string' ? { text: body } : body;
+    const message = { envelope_id: id, payload: { ..._body } };
 
     return new Promise((resolve, reject) => {
       this.logger.debug(`send() in state: ${this.stateMachine.getStateHierarchy()}`);


### PR DESCRIPTION
###  Summary

This pull request resolves #1455 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
