### PR TITLE
Add domain to team.info API parameters

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1986,6 +1986,7 @@ export interface TeamInfoArguments extends WebAPICallOptions, TokenOverridable {
   // Team to get info on, if omitted, will return information about the current team.
   // Will only return team that the authenticated token is allowed to see through external shared channels
   team?: string;
+  domain?: string; // available only for Enterprise Grid
 }
 export interface TeamIntegrationLogsArguments extends WebAPICallOptions, TokenOverridable {
   app_id?: string;


### PR DESCRIPTION
###  Summary

This pull request adds `domain` parameter to the [team.info](https://api.slack.com/methods/team.info) API method.

>The [team.info](https://api.slack.com/methods/team.info) parameter [domain](https://api.slack.com/methods/team.info#arg_domain) is now public. Query for your team's information by domain only when team is null.
>https://api.slack.com/changelog

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
