### PR TITLE
Add skip comments for any type warnings in socket-mode module

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -543,6 +543,7 @@ export class SocketModeClient extends EventEmitter {
     let event: {
       type: string;
       reason: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: { [key: string]: any };
       envelope_id: string;
       retry_attempt?: number; // type: events_api
@@ -552,6 +553,7 @@ export class SocketModeClient extends EventEmitter {
 
     try {
       event = JSON.parse(data);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (parseError: any) {
       // prevent application from crashing on a bad message, but log an error to bring attention
       this.logger.error(

--- a/packages/socket-mode/src/errors.ts
+++ b/packages/socket-mode/src/errors.ts
@@ -22,6 +22,7 @@ export type SMCallError = SMPlatformError | SMWebsocketError | SMNoReplyReceived
 
 export interface SMPlatformError extends CodedError {
   code: ErrorCode.SendMessagePlatformError;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any;
 }
 
@@ -67,7 +68,10 @@ export function websocketErrorWithOriginal(original: Error): SMWebsocketError {
 /**
  * A factory to create SMPlatformError objects.
  */
-export function platformErrorFromEvent(event: any & { error: { msg: string; } }): SMPlatformError {
+export function platformErrorFromEvent(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  event: any & { error: { msg: string; } },
+): SMPlatformError {
   const error = errorWithCode(
     new Error(`An API error occurred: ${event.error.msg}`),
     ErrorCode.SendMessagePlatformError,


### PR DESCRIPTION
###  Summary

Since we are not planning to change the types in the short term, we can add skip comments for the any-type-usage warnings.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
