### PR TITLE
Fix #1450 Add isActive property to the SocketModeClient

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.spec.js
+++ b/packages/socket-mode/src/SocketModeClient.spec.js
@@ -2,6 +2,15 @@ const { assert } = require('chai');
 const { SocketModeClient } = require('./SocketModeClient');
 
 describe('SocketModeClient', () => {
+  describe('public APIs', () => {
+    describe('isActive()', () => {
+      it('should return false when initialized', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        assert.isFalse(client.isActive());
+      });
+    });
+  });
+
   describe('onWebsocketMessage', () => {
     beforeEach(() => {
     });

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -46,6 +46,14 @@ export class SocketModeClient extends EventEmitter {
    */
   public authenticated: boolean = false;
 
+  /**
+   * Returns true if the underlying WebSocket connection is active.
+   */
+  public isActive(): boolean {
+    this.logger.debug(`The connection state (connected: ${this.connected}, authenticated: ${this.authenticated}, badConnection: ${this.badConnection})`);
+    return this.connected && this.authenticated && !this.badConnection;
+  }
+
   // public listenerIterator: AsyncGenerator | undefined;
 
   /**


### PR DESCRIPTION
###  Summary

This pull request resolves #1450 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
