### PR TITLE
Fix #1462 Add app unfurl related properties in attachments

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -389,6 +389,20 @@ export interface MessageAttachment {
   actions?: AttachmentAction[];
   callback_id?: string;
   mrkdwn_in?: ('pretext' | 'text' | 'fields')[];
+  app_unfurl_url?: string;
+  is_app_unfurl?: boolean;
+  app_id?: string;
+  bot_id?: string;
+  preview?: MessageAttachmentPreview; // https://api.slack.com/methods/chat.unfurl#markdown
+}
+
+// https://api.slack.com/methods/chat.unfurl#markdown
+export interface MessageAttachmentPreview {
+  type?: string;
+  can_remove?: boolean;
+  title?: PlainTextElement;
+  subtitle?: PlainTextElement;
+  iconUrl?: string;
 }
 
 export interface AttachmentAction {


### PR DESCRIPTION
###  Summary

This pull request resolves #1462 by adding some of the missing properties in type definition. There are more properties in an attachment but this pull request resolves only the ones I've verified if they exist for sure in the scenario of an app's unfurling.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
