### PR TITLE
Add envelope_id to Socket Mode listener arguments

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.spec.js
+++ b/packages/socket-mode/src/SocketModeClient.spec.js
@@ -19,26 +19,27 @@ describe('SocketModeClient', () => {
     });
 
     describe('slash_commands messages', () => {
+      const message = {
+        "envelope_id": "1d3c79ab-0ffb-41f3-a080-d19e85f53649",
+        "payload": {
+          "token": "verification-token",
+          "team_id": "T111",
+          "team_domain": "xxx",
+          "channel_id": "C111",
+          "channel_name": "random",
+          "user_id": "U111",
+          "user_name": "seratch",
+          "command": "/hello-socket-mode",
+          "text": "",
+          "api_app_id": "A111",
+          "response_url": "https://hooks.slack.com/commands/T111/111/xxx",
+          "trigger_id": "111.222.xxx"
+        },
+        "type": "slash_commands",
+        "accepts_response_payload": true
+      };
+
       it('should be sent to two listeners', async () => {
-        const message = {
-          "envelope_id": "1d3c79ab-0ffb-41f3-a080-d19e85f53649",
-          "payload": {
-            "token": "verification-token",
-            "team_id": "T111",
-            "team_domain": "xxx",
-            "channel_id": "C111",
-            "channel_name": "random",
-            "user_id": "U111",
-            "user_name": "seratch",
-            "command": "/hello-socket-mode",
-            "text": "",
-            "api_app_id": "A111",
-            "response_url": "https://hooks.slack.com/commands/T111/111/xxx",
-            "trigger_id": "111.222.xxx"
-          },
-          "type": "slash_commands",
-          "accepts_response_payload": true
-        };
         const client = new SocketModeClient({ appToken: 'xapp-' });
         let commandListenerCalled = false;
         client.on("slash_commands", async (args) => {
@@ -56,63 +57,85 @@ describe('SocketModeClient', () => {
         assert.isTrue(commandListenerCalled);
         assert.isTrue(slackEventListenerCalled);
       });
+
+      it('should pass all the properties to slash_commands listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("slash_commands", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, '1d3c79ab-0ffb-41f3-a080-d19e85f53649');
+      });
+      it('should pass all the properties to slack_event listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("slack_event", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, '1d3c79ab-0ffb-41f3-a080-d19e85f53649');
+      });
     });
 
     describe('events_api messages', () => {
-      it('should be sent to two listeners', async () => {
-        const message = {
-          "envelope_id": "cda4159a-72a5-4744-aba3-4d66eb52682b",
-          "payload": {
-            "token": "verification-token",
-            "team_id": "T111",
-            "api_app_id": "A111",
-            "event": {
-              "client_msg_id": "f0582a78-72db-4feb-b2f3-1e47d66365c8",
-              "type": "app_mention",
-              "text": "<@U111>",
-              "user": "U222",
-              "ts": "1610241741.000200",
-              "team": "T111",
-              "blocks": [
-                {
-                  "type": "rich_text",
-                  "block_id": "Sesm",
-                  "elements": [
-                    {
-                      "type": "rich_text_section",
-                      "elements": [
-                        {
-                          "type": "user",
-                          "user_id": "U111"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "channel": "C111",
-              "event_ts": "1610241741.000200"
-            },
-            "type": "event_callback",
-            "event_id": "Ev111",
-            "event_time": 1610241741,
-            "authorizations": [
+      const message = {
+        "envelope_id": "cda4159a-72a5-4744-aba3-4d66eb52682b",
+        "payload": {
+          "token": "verification-token",
+          "team_id": "T111",
+          "api_app_id": "A111",
+          "event": {
+            "client_msg_id": "f0582a78-72db-4feb-b2f3-1e47d66365c8",
+            "type": "app_mention",
+            "text": "<@U111>",
+            "user": "U222",
+            "ts": "1610241741.000200",
+            "team": "T111",
+            "blocks": [
               {
-                "enterprise_id": null,
-                "team_id": "T111",
-                "user_id": "U222",
-                "is_bot": true,
-                "is_enterprise_install": false
+                "type": "rich_text",
+                "block_id": "Sesm",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "user",
+                        "user_id": "U111"
+                      }
+                    ]
+                  }
+                ]
               }
             ],
-            "is_ext_shared_channel": false,
-            "event_context": "1-app_mention-T111-C111"
+            "channel": "C111",
+            "event_ts": "1610241741.000200"
           },
-          "type": "events_api",
-          "accepts_response_payload": false,
-          "retry_attempt": 2,
-          "retry_reason": "timeout"
-        };
+          "type": "event_callback",
+          "event_id": "Ev111",
+          "event_time": 1610241741,
+          "authorizations": [
+            {
+              "enterprise_id": null,
+              "team_id": "T111",
+              "user_id": "U222",
+              "is_bot": true,
+              "is_enterprise_install": false
+            }
+          ],
+          "is_ext_shared_channel": false,
+          "event_context": "1-app_mention-T111-C111"
+        },
+        "type": "events_api",
+        "accepts_response_payload": false,
+        "retry_attempt": 2,
+        "retry_reason": "timeout"
+      };
+
+      it('should be sent to two listeners', async () => {
         const client = new SocketModeClient({ appToken: 'xapp-' });
         let otherListenerCalled = false;
         client.on("app_home_opend", async () => {
@@ -137,34 +160,55 @@ describe('SocketModeClient', () => {
         assert.isTrue(eventsApiListenerCalled);
         assert.isTrue(slackEventListenerCalled);
       });
+
+      it('should pass all the properties to app_mention listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("app_mention", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, 'cda4159a-72a5-4744-aba3-4d66eb52682b');
+      });
+      it('should pass all the properties to slack_event listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("slack_event", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, 'cda4159a-72a5-4744-aba3-4d66eb52682b');
+      });
     });
 
     describe('interactivity messages', () => {
-      it('should be sent to two listeners', async () => {
-        const message = {
-          "envelope_id": "57d6a792-4d35-4d0b-b6aa-3361493e1caf",
-          "payload": {
-            "type": "shortcut",
-            "token": "verification-token",
-            "action_ts": "1610198080.300836",
-            "team": {
-              "id": "T111",
-              "domain": "seratch"
-            },
-            "user": {
-              "id": "U111",
-              "username": "seratch",
-              "team_id": "T111"
-            },
-            "is_enterprise_install": false,
-            "enterprise": null,
-            "callback_id": "do-something",
-            "trigger_id": "111.222.xxx"
+      const message = {
+        "envelope_id": "57d6a792-4d35-4d0b-b6aa-3361493e1caf",
+        "payload": {
+          "type": "shortcut",
+          "token": "verification-token",
+          "action_ts": "1610198080.300836",
+          "team": {
+            "id": "T111",
+            "domain": "seratch"
           },
-          "type": "interactive",
-          "accepts_response_payload": false
-        }
-          ;
+          "user": {
+            "id": "U111",
+            "username": "seratch",
+            "team_id": "T111"
+          },
+          "is_enterprise_install": false,
+          "enterprise": null,
+          "callback_id": "do-something",
+          "trigger_id": "111.222.xxx"
+        },
+        "type": "interactive",
+        "accepts_response_payload": false
+      };
+
+      it('should be sent to two listeners', async () => {
         const client = new SocketModeClient({ appToken: 'xapp-' });
         let otherListenerCalled = false;
         client.on("slash_commands", async () => {
@@ -183,6 +227,27 @@ describe('SocketModeClient', () => {
         assert.isFalse(otherListenerCalled);
         assert.isTrue(interactiveListenerCalled);
         assert.isTrue(slackEventListenerCalled);
+      });
+
+      it('should pass all the properties to interactive listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("interactive", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, '57d6a792-4d35-4d0b-b6aa-3361493e1caf');
+      });
+      it('should pass all the properties to slack_event listeners', async () => {
+        const client = new SocketModeClient({ appToken: 'xapp-' });
+        let passedEnvelopeId = undefined;
+        client.on("slack_event", async ({ envelope_id }) => {
+          passedEnvelopeId = envelope_id;
+        });
+        await client.onWebSocketMessage({ data: JSON.stringify(message) });
+        await sleep(30);
+        assert.equal(passedEnvelopeId, '57d6a792-4d35-4d0b-b6aa-3361493e1caf');
       });
     });
   });

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -602,6 +602,7 @@ export class SocketModeClient extends EventEmitter {
     if (event.type === 'events_api') {
       this.emit(event.payload.event.type, {
         ack,
+        envelope_id: event.envelope_id,
         body: event.payload,
         event: event.payload.event,
         retry_num: event.retry_attempt,
@@ -612,6 +613,7 @@ export class SocketModeClient extends EventEmitter {
       // emit just ack and body for all other types of messages
       this.emit(event.type, {
         ack,
+        envelope_id: event.envelope_id,
         body: event.payload,
         accepts_response_payload: event.accepts_response_payload,
       });
@@ -621,6 +623,7 @@ export class SocketModeClient extends EventEmitter {
     // used in tools like bolt-js
     this.emit('slack_event', {
       ack,
+      envelope_id: event.envelope_id,
       type: event.type,
       body: event.payload,
       retry_num: event.retry_attempt,


### PR DESCRIPTION
###  Summary

This pull request enhances the payload data to have `envelope_id` for all listeners. 

The motivation that I would like to add this property is for better debug-level logging on the bolt-js side. In most cases, developers do not need to directly use `envelope_id` as the `ack()` method does everything for you. However, the libraries built on top of `@slack/socket-mode` may want to use the property for logging and so on.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
