### PR TITLE
Split SocketModeClient.ts into several files

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -15,18 +15,10 @@ import {
   sendWhileDisconnectedError,
   sendWhileNotReadyError,
 } from './errors';
+import { UnrecoverableSocketModeStartError } from './UnrecoverableSocketModeStartError';
+import { SocketModeOptions } from './SocketModeOptions';
 
 const packageJson = require('../package.json'); // eslint-disable-line import/no-commonjs, @typescript-eslint/no-var-requires
-
-// NOTE: there may be a better way to add metadata to an error about being "unrecoverable" than to keep an
-// independent enum, probably a Set (this isn't used as a type).
-enum UnrecoverableSocketModeStartError {
-  NotAuthed = 'not_authed',
-  InvalidAuth = 'invalid_auth',
-  AccountInactive = 'account_inactive',
-  UserRemovedFromTeam = 'user_removed_from_team',
-  TeamDisabled = 'team_disabled',
-}
 
 /**
  * An Socket Mode Client allows programs to communicate with the
@@ -634,16 +626,3 @@ export class SocketModeClient extends EventEmitter {
 addAppMetadata({ name: packageJson.name, version: packageJson.version });
 
 export default SocketModeClient;
-
-/*
- * Exported types
- */
-
-export interface SocketModeOptions {
-  appToken?: string; // app level token
-  logger?: Logger;
-  logLevel?: LogLevel;
-  autoReconnectEnabled?: boolean;
-  clientPingTimeout?: number;
-  clientOptions?: Omit<WebClientOptions, 'logLevel' | 'logger'>;
-}

--- a/packages/socket-mode/src/SocketModeOptions.ts
+++ b/packages/socket-mode/src/SocketModeOptions.ts
@@ -1,0 +1,11 @@
+import { WebClientOptions } from '@slack/web-api';
+import { LogLevel, Logger } from './logger';
+
+export interface SocketModeOptions {
+  appToken?: string; // app level token
+  logger?: Logger;
+  logLevel?: LogLevel;
+  autoReconnectEnabled?: boolean;
+  clientPingTimeout?: number;
+  clientOptions?: Omit<WebClientOptions, 'logLevel' | 'logger'>;
+}

--- a/packages/socket-mode/src/UnrecoverableSocketModeStartError.ts
+++ b/packages/socket-mode/src/UnrecoverableSocketModeStartError.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+
+// NOTE: there may be a better way to add metadata to an error about being "unrecoverable" than to keep an
+// independent enum, probably a Set (this isn't used as a type).
+export enum UnrecoverableSocketModeStartError {
+  NotAuthed = 'not_authed',
+  InvalidAuth = 'invalid_auth',
+  AccountInactive = 'account_inactive',
+  UserRemovedFromTeam = 'user_removed_from_team',
+  TeamDisabled = 'team_disabled',
+}

--- a/packages/socket-mode/src/index.ts
+++ b/packages/socket-mode/src/index.ts
@@ -1,8 +1,8 @@
 /// <reference lib="es2017" />
 
-export {
-  SocketModeClient,
-} from './SocketModeClient';
+export { SocketModeClient } from './SocketModeClient';
+export { SocketModeOptions } from './SocketModeOptions';
+export { UnrecoverableSocketModeStartError } from './UnrecoverableSocketModeStartError';
 
 export { Logger, LogLevel } from './logger';
 


### PR DESCRIPTION
###  Summary

This pull request refactors the internals of `@slack/socket-mode` module. Also, it adds `SocketModeOptions` and `UnrecoverableSocketModeStartError` to `index.ts` primarily for TypeScript developers. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
