### PR TITLE
webhook: upgrade minimum axios version to latest

### DIFF
--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@slack/types": "^1.2.1",
     "@types/node": ">=12.0.0",
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.4",


### PR DESCRIPTION
###  Summary

This PR upgrades axios to the latest version to fix a vulnerability in follow-redirects - https://github.com/advisories/GHSA-pw2r-vq6v-hr8c.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
