### PR TITLE
Apply more improvements to #1465 changes

### DIFF
--- a/packages/socket-mode/examples/manually-connecting.js
+++ b/packages/socket-mode/examples/manually-connecting.js
@@ -1,0 +1,33 @@
+const { SocketModeClient, LogLevel } = require("@slack/socket-mode");
+const { WebClient } = require("@slack/web-api");
+
+const logLevel = LogLevel.DEBUG;
+const socketModeClient = new SocketModeClient({
+  appToken: process.env.SLACK_APP_TOKEN,
+  logLevel,
+  // pingPongLoggingEnabled: true,
+  // serverPingTimeout: 30000,
+  // clientPingTimeout: 5000,
+});
+const webClient = new WebClient(process.env.SLACK_BOT_TOKEN, {
+  logLevel,
+});
+
+socketModeClient.on("slack_event", async ({ ack, body }) => {
+  try {
+    console.log(body);
+    // setTimeout(() => { ack(); }, 2000);
+    await ack();
+  } catch (e) {
+    console.error(e);
+  }
+});
+
+(async () => {
+  await socketModeClient.connect();
+  setTimeout(() => socketModeClient.disconnect(), 5000)
+  setTimeout(() => socketModeClient.connect(), 10000)
+  setTimeout(() => socketModeClient.disconnect(), 15000)
+  setTimeout(() => socketModeClient.connect(), 20000)
+  setTimeout(() => {}, Number.MAX_VALUE)
+})();

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -150,7 +150,7 @@ export class SocketModeClient extends EventEmitter {
    * It may take a few milliseconds before being connected.
    * This method must be called before any messages can be sent or received.
    */
-  public async connect(): Promise<void> {
+  public connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
         // The state machine handles all the WebSocket releated operations.
@@ -255,7 +255,7 @@ export class SocketModeClient extends EventEmitter {
         .transitionTo(State.Connecting)
     .state(State.Connecting)
       .onEnter(() => {
-        this.logger.info('Going to establish a new connectiont to Slack ...');
+        this.logger.info('Going to establish a new connection to Slack ...');
       })
       .submachine(this.connectingStateMachineConfig)
       .on(Event.ServerHello)


### PR DESCRIPTION
###  Summary

This pull request slightly improves the changes in #1465 by applying the following changes:

* Make the logic of switching connections more robust
* Correct the `badConnection` state for some reconnecting scenarios such as "warning" from Slack
* Make the error handling to better manage the resources
* Add `SocketModeClient#connet()` method to make the existing `disconnect()` method meaningful

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
