### PR TITLE
Publish @slack/socket-mode@1.3.0

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

My own testing with the 1.3.0-rc.1 version for a few weeks did not detect any issues and we haven't received any bug reports with the version. For this reason, we can plan releasing 1.3.0 to the latest tag.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
