### PR TITLE
Remove Subscribe in Slack

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,17 +61,7 @@ export interface WorkflowStepView {
   external_id?: string;
 }
 
-export interface SubscriptionConfigureView {
-  type: 'app_notification_subscription_configuration';
-  title: PlainTextElement;
-  blocks: (KnownBlock | Block)[];
-  close?: PlainTextElement;
-  submit?: PlainTextElement;
-  callback_id?: string;
-  private_metadata?: string;
-}
-
-export type View = HomeView | ModalView | WorkflowStepView | SubscriptionConfigureView;
+export type View = HomeView | ModalView | WorkflowStepView;
 
 /*
  * Block Elements

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -472,13 +472,6 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         ),
       },
     },
-    notifications: {
-      subscriptions: {
-        create: bindApiCall<AppsNotificationsSubscriptionsCreateArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.create'),
-        delete: bindApiCall<AppsNotificationsSubscriptionsDeleteArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.delete'),
-        update: bindApiCall<AppsNotificationsSubscriptionsUpdateArguments, WebAPICallResult>(this, 'apps.notifications.subscriptions.update'),
-      },
-    },
     uninstall: bindApiCall<AppsUninstallArguments, AppsUninstallResponse>(this, 'apps.uninstall'),
   };
 
@@ -1215,27 +1208,6 @@ export interface AppsEventAuthorizationsListArguments
   event_context: string;
 }
 cursorPaginationEnabledMethods.add('apps.event.authorizations.list');
-
-export interface AppsNotificationsSubscriptionsCreateArguments extends WebAPICallOptions {
-  trigger_id: string;
-  channel_id: string;
-  name: string;
-  type?: {
-    name: string;
-    label: string;
-  };
-  resource_link?: string;
-}
-
-export interface AppsNotificationsSubscriptionsDeleteArguments extends WebAPICallOptions {
-  notification_subscription_id: string;
-}
-
-export interface AppsNotificationsSubscriptionsUpdateArguments extends WebAPICallOptions {
-  notification_subscription_id: string;
-  channel_id: string;
-  trigger_id: string;
-}
 
 export interface AppsUninstallArguments extends WebAPICallOptions {
   client_id: string;

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -293,9 +293,9 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       ekm: {
         listOriginalConnectedChannelInfo:
           bindApiCall<AdminConversationsEKMListOriginalConnectedChannelInfoArguments,
-            AdminConversationsEkmListOriginalConnectedChannelInfoResponse>(
-              this, 'admin.conversations.ekm.listOriginalConnectedChannelInfo',
-            ),
+          AdminConversationsEkmListOriginalConnectedChannelInfoResponse>(
+            this, 'admin.conversations.ekm.listOriginalConnectedChannelInfo',
+          ),
       },
       getConversationPrefs:
         bindApiCall<AdminConversationsGetConversationPrefsArguments, AdminConversationsGetConversationPrefsResponse>(
@@ -308,19 +308,19 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       rename: bindApiCall<AdminConversationsRenameArguments, AdminConversationsRenameResponse>(this, 'admin.conversations.rename'),
       restrictAccess: {
         addGroup: bindApiCall<AdminConversationsRestrictAccessAddGroupArguments,
-          AdminConversationsRestrictAccessAddGroupResponse>(
-            this, 'admin.conversations.restrictAccess.addGroup',
-          ),
+        AdminConversationsRestrictAccessAddGroupResponse>(
+          this, 'admin.conversations.restrictAccess.addGroup',
+        ),
         listGroups:
           bindApiCall<AdminConversationsRestrictAccessListGroupsArguments,
-            AdminConversationsRestrictAccessListGroupsResponse>(
-              this, 'admin.conversations.restrictAccess.listGroups',
-            ),
+          AdminConversationsRestrictAccessListGroupsResponse>(
+            this, 'admin.conversations.restrictAccess.listGroups',
+          ),
         removeGroup:
           bindApiCall<AdminConversationsRestrictAccessRemoveGroupArguments,
-            AdminConversationsRestrictAccessRemoveGroupResponse>(
-              this, 'admin.conversations.restrictAccess.removeGroup',
-            ),
+          AdminConversationsRestrictAccessRemoveGroupResponse>(
+            this, 'admin.conversations.restrictAccess.removeGroup',
+          ),
       },
       getCustomRetention:
         bindApiCall<AdminConversationsGetCustomRetentionArguments, AdminConversationsGetCustomRetentionResponse>(
@@ -391,9 +391,9 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
           ),
         setDiscoverability:
           bindApiCall<AdminTeamsSettingsSetDiscoverabilityArguments,
-            AdminTeamsSettingsSetDiscoverabilityResponse>(
-              this, 'admin.teams.settings.setDiscoverability',
-            ),
+          AdminTeamsSettingsSetDiscoverabilityResponse>(
+            this, 'admin.teams.settings.setDiscoverability',
+          ),
         setIcon: bindApiCall<AdminTeamsSettingsSetIconArguments, AdminTeamsSettingsSetIconResponse>(
           this, 'admin.teams.settings.setIcon',
         ),


### PR DESCRIPTION
###  Summary

This PR contains changes to `web-api` and `types` packages that removes the Subscribe in Slack feature previously supported in the beta from the hermes development branch.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
