### PR TITLE
Added in timezone string property to timepicker block element in types package

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -264,6 +264,7 @@ export interface Timepicker extends Action {
   placeholder?: PlainTextElement;
   confirm?: Confirm;
   focus_on_load?: boolean;
+  timezone?: string;
 }
 
 export interface RadioButtons extends Action {


### PR DESCRIPTION
###  Summary

As mentioned in Issue #1502, we need to add a new optional String property, `timezone`, for the Timepicker element. This needs to be added to the `@slack/types` package.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
