### PR TITLE
Adding Message Metadata support

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -366,6 +366,13 @@ export interface InputBlock extends Block {
   dispatch_action?: boolean;
 }
 
+export interface MessageMetadata {
+  event_type: string;
+  event_payload: {
+      [key: string]: any;
+  }
+}
+
 export interface MessageAttachment {
   blocks?: (KnownBlock | Block)[];
   fallback?: string; // either this or text must be defined

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -369,8 +369,12 @@ export interface InputBlock extends Block {
 export interface MessageMetadata {
   event_type: string;
   event_payload: {
-      [key: string]: any;
+    [key: string]: string | number | boolean | MessageMetadataEventPayloadObject | MessageMetadataEventPayloadObject[];
   }
+}
+
+export interface MessageMetadataEventPayloadObject {
+  [key: string]: string | number | boolean
 }
 
 export interface MessageAttachment {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1,5 +1,5 @@
 import { Stream } from 'stream';
-import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser } from '@slack/types';
+import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUser, MessageMetadata } from '@slack/types';
 import { EventEmitter } from 'eventemitter3';
 import { WebAPICallOptions, WebAPICallResult, WebClient, WebClientEvent } from './WebClient';
 import {
@@ -1412,6 +1412,7 @@ export interface ChatPostMessageArguments extends WebAPICallOptions, TokenOverri
   blocks?: (KnownBlock | Block)[];
   icon_emoji?: string; // if specified, as_user must be false
   icon_url?: string; // if specified, as_user must be false
+  metadata?: MessageMetadata;
   link_names?: boolean;
   mrkdwn?: boolean;
   parse?: 'full' | 'none';
@@ -1428,6 +1429,7 @@ export interface ChatScheduleMessageArguments extends WebAPICallOptions, TokenOv
   as_user?: boolean;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];
+  metadata?: MessageMetadata;
   link_names?: boolean;
   parse?: 'full' | 'none';
   reply_broadcast?: boolean; // if specified, thread_ts must be set
@@ -1460,6 +1462,7 @@ export interface ChatUpdateArguments extends WebAPICallOptions, TokenOverridable
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];
   link_names?: boolean;
+  metadata?: MessageMetadata;
   parse?: 'full' | 'none';
   file_ids?: string[];
   reply_broadcast?: boolean;

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1502,6 +1502,7 @@ export interface ConversationsDeclineSharedInviteArguments extends WebAPICallOpt
 export interface ConversationsHistoryArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled,
   TimelinePaginationEnabled {
   channel: string;
+  include_all_metadata?: boolean;
 }
 cursorPaginationEnabledMethods.add('conversations.history');
 export interface ConversationsInfoArguments extends WebAPICallOptions, TokenOverridable, LocaleAware {


### PR DESCRIPTION
###  Summary

This PR introduces support for Slack's latest [Message Metadata](https://api.slack.com/metadata) feature. A new type "MessageMetadata" is introduced and additionally adding an optional "metadata" argument on ChatPostMessageArguments, ChatScheduleMessageArguments and ChatUpdateArguments.  

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
