### PR TITLE
Allow `handlerInstallPath` to work without `stateStore`

### DIFF
--- a/packages/webhook/src/IncomingWebhook.spec.js
+++ b/packages/webhook/src/IncomingWebhook.spec.js
@@ -11,7 +11,7 @@ const url = 'https://hooks.slack.com/services/FAKEWEBHOOK';
 describe('IncomingWebhook', function () {
 
   describe('constructor()', function () {
-    it('should build a default wehbook given a URL', function () {
+    it('should build a default webhook given a URL', function () {
       const webhook = new IncomingWebhook(url);
       assert.instanceOf(webhook, IncomingWebhook);
     });


### PR DESCRIPTION
###  Summary
#1506

This is a bit of a guess.  It worked when I edited the compiled code in my `node_modules` 🤮 but I wouldn't be surprised if there was a better way :)

I can't run the tests locally so I'm fully expecting them to fail.  This is more of a "here's what I found" PR.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
