### PR TITLE
Add types module to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,6 +18,7 @@ Select all that apply:
 - [ ] `@slack/webhooks`
 - [ ] `@slack/oauth`
 - [ ] `@slack/socket-mode`
+- [ ] `@slack/types`
 - [ ] I don't know
 
 ### Reproducible in:

--- a/.github/ISSUE_TEMPLATE/enhancement---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement---feature-request.md
@@ -18,8 +18,8 @@ Select all that apply:
 - [ ] `@slack/webhooks`
 - [ ] `@slack/oauth`
 - [ ] `@slack/socket-mode`
+- [ ] `@slack/types`
 - [ ] I don't know
-
 
 ### Requirements
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -18,6 +18,7 @@ Select all that apply:
 - [ ] `@slack/webhooks`
 - [ ] `@slack/oauth`
 - [ ] `@slack/socket-mode`
+- [ ] `@slack/types`
 - [ ] I don't know
 
 ### Reproducible in:

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -26,12 +26,11 @@ Filling out the following details about bugs will help us solve your issue soone
 Select all that apply:
 
 - [ ] `@slack/web-api`
-- [ ] `@slack/events-api`
-- [ ] `@slack/interactive-messages`
 - [ ] `@slack/rtm-api`
 - [ ] `@slack/webhooks`
 - [ ] `@slack/oauth`
 - [ ] `@slack/socket-mode`
+- [ ] `@slack/types`
 - [ ] I don't know
 
 #### Reproducible in:


### PR DESCRIPTION
###  Summary

This pull request updates the issue templates to have the types module.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
