### PR TITLE
Added in functionality for admin.analytics.getFile method

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -11,6 +11,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import FormData from 'form-data';
 import isElectron from 'is-electron';
 import zlib from 'zlib';
+import { TextDecoder } from 'util';
 
 import { Methods, CursorPaginationEnabled, cursorPaginationEnabledMethods } from './methods';
 import { getUserAgent } from './instrument';

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -13,9 +13,9 @@ import isElectron from 'is-electron';
 import zlib from 'zlib';
 import { TextDecoder } from 'util';
 import {
-  MemberDetails,
-  PublicChannelDetails,
-  PublicChannelMetadataDetails,
+  AdminAnalyticsMemberDetails,
+  AdminAnalyticsPublicChannelDetails,
+  AdminAnalyticsPublicChannelMetadataDetails,
 } from './response';
 
 import { Methods, CursorPaginationEnabled, cursorPaginationEnabledMethods } from './methods';
@@ -267,6 +267,8 @@ export class WebClient extends Methods {
     }
 
     // If result's content is gzip, "ok" property is not returned with successful response
+    // TODO: look into simplifying this code block to only check for the second condition
+    // if an { ok: false } body applies for all API errors
     if (!result.ok && (response.headers['content-type'] !== 'application/gzip')) {
       throw platformErrorFromResult(result as (WebAPICallResult & { error: string; }));
     } else if ('ok' in result && result.ok === false) {
@@ -569,7 +571,9 @@ export class WebClient extends Methods {
           .catch((err) => {
             throw err;
           });
-        const fileData: Array<MemberDetails | PublicChannelDetails | PublicChannelMetadataDetails> = [];
+        const fileData: Array<AdminAnalyticsMemberDetails |
+        AdminAnalyticsPublicChannelDetails |
+        AdminAnalyticsPublicChannelMetadataDetails> = [];
         if (Array.isArray(unzippedData)) {
           unzippedData.forEach((dataset) => {
             if (dataset && dataset.length > 0) {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -3,6 +3,7 @@ import { Dialog, View, KnownBlock, Block, MessageAttachment, LinkUnfurls, CallUs
 import { EventEmitter } from 'eventemitter3';
 import { WebAPICallOptions, WebAPICallResult, WebClient, WebClientEvent } from './WebClient';
 import {
+  AdminAnalyticsGetFileResponse,
   AdminAppsApproveResponse,
   AdminAppsApprovedListResponse,
   AdminAppsClearResolutionResponse,
@@ -247,7 +248,9 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
   public abstract apiCall(method: string, options?: WebAPICallOptions): Promise<WebAPICallResult>;
 
   public readonly admin = {
-    // TODO: admin.analytics.getFile
+    analytics: {
+      getFile: bindApiCall<AdminAnalyticsGetFileArguments, AdminAnalyticsGetFileResponse>(this, 'admin.analytics.getFile'),
+    },
     apps: {
       approve: bindApiCall<AdminAppsApproveArguments, AdminAppsApproveResponse>(this, 'admin.apps.approve'),
       approved: {
@@ -845,6 +848,11 @@ export interface TraditionalPagingEnabled {
 /*
 * `admin.*`
 */
+export interface AdminAnalyticsGetFileArguments extends WebAPICallOptions, TokenOverridable {
+  type: string;
+  date?: string;
+  metadata_only?: boolean;
+}
 export interface AdminAppsApproveArguments extends WebAPICallOptions, TokenOverridable {
   app_id?: string;
   request_id?: string;

--- a/packages/web-api/src/response/AdminAnalyticsGetFileResponse.ts
+++ b/packages/web-api/src/response/AdminAnalyticsGetFileResponse.ts
@@ -10,6 +10,7 @@
 
 import { WebAPICallResult } from '../WebClient';
 export type AdminAnalyticsGetFileResponse = WebAPICallResult & {
+  file_data?:         Array<MemberDetails|PublicChannelDetails|PublicChannelMetadataDetails>[];
   error?:             string;
   needed?:            string;
   ok?:                boolean;
@@ -19,4 +20,74 @@ export type AdminAnalyticsGetFileResponse = WebAPICallResult & {
 
 export interface ResponseMetadata {
   messages?: string[];
+}
+
+export interface MemberDetails {
+	enterprise_id:                 string;
+	date:                          string;
+	user_id:                       string;
+	email_address:                 string;
+	is_guest:                      boolean;
+	is_billable_seat:              boolean;
+	is_active:                     boolean;
+	is_active_ios:                 boolean;
+	is_active_android:             boolean;
+	is_active_desktop:             boolean;
+	reactions_added_count:         number;
+	messages_posted_count:         number;
+	channel_messages_posted_count: number;
+	files_added_count:             number;
+	is_active_apps:                boolean;
+	is_active_workflows:           boolean;
+	is_active_slack_connect:       boolean;
+	total_calls_count:             number;
+	slack_calls_count:             number;
+	slack_huddles_count:           number;
+	search_count:                  number;
+	date_claimed:                  number;
+}
+
+export interface PublicChannelDetails {
+  enterprise_id:                        string;
+  originating_team:                     OriginatingTeamDetails;
+  channel_id:                           string;
+  date_created:                         number;
+  date_last_active:                     number;
+  total_members_count:                  number;
+  full_members_count:                   number;
+  guest_member_count:                   number;
+  messages_posted_count:                number;
+  messages_posted_by_members_count:     number;
+  members_who_viewed_count:             number;
+  members_who_posted_count:             number;
+  reactions_added_count:                number;
+  visibility:                           string;
+  channel_type:                         string;
+  is_shared_externally:                 boolean;
+  shared_with:                          SharedWithDetails[];
+  externally_shared_with_organizations: ExternallySharedWithOrganizationsDetails[];
+  date:                                 string;
+}
+
+export interface PublicChannelMetadataDetails {
+  channel_id:  string;
+  name:        string;
+  topic:       string;
+  description: string;
+  date:        string;
+}
+
+export interface OriginatingTeamDetails {
+  team_id: string;
+  name:    string;
+}
+
+export interface SharedWithDetails {
+  team_id: string;
+  name:    string;
+}
+
+export interface ExternallySharedWithOrganizationsDetails {
+  name:      string;
+  domain:    string;
 }

--- a/packages/web-api/src/response/AdminAnalyticsGetFileResponse.ts
+++ b/packages/web-api/src/response/AdminAnalyticsGetFileResponse.ts
@@ -10,7 +10,7 @@
 
 import { WebAPICallResult } from '../WebClient';
 export type AdminAnalyticsGetFileResponse = WebAPICallResult & {
-  file_data?:         Array<MemberDetails|PublicChannelDetails|PublicChannelMetadataDetails>[];
+  file_data?:         Array<AdminAnalyticsMemberDetails|AdminAnalyticsPublicChannelDetails|AdminAnalyticsPublicChannelMetadataDetails>[];
   error?:             string;
   needed?:            string;
   ok?:                boolean;
@@ -22,34 +22,34 @@ export interface ResponseMetadata {
   messages?: string[];
 }
 
-export interface MemberDetails {
-	enterprise_id:                 string;
-	date:                          string;
-	user_id:                       string;
-	email_address:                 string;
-	is_guest:                      boolean;
-	is_billable_seat:              boolean;
-	is_active:                     boolean;
-	is_active_ios:                 boolean;
-	is_active_android:             boolean;
-	is_active_desktop:             boolean;
-	reactions_added_count:         number;
-	messages_posted_count:         number;
-	channel_messages_posted_count: number;
-	files_added_count:             number;
-	is_active_apps:                boolean;
-	is_active_workflows:           boolean;
-	is_active_slack_connect:       boolean;
-	total_calls_count:             number;
-	slack_calls_count:             number;
-	slack_huddles_count:           number;
-	search_count:                  number;
-	date_claimed:                  number;
+export interface AdminAnalyticsMemberDetails {
+  enterprise_id:                 string;
+  date:                          string;
+  user_id:                       string;
+  email_address:                 string;
+  is_guest:                      boolean;
+  is_billable_seat:              boolean;
+  is_active:                     boolean;
+  is_active_ios:                 boolean;
+  is_active_android:             boolean;
+  is_active_desktop:             boolean;
+  reactions_added_count:         number;
+  messages_posted_count:         number;
+  channel_messages_posted_count: number;
+  files_added_count:             number;
+  is_active_apps:                boolean;
+  is_active_workflows:           boolean;
+  is_active_slack_connect:       boolean;
+  total_calls_count:             number;
+  slack_calls_count:             number;
+  slack_huddles_count:           number;
+  search_count:                  number;
+  date_claimed:                  number;
 }
 
-export interface PublicChannelDetails {
+export interface AdminAnalyticsPublicChannelDetails {
   enterprise_id:                        string;
-  originating_team:                     OriginatingTeamDetails;
+  originating_team:                     AdminAnalyticsOriginatingTeamDetails;
   channel_id:                           string;
   date_created:                         number;
   date_last_active:                     number;
@@ -64,12 +64,12 @@ export interface PublicChannelDetails {
   visibility:                           string;
   channel_type:                         string;
   is_shared_externally:                 boolean;
-  shared_with:                          SharedWithDetails[];
-  externally_shared_with_organizations: ExternallySharedWithOrganizationsDetails[];
+  shared_with:                          AdminAnalyticsSharedWithDetails[];
+  externally_shared_with_organizations: AdminAnalyticsExternallySharedWithOrganizationsDetails[];
   date:                                 string;
 }
 
-export interface PublicChannelMetadataDetails {
+export interface AdminAnalyticsPublicChannelMetadataDetails {
   channel_id:  string;
   name:        string;
   topic:       string;
@@ -77,17 +77,17 @@ export interface PublicChannelMetadataDetails {
   date:        string;
 }
 
-export interface OriginatingTeamDetails {
+export interface AdminAnalyticsOriginatingTeamDetails {
   team_id: string;
   name:    string;
 }
 
-export interface SharedWithDetails {
+export interface AdminAnalyticsSharedWithDetails {
   team_id: string;
   name:    string;
 }
 
-export interface ExternallySharedWithOrganizationsDetails {
+export interface AdminAnalyticsExternallySharedWithOrganizationsDetails {
   name:      string;
   domain:    string;
 }

--- a/packages/web-api/src/response/index.ts
+++ b/packages/web-api/src/response/index.ts
@@ -1,4 +1,4 @@
-export { AdminAnalyticsGetFileResponse } from './AdminAnalyticsGetFileResponse';
+export { AdminAnalyticsGetFileResponse, MemberDetails, PublicChannelDetails, PublicChannelMetadataDetails } from './AdminAnalyticsGetFileResponse';
 export { AdminAppsApproveResponse } from './AdminAppsApproveResponse';
 export { AdminAppsApprovedListResponse } from './AdminAppsApprovedListResponse';
 export { AdminAppsClearResolutionResponse } from './AdminAppsClearResolutionResponse';

--- a/packages/web-api/src/response/index.ts
+++ b/packages/web-api/src/response/index.ts
@@ -1,4 +1,4 @@
-export { AdminAnalyticsGetFileResponse, MemberDetails, PublicChannelDetails, PublicChannelMetadataDetails } from './AdminAnalyticsGetFileResponse';
+export { AdminAnalyticsGetFileResponse, AdminAnalyticsMemberDetails, AdminAnalyticsPublicChannelDetails, AdminAnalyticsPublicChannelMetadataDetails } from './AdminAnalyticsGetFileResponse';
 export { AdminAppsApproveResponse } from './AdminAppsApproveResponse';
 export { AdminAppsApprovedListResponse } from './AdminAppsApprovedListResponse';
 export { AdminAppsClearResolutionResponse } from './AdminAppsClearResolutionResponse';

--- a/prod-server-integration-tests/test/admin-web-api-analytics.js
+++ b/prod-server-integration-tests/test/admin-web-api-analytics.js
@@ -1,0 +1,58 @@
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+describe('admin.analytics.* Web API', function () {
+  // org-level admin user's token
+  const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
+
+  describe('admin.analytics.getFile', function () {
+    it('should get file data', async function () {
+      const body = { type: 'public_channel', date: '2022-07-06' };
+      const res = await orgAdminClient.admin.analytics.getFile(body);
+      assert.isUndefined(res.error);
+      assert.isDefined(res.file_data);
+    });
+  });
+
+  describe('admin.analytics.getFile', function () {
+    it('should fail to get an available file', async function () {
+      const body = { type: 'public_channel', date: '2022-10-06' };
+      try {
+        await orgAdminClient.admin.analytics.getFile(body);
+      } catch (error) {
+        assert.isFalse(error.data.ok);
+        assert.isDefined(error.data.error, 'file_not_yet_available');
+      }
+    });
+  });
+
+  describe('admin.analytics.getFile', function () {
+    it('should get metadata when using public_channel type', async function () {
+      const body = { type: 'public_channel', metadata_only: true };
+      const res1 = await orgAdminClient.admin.analytics.getFile(body);
+      assert.isUndefined(res1.error);
+      assert.isDefined(res1.file_data);
+    });
+  });
+
+  describe('admin.analytics.getFile', function () {
+    it('should fail to get metadata when using member type', async function () {
+      const body = { type: 'member', metadata_only: true };
+      try {
+        await orgAdminClient.admin.analytics.getFile(body);
+      } catch (error) {
+        assert.isFalse(error.data.ok);
+        assert.isDefined(error.data.error, 'metadata_not_available');
+      }
+    });
+  });
+});

--- a/prod-server-integration-tests/test/admin-web-api-analytics.js
+++ b/prod-server-integration-tests/test/admin-web-api-analytics.js
@@ -15,43 +15,59 @@ describe('admin.analytics.* Web API', function () {
   const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
 
   describe('admin.analytics.getFile', function () {
-    it('should get file data', async function () {
+    it('should get an available file for a public_channel type and a date that has passed', async function () {
+      // This test may fail depending on the enterprise grid account you are testing on.
+      // To get this test to pass, please adjust the date to anywhere from 1 day after
+      // your enterprise grid org was created to the current date.
       const body = { type: 'public_channel', date: '2022-07-06' };
       const res = await orgAdminClient.admin.analytics.getFile(body);
       assert.isUndefined(res.error);
       assert.isDefined(res.file_data);
+      assert.property(res.file_data[0], 'total_members_count');
+      assert.property(res.file_data[0], 'full_members_count');
     });
-  });
 
-  describe('admin.analytics.getFile', function () {
-    it('should fail to get an available file', async function () {
-      const body = { type: 'public_channel', date: '2022-10-06' };
+    it('should fail to get an available file for a future date', async function () {
+      // This test may fail depending on the current date and the enterprise grid account you are testing on.
+      // To get this test to pass, please adjust the date to anywhere after today's date.
+      const body = { type: 'public_channel', date: '2035-10-06' };
       try {
         await orgAdminClient.admin.analytics.getFile(body);
       } catch (error) {
         assert.isFalse(error.data.ok);
-        assert.isDefined(error.data.error, 'file_not_yet_available');
+        assert.equal(error.data.error, 'file_not_yet_available');
       }
     });
-  });
 
-  describe('admin.analytics.getFile', function () {
-    it('should get metadata when using public_channel type', async function () {
-      const body = { type: 'public_channel', metadata_only: true };
+    it('should get an available file for a member type and a date that has passed', async function () {
+      // This test may fail depending on the enterprise grid account you are testing on.
+      // To get this test to pass, please adjust the date to anywhere from 1 day after
+      // your enterprise grid org was created to the current date.
+      const body = { type: 'member', date: '2022-07-06' };
       const res1 = await orgAdminClient.admin.analytics.getFile(body);
       assert.isUndefined(res1.error);
       assert.isDefined(res1.file_data);
+      assert.property(res1.file_data[0], 'user_id');
+      assert.property(res1.file_data[0], 'email_address');
     });
-  });
 
-  describe('admin.analytics.getFile', function () {
-    it('should fail to get metadata when using member type', async function () {
+    it('should get metadata when using public_channel type and metadata_only options', async function () {
+      const body = { type: 'public_channel', metadata_only: true };
+      const res2 = await orgAdminClient.admin.analytics.getFile(body);
+      assert.isUndefined(res2.error);
+      assert.isDefined(res2.file_data);
+      assert.property(res2.file_data[0], 'name');
+      assert.property(res2.file_data[0], 'topic');
+      assert.property(res2.file_data[0], 'description');
+    });
+
+    it('should fail to get metadata when using member type and metadata_only options', async function () {
       const body = { type: 'member', metadata_only: true };
       try {
         await orgAdminClient.admin.analytics.getFile(body);
       } catch (error) {
         assert.isFalse(error.data.ok);
-        assert.isDefined(error.data.error, 'metadata_not_available');
+        assert.equal(error.data.error, 'metadata_not_available');
       }
     });
   });

--- a/scripts/code_generator.rb
+++ b/scripts/code_generator.rb
@@ -48,6 +48,12 @@ class TsWriter
       index_f.puts("export { #{root_class_name} } from './#{root_class_name}';")
     end
   end
+
+  def append_multiple_classes_to_index(root_class_name, root_file_name, index_file)
+    File.open(index_file, 'a') do |index_f|
+      index_f.puts("export { #{root_class_name} } from './#{root_file_name}';")
+    end
+  end
 end
 
 ts_writer = TsWriter.new
@@ -77,7 +83,10 @@ Dir.glob(__dir__ + '/../tmp/java-slack-sdk/json-logs/samples/api/*').sort.each d
       input_json = json_file.read
       ts_writer.write(root_class_name, json_path, typedef_filepath, input_json)
       ts_writer.append_to_index(root_class_name, index_file)
-    end
+    else
+      puts "Generating AdminAnalyticsGetFileResponse, AdminAnalyticsMemberDetails, AdminAnalyticsPublicChannelDetails, AdminAnalyticsPublicChannelMetadataDetails from #{json_path}"
+      ts_writer.append_multiple_classes_to_index("AdminAnalyticsGetFileResponse, AdminAnalyticsMemberDetails, AdminAnalyticsPublicChannelDetails, AdminAnalyticsPublicChannelMetadataDetails", "AdminAnalyticsGetFileResponse", index_file)
+    end 
   end
 end
 

--- a/scripts/code_generator.rb
+++ b/scripts/code_generator.rb
@@ -57,25 +57,27 @@ Dir.glob(__dir__ + '/../tmp/java-slack-sdk/json-logs/samples/api/*').sort.each d
     root_class_name = ''
     prev_c = nil
     filename = json_path.split('/').last.gsub(/\.json$/, '')
-    filename.split('').each do |c|
-      if prev_c.nil? || prev_c == '.'
-        root_class_name << c.upcase
-      elsif c == '.'
-        # noop
-      else
-        root_class_name << c
+    if !filename.include? "admin.analytics.getFile"
+      filename.split('').each do |c|
+        if prev_c.nil? || prev_c == '.'
+          root_class_name << c.upcase
+        elsif c == '.'
+          # noop
+        else
+          root_class_name << c
+        end
+        prev_c = c
       end
-      prev_c = c
-    end
-    if root_class_name.start_with? 'Openid'
-      root_class_name.sub!('Openid', 'OpenID')
-    end
+      if root_class_name.start_with? 'Openid'
+        root_class_name.sub!('Openid', 'OpenID')
+      end
 
-    root_class_name << 'Response'
-    typedef_filepath = __dir__ + "/../packages/web-api/src/response/#{root_class_name}.ts"
-    input_json = json_file.read
-    ts_writer.write(root_class_name, json_path, typedef_filepath, input_json)
-    ts_writer.append_to_index(root_class_name, index_file)
+      root_class_name << 'Response'
+      typedef_filepath = __dir__ + "/../packages/web-api/src/response/#{root_class_name}.ts"
+      input_json = json_file.read
+      ts_writer.write(root_class_name, json_path, typedef_filepath, input_json)
+      ts_writer.append_to_index(root_class_name, index_file)
+    end
   end
 end
 


### PR DESCRIPTION
###  Summary

Adding in `admin.analytics.getFile` support as mentioned in: https://github.com/slackapi/node-slack-sdk/issues/1191

Link to docs for the method is here: https://api.slack.com/methods/admin.analytics.getFile. This method is a little more unique to other methods -
* In the event of a successful response, this method returns a binary string for a compressed JSON.gz file. Unlike other methods, there is no `ok` property to note its success. Due to the successful response being binary, it needs to be sent as an ArrayBuffer response to be able to be parsed properly - this was also added in this PR
* In the event of a failed response, this method has a similar JSON structure as errors for other methods: `{ ok: false, error: "error message" } `

Tested this functionality + tests locally on my own enterprise grid account.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
