### PR TITLE
Update @slack/client README to reflect deprecation

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,3 +1,5 @@
+> ### ⚠️ This package has been deprecated. View it on [npm](https://www.npmjs.com/package/@slack/client) for more information.
+
 # Slack Client (legacy)
 
 Legacy wrapper for official Slack Platform's Web API, RTM API, and Incoming Webhook libraries.


### PR DESCRIPTION
###  Summary

The `@slack/client` package has been deprecated based on issue #1508. Adding in a note in the README that it is deprecated.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
