### PR TITLE
Always handle web socket open when connecting

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -276,6 +276,7 @@ export class SocketModeClient extends EventEmitter {
       .on(Event.Failure)
         .transitionTo(State.Disconnected)
       .on(Event.WebSocketOpen)
+        // If submachine not `authenticated` ignore event
         .ignore()
     .state(State.Connected)
       .onEnter(() => {

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -275,6 +275,8 @@ export class SocketModeClient extends EventEmitter {
         .transitionTo(State.Disconnecting)
       .on(Event.Failure)
         .transitionTo(State.Disconnected)
+      .on(Event.WebSocketOpen)
+        .ignore()
     .state(State.Connected)
       .onEnter(() => {
         this.connected = true;


### PR DESCRIPTION
###  Summary

This should resolve #1521 
An edge case seem to be present when the `finite state machine (fns)` is not in the authenticated state and the listeners are initialized. This can happen when the application was connected (initialized), lost connection and is reconnecting.

If for some reason the `web socket open` event is triggered before authentication is successful the `fns` falls-back to handling this event at the `connecting` state level instead of the `submachine`. This causes an `fns` error which terminates the running process.

This pr changes the behavior of the `fns` to ignore `web socket open` events when it is in the `connecting` state and the submachine is not `authenticated`, this should prevent the process from terminating.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
