### PR TITLE
fix(1528): better warnings about webclient fallbacks

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -278,7 +278,7 @@ describe('WebClient', function () {
           .map((v) => ({ method, args: Object.assign({}, v, args) }))
         return acc.concat(textPatterns)
       }, []).forEach(({ method, args }) => {
-        it(`should send both text and fallback-argument-specific warning to logs when client executes ${method} without text argument(${args.text === "" ? "empty" : args.text}) nor without attachment-level fallback argument (${args.attachments[0].fallback === "  " ? "empty" : args.attachments[0].fallback})`, function () {
+        it(`should send attachment fallback warning to logs when client executes ${method} without text argument(${args.text === "" ? "empty" : args.text}) nor without attachment-level fallback argument (${args.attachments[0].fallback === "  " ? "empty" : args.attachments[0].fallback})`, function () {
           const logger = {
             debug: sinon.spy(),
             info: sinon.spy(),
@@ -290,7 +290,7 @@ describe('WebClient', function () {
           const warnClient = new WebClient(token, { logLevel: LogLevel.WARN, logger });
           return warnClient.apiCall(method, args)
             .then(() => {
-              assert.equal(logger.warn.callCount, 5)
+              assert.equal(logger.warn.callCount, 4)
             });
         });
       });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -699,8 +699,10 @@ function warnIfFallbackIsMissing(method: string, logger: Logger, options?: WebAP
   const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
   const isTargetMethod = targetMethods.includes(method);
 
+  const hasAttachments = (args: WebAPICallOptions) => Array.isArray(args.attachments) && args.attachments.length;
+
   const missingAttachmentFallbackDetected = (args: WebAPICallOptions) => Array.isArray(args.attachments) &&
-    args.attachments.length && args.attachments.some((attachment) => !attachment.fallback || attachment.fallback.trim() === '');
+    args.attachments.some((attachment) => !attachment.fallback || attachment.fallback.trim() === '');
 
   const isEmptyText = (args: WebAPICallOptions) => args.text === undefined || args.text === null || args.text === '';
 
@@ -713,12 +715,13 @@ function warnIfFallbackIsMissing(method: string, logger: Logger, options?: WebAP
     'To avoid this warning, it is recommended to always provide a top-level `text` argument when posting a message. ' +
     'Alternatively, you can provide an attachment-level `fallback` argument, though this is now considered a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details).';
   if (isTargetMethod && typeof options === 'object') {
-    if (isEmptyText(options)) {
-      if (missingAttachmentFallbackDetected(options)) {
-        logger.warn(buildMissingFallbackWarning());
-      } else {
+    if (hasAttachments(options)) {
+      if (missingAttachmentFallbackDetected(options) && isEmptyText(options)) {
         logger.warn(buildMissingTextWarning());
+        logger.warn(buildMissingFallbackWarning());
       }
+    } else if (isEmptyText(options)) {
+      logger.warn(buildMissingTextWarning());
     }
   }
 }

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -700,7 +700,7 @@ function warnIfFallbackIsMissing(method: string, logger: Logger, options?: WebAP
   const isTargetMethod = targetMethods.includes(method);
 
   const missingAttachmentFallbackDetected = (args: WebAPICallOptions) => Array.isArray(args.attachments) &&
-    args.attachments.some((attachment) => !attachment.fallback || attachment.fallback.trim() === '');
+    args.attachments.length && args.attachments.some((attachment) => !attachment.fallback || attachment.fallback.trim() === '');
 
   const isEmptyText = (args: WebAPICallOptions) => args.text === undefined || args.text === null || args.text === '';
 
@@ -714,9 +714,10 @@ function warnIfFallbackIsMissing(method: string, logger: Logger, options?: WebAP
     'Alternatively, you can provide an attachment-level `fallback` argument, though this is now considered a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details).';
   if (isTargetMethod && typeof options === 'object') {
     if (isEmptyText(options)) {
-      logger.warn(buildMissingTextWarning());
       if (missingAttachmentFallbackDetected(options)) {
         logger.warn(buildMissingFallbackWarning());
+      } else {
+        logger.warn(buildMissingTextWarning());
       }
     }
   }


### PR DESCRIPTION
###  Summary

fixes https://github.com/slackapi/node-slack-sdk/issues/1528

this PR updates the warning logic for the conversation api to better match this logic:

> If the top-level text does not exist and any of its attachments does not have fallback property, we still should warn it (we can say "You should have either top-level text or fallback in all the attachments" if we want to make it more accurate). If all the attachments have the fallback property, no warnings should be printed.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
