### PR TITLE
Bump lerna dependency

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    # - TODO run npm install and test on individual packages
     # - run: npm install
     # - run: npm run setup
     # - run: npm run test

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run setup
-    - run: npm run test
+    # - run: npm install
+    # - run: npm run setup
+    # - run: npm run test
     # - run: npm run coverage

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,8 +25,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    # - TODO run npm install and test on individual packages
-    # - run: npm install
-    # - run: npm run setup
-    # - run: npm run test
+    - run: npm install
+    - run: npm run setup
+    - run: npm run test
     # - run: npm run coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
+  "scripts": {
+    "test": "lerna run test",
+    "lint": "lerna run lint",
+    "setup": "lerna bootstrap --no-ci --hoist",
+    "ref-docs": "lerna run ref-docs:model --no-bail; lerna run start --scope @slack/sdk-ref-docs"
+  },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-plugin-jsdoc": "^30.6.1"
+    "eslint-plugin-jsdoc": "^30.6.1",
+    "lerna": "^5.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,6 @@
 {
-  "scripts": {
-    "test": "lerna run test",
-    "lint": "lerna run lint",
-    "setup": "lerna bootstrap --no-ci --hoist",
-    "ref-docs": "lerna run ref-docs:model --no-bail; lerna run start --scope @slack/sdk-ref-docs"
-  },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-plugin-jsdoc": "^30.6.1",
-    "lerna": "^4.0.0"
+    "eslint-plugin-jsdoc": "^30.6.1"
   }
 }


### PR DESCRIPTION
###  Summary

~~Lerna is officially [not actively maintained](https://github.com/lerna/lerna/pull/3092), and as far as I can tell it isn't used at the individual package level - each package maintains it's own tests.~~

Lerna ownership was handed over to a corp sponsor! I've bumped the version. 

This change ~~removes~~ bumps this dependency. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
