### PR TITLE
Remove Node 12.x from CI build 

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Refer to [the module document page](https://slack.dev/node-slack-sdk/socket-mode
 
 ## Requirements
 
-This package supports Node v12 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/docs/_main/index.md
+++ b/docs/_main/index.md
@@ -55,7 +55,7 @@ $ yarn add @slack/web-api @slack/events-api
 
 ## Requirements
 
-This package supports Node v12 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/docs/_packages/oauth.md
+++ b/docs/_packages/oauth.md
@@ -477,7 +477,7 @@ const installer = new InstallProvider({
 
 ### Requirements
 
-This package supports Node v12 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/docs/_packages/socket_mode.md
+++ b/docs/_packages/socket_mode.md
@@ -274,7 +274,7 @@ const socketModeClient = new SocketModeClient({
 
 ## Requirements
 
-This package supports Node v12 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features from that version.
 
 ## Getting Help

--- a/packages/events-api/README.md
+++ b/packages/events-api/README.md
@@ -316,7 +316,7 @@ the `SlackEventAdapter`:
 
 ## Requirements
 
-This package supports Node v8 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/packages/interactive-messages/README.md
+++ b/packages/interactive-messages/README.md
@@ -677,7 +677,7 @@ additional features of the `SlackMessageAdapter`:
 
 ## Requirements
 
-This package supports Node v8 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -362,7 +362,7 @@ const installer = new InstallProvider({
 
 ### Requirements
 
-This package supports Node v10 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -430,7 +430,7 @@ const rtm = new RTMClient(token, {
 
 ## Requirements
 
-This package supports Node v8 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 

--- a/packages/socket-mode/README.md
+++ b/packages/socket-mode/README.md
@@ -222,7 +222,7 @@ const socketModeClient = new SocketModeClient({
 
 ## Requirements
 
-This package supports Node v12 LTS and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features from that version.
 
 ## Getting Help

--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -6,7 +6,7 @@ The `@slack/web-api` package contains a simple, convenient, and configurable HTT
 
 ## Requirements
 
-This package supports Node v12.13 and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 


### PR DESCRIPTION
###  Summary

Remove Node 12.x as it has been EOL'ed. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
