### PR TITLE
Fix #1546 SocketModeClient raise TypeError when running Node.js 19

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -420,7 +420,7 @@ export class SocketModeClient extends EventEmitter {
         const flatMessage = JSON.stringify(message);
         this.logger.debug(`Sending a WebSocket message: ${flatMessage}`);
         this.websocket.send(flatMessage, (error) => {
-          if (error !== undefined) {
+          if (error !== undefined && error !== null) {
             this.logger.error(`Failed to send a WebSocket message (error: ${error.message})`);
             return reject(websocketErrorWithOriginal(error));
           }


### PR DESCRIPTION
###  Summary

This pull request resolves #1546. Since Node.js 19, underlying modules have changed their behaviors.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
