### PR TITLE
Publish @slack/types@2.8.0

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/types",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Shared type definitions for the Node Slack SDK",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

Release 2.8.0 for `@slack/types`: https://github.com/slackapi/node-slack-sdk/milestone/58?closed=1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
