### PR TITLE
Publish @slack/web-api@6.8.0

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "6.7.2",
+  "version": "6.8.0",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

Release new version of `@slack/web-api`, 6.8.0: https://github.com/slackapi/node-slack-sdk/milestone/46?closed=1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
