### PR TITLE
Upgrade dependency to @slack/types

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/types": "^2.0.0",
+    "@slack/types": "^2.8.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=12.0.0",
     "axios": "^0.27.2",


### PR DESCRIPTION
###  Summary

Upgrade dependency to @slack/types since type MessageMetaData (available in types ^2.6.0) is required 