### PR TITLE
fix(web-api): fix auth.revoke argument type definition

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1251,7 +1251,7 @@ export interface AppsUninstallArguments extends WebAPICallOptions {
  * `auth.*`
  */
 export interface AuthRevokeArguments extends WebAPICallOptions, TokenOverridable {
-  test: boolean;
+  test?: boolean;
 }
 export interface AuthTeamsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   include_icon?: boolean;


### PR DESCRIPTION
###  Summary

`test` argument for method `auth.revoke` should be optional. [docs](https://api.slack.com/methods/auth.revoke#arg_test)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
