### PR TITLE
Fix issue #1566 Add admin.conversations.bulk{Archive|Delete|Move} API method support

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -38,6 +38,9 @@ import {
   AdminConversationsGetCustomRetentionResponse,
   AdminConversationsSetCustomRetentionResponse,
   AdminConversationsRemoveCustomRetentionResponse,
+  AdminConversationsBulkArchiveResponse,
+  AdminConversationsBulkDeleteResponse,
+  AdminConversationsBulkMoveResponse,
   AdminEmojiAddAliasResponse,
   AdminEmojiAddResponse,
   AdminEmojiListResponse,
@@ -292,6 +295,9 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     },
     conversations: {
       archive: bindApiCall<AdminConversationsArchiveArguments, AdminConversationsArchiveResponse>(this, 'admin.conversations.archive'),
+      bulkArchive: bindApiCall<AdminConversationsBulkArchiveArguments, AdminConversationsBulkArchiveResponse>(this, 'admin.conversations.bulkArchive'),
+      bulkDelete: bindApiCall<AdminConversationsBulkDeleteArguments, AdminConversationsBulkDeleteResponse>(this, 'admin.conversations.bulkDelete'),
+      bulkMove: bindApiCall<AdminConversationsBulkMoveArguments, AdminConversationsBulkMoveResponse>(this, 'admin.conversations.bulkMove'),
       convertToPrivate:
         bindApiCall<AdminConversationsConvertToPrivateArguments, AdminConversationsConvertToPrivateResponse>(
           this, 'admin.conversations.convertToPrivate',
@@ -957,6 +963,16 @@ export interface AdminBarriersUpdateArguments extends WebAPICallOptions, TokenOv
 
 export interface AdminConversationsArchiveArguments extends WebAPICallOptions, TokenOverridable {
   channel_id: string;
+}
+export interface AdminConversationsBulkArchiveArguments extends WebAPICallOptions, TokenOverridable {
+  channel_ids: string[];
+}
+export interface AdminConversationsBulkDeleteArguments extends WebAPICallOptions, TokenOverridable {
+  channel_ids: string[];
+}
+export interface AdminConversationsBulkMoveArguments extends WebAPICallOptions, TokenOverridable {
+  channel_ids: string[];
+  target_team_id: string;
 }
 export interface AdminConversationsConvertToPrivateArguments extends WebAPICallOptions, TokenOverridable {
   channel_id: string;

--- a/prod-server-integration-tests/README.md
+++ b/prod-server-integration-tests/README.md
@@ -18,7 +18,7 @@ export SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN=xoxp-
 # org-level admin user's token
 export SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN=xoxp-
 # admin user's token for a secondary workspace in an Enterprise Grid org (must be in same org as workspace for SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, but a different workspace) - required for admin.conversations.bulkMove test
-export SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID=T0123456789
+export SLACK_SDK_TEST_GRID_SECONDARY_WORKSPACE_ID=T0123456789
 
 npm test
 ```

--- a/prod-server-integration-tests/README.md
+++ b/prod-server-integration-tests/README.md
@@ -17,6 +17,8 @@ export SLACK_SDK_TEST_USER_TOKEN=xoxp-
 export SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN=xoxp-
 # org-level admin user's token
 export SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN=xoxp-
+# admin user's token for a secondary workspace in an Enterprise Grid org (must be in same org as workspace for SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, but a different workspace) - required for admin.conversations.bulkMove test
+export SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID=T0123456789
 
 npm test
 ```

--- a/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
+++ b/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
@@ -1,0 +1,119 @@
+require('mocha');
+const { assert } = require('chai');
+const { WebClient } = require('@slack/web-api');
+
+const winston = require('winston');
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.File({ filename: 'logs/console.log' }),
+  ],
+});
+
+// Note: to run this test, you must have 2 workspaces on your Enterprise Grid and
+// you must have the SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID environment variable configured.
+describe('admin.* Web APIs', function () {
+  // admin user's token for a workspace in an Enterprise Grid org
+  const teamAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, { logger, });
+  // admin user's team ID for a secondary workspace in an Enterprise Grid org
+  // (must be in same org as workspace for teamAdminClient, but a different workspace)
+  const secondaryTeamId = process.env.SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID;
+  // org-level admin user's token
+  const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
+
+  describe('admin.conversations.bulk{Archive|Move|Delete}', function () {
+    // Test bulkArchive
+    it('should bulk archive conversations using admin.conversations.bulkArchive', async function () {
+      const testChannel = await teamAdminClient.conversations.create({
+        name: `test-bulk-archive-${new Date().getTime()}`,
+      });
+      const channelId = testChannel.channel.id;
+      let archiving = null;
+      let isInProgress = false;
+
+      while (archiving === null || isInProgress) {
+        try {
+          archiving = await orgAdminClient.admin.conversations.bulkArchive({
+            channel_ids: [channelId]
+          }).catch((error) => {
+            if (error.data.error === 'action_already_in_progress') {
+                isInProgress = true;
+                new Promise(r => setTimeout(r, 3000));
+            } else {
+                throw error;
+            }
+          });
+
+          if (archiving && archiving.ok) {
+            isInProgress = false;
+          }
+        } finally {
+          await orgAdminClient.admin.conversations.delete({
+            channel_id: channelId,
+          });
+        }
+      }
+
+      logger.info(archiving);
+      assert.isDefined(archiving.bulk_action_id);
+      assert.isUndefined(archiving.error);
+    });
+    it('should bulk delete conversations using admin.conversations.bulkDelete', async function () {
+      const testChannel = await teamAdminClient.conversations.create({
+        name: `test-bulk-delete-${new Date().getTime()}`,
+      });
+      const channelId = testChannel.channel.id;
+      let removing = null;
+      let isInProgress = false;
+
+      while (removing === null || isInProgress) {
+        removing = await orgAdminClient.admin.conversations.bulkDelete({
+            channel_ids: [channelId]
+          }).catch((error) => {
+            if (error.data.error === 'action_already_in_progress') {
+              isInProgress = true;
+              new Promise(r => setTimeout(r, 3000));
+            } else {
+              throw error;
+            }
+          });
+
+          if (removing && removing.ok) {
+            isInProgress = false;
+          }
+        }
+        logger.info(removing);
+        assert.isDefined(removing.bulk_action_id);
+        assert.isUndefined(removing.error);
+    });
+    it('should bulk move conversations using admin.conversations.bulkMove', async function () {
+      const testChannel = await teamAdminClient.conversations.create({
+        name: `test-bulk-move-${new Date().getTime()}`,
+      });
+      const channelId = testChannel.channel.id;
+      let moving = null;
+      let isInProgress = false;
+
+      while (moving === null || isInProgress) {
+        moving = await orgAdminClient.admin.conversations.bulkMove({
+            channel_ids: [channelId],
+            target_team_id: secondaryTeamId,
+          }).catch((error) => {
+            if (error.data.error === 'action_already_in_progress') {
+              isInProgress = true;
+              new Promise(r => setTimeout(r, 3000));
+            } else {
+              throw error;
+            }
+          });
+
+          if (moving && moving.ok) {
+            isInProgress = false;
+          }
+        }
+        logger.info(moving);
+        assert.isDefined(moving.bulk_action_id);
+        assert.isUndefined(moving.error);
+    });
+  });
+});

--- a/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
+++ b/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
@@ -11,13 +11,13 @@ const logger = winston.createLogger({
 });
 
 // Note: to run this test, you must have 2 workspaces on your Enterprise Grid and
-// you must have the SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID environment variable configured.
+// you must have the SLACK_SDK_TEST_GRID_SECONDARY_WORKSPACE_ID environment variable configured.
 describe('admin.* Web APIs', function () {
   // admin user's token for a workspace in an Enterprise Grid org
   const teamAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN, { logger, });
   // admin user's team ID for a secondary workspace in an Enterprise Grid org
   // (must be in same org as workspace for teamAdminClient, but a different workspace)
-  const secondaryTeamId = process.env.SLACK_SDK_TEST_GRID_WORKSPACE_TEAM_ID;
+  const secondaryTeamId = process.env.SLACK_SDK_TEST_GRID_SECONDARY_WORKSPACE_ID;
   // org-level admin user's token
   const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
 

--- a/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
+++ b/prod-server-integration-tests/test/admin-web-api-conversations-bulk.js
@@ -22,7 +22,6 @@ describe('admin.* Web APIs', function () {
   const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
 
   describe('admin.conversations.bulk{Archive|Move|Delete}', function () {
-    // Test bulkArchive
     it('should bulk archive conversations using admin.conversations.bulkArchive', async function () {
       const testChannel = await teamAdminClient.conversations.create({
         name: `test-bulk-archive-${new Date().getTime()}`,


### PR DESCRIPTION
###  Summary

This PR fixes Issue #1566 and adds support for the following methods in the `web-api` package:
- [admin.conversations.bulkArchive](https://api.slack.com/methods/admin.conversations.bulkArchive)
- [admin.conversations.bulkDelete](https://api.slack.com/methods/admin.conversations.bulkDelete)
- [admin.conversations.bulkMove](https://api.slack.com/methods/admin.conversations.bulkMove)

This PR also adds related tests in `prod-server-integration-tests` for these endpoints. Something to note is that with the addition of these tests, a new Env variable is required (`SLACK_SDK_TEST_GRID_SECONDARY_WORKSPACE_ID`), which is a workspace ID for a workspace in the same enterprise grid instance as the token for which `SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN` was generated. Integration tests were run locally to test and Node SDK updates were tested by importing the `web-api` package into a separate project and testing API calls with a script.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
