### PR TITLE
Upgrade jsonwebtoken for critical level security issues

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -43,7 +43,7 @@
     "@slack/web-api": "^6.3.0",
     "@types/jsonwebtoken": "^8.3.7",
     "@types/node": ">=12",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "lodash.isstring": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
###  Summary

```
$ npm audit
# npm audit report

jsonwebtoken  <=8.5.1
Severity: high
jsonwebtoken has insecure input validation in jwt.verify function - https://github.com/advisories/GHSA-27h2-hvpr-p74q
jsonwebtoken's insecure implementation of key retrieval function could lead to Forgeable Public/Private Tokens from RSA to HMAC - https://github.com/advisories/GHSA-hjrf-2m68-5959
jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify() - https://github.com/advisories/GHSA-qwph-4952-7xr6
jsonwebtoken unrestricted key type could lead to legacy keys usage  - https://github.com/advisories/GHSA-8cf7-32gw-wr33
fix available via `npm audit fix --force`
Will install jsonwebtoken@9.0.0, which is a breaking change
node_modules/jsonwebtoken

1 high severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
