### PR TITLE
Use Readable instead of ReadStream in uploadV2

### DIFF
--- a/packages/web-api/src/file-upload.spec.js
+++ b/packages/web-api/src/file-upload.spec.js
@@ -135,7 +135,7 @@ describe('file-upload', () => {
         const res = await getFileData(invalidFileUpload);
         assert.fail(res, "an error", "Was expecting an error, but got a result");
       } catch (err) {
-        assert.equal(err.message, 'file must be a valid string path, buffer or ReadStream');
+        assert.equal(err.message, 'file must be a valid string path, buffer or Readable');
         assert.equal(err.code, ErrorCode.FileUploadInvalidArgumentsError);
       }
 

--- a/packages/web-api/src/file-upload.ts
+++ b/packages/web-api/src/file-upload.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@slack/logger';
-import { readFileSync, ReadStream } from 'fs';
+import { readFileSync } from 'fs';
+import { Readable } from 'stream';
 import { errorWithCode, ErrorCode } from './errors';
 import { FilesCompleteUploadExternalArguments, FilesUploadV2Arguments, FileUploadV2, FileUploadV2Job } from './methods';
 
@@ -126,8 +127,8 @@ export async function getFileData(options: FilesUploadV2Arguments | FileUploadV2
       }
     }
 
-    // try to handle as ReadStream
-    const data = await getFileDataAsStream(file as ReadStream);
+    // try to handle as Readable
+    const data = await getFileDataAsStream(file as Readable);
     if (data) return data;
   }
   if (content) return Buffer.from(content);
@@ -149,7 +150,7 @@ export function getFileDataLength(data: Buffer): number {
   );
 }
 
-export async function getFileDataAsStream(readable: ReadStream): Promise<Buffer> {
+export async function getFileDataAsStream(readable: Readable): Promise<Buffer> {
   const chunks: Uint8Array[] = [];
 
   return new Promise((resolve, reject) => {
@@ -259,9 +260,9 @@ export function errorIfInvalidOrMissingFileData(options: FilesUploadV2Arguments 
     );
   }
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  if (file && !(typeof file === 'string' || Buffer.isBuffer(file) || (file as any) instanceof ReadStream)) {
+  if (file && !(typeof file === 'string' || Buffer.isBuffer(file) || (file as any) instanceof Readable)) {
     throw errorWithCode(
-      new Error('file must be a valid string path, buffer or ReadStream'),
+      new Error('file must be a valid string path, buffer or Readable'),
       ErrorCode.FileUploadInvalidArgumentsError,
     );
   }


### PR DESCRIPTION
###  Summary

The old `upload` method accepts a `Readable` for its file argument, but the new `uploadV2` accepts a `ReadStream`. There is no reason to use `ReadStream` here: `Readable` is strictly more generic (it's a superclass of `ReadStream`) and the code actually does not use any functionality specific to `ReadStream`, it only uses methods and events from `Readable`. This will make the transition from `upload` to `uploadV2` more easy.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
