### PR TITLE
feat: set default max concurrency to 100 for web-api client

### DIFF
--- a/docs/_packages/web_api.md
+++ b/docs/_packages/web_api.md
@@ -642,8 +642,8 @@ Each of the API method calls the client starts are happening **concurrently**, o
 to perform a lot of method calls, let's say 100 of them, at the same time, each one of them would be competing for the
 same network resources (such as bandwidth). By competing, they might negatively affect the performance of all the rest,
 and therefore negatively affect the performance of your app. This is one of the reasons why the `WebClient` limits the
-**concurrency** of requests by default to ten, which means it keeps track of how many requests are waiting, and only
-starts an eleventh request when one of them completes. The exact number of requests the client allows at the same time
+**concurrency** of requests by default to one hundred, which means it keeps track of how many requests are waiting, and only
+starts an additional request when one of them completes. The exact number of requests the client allows at the same time
 can be set using the `maxRequestConcurrency` option.
 
 ```javascript

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1040,25 +1040,23 @@ describe('WebClient', function () {
         });
     });
 
-    it('should have a default conncurrency of 3', function () {
+    it('should have a default conncurrency of 100', function () {
       const client = new WebClient(token);
-      const requests = [
-        client.apiCall('1'),
-        client.apiCall('2'),
-        client.apiCall('3'),
-        client.apiCall('4'),
-      ];
+      const requests = [];
+      for (let i = 0; i < 101; i++) {
+        requests.push(client.apiCall(`${i}`));
+      }
       return Promise.all(requests)
         .then((responses) => {
           // verify all responses are present
-          assert.lengthOf(responses, 4);
+          assert.lengthOf(responses, 101);
 
           // verify that maxRequestConcurrency requests were all sent concurrently
-          const concurrentResponses = responses.slice(0, 3); // the first 3 responses
+          const concurrentResponses = responses.slice(0, 100); // the first 100 responses
           concurrentResponses.forEach((r) => assert.isBelow(r.diff, responseDelay));
 
           // verify that any requests after maxRequestConcurrency were delayed by the responseDelay
-          const queuedResponses = responses.slice(3);
+          const queuedResponses = responses.slice(100);
           const minDiff = concurrentResponses[concurrentResponses.length - 1].diff + responseDelay;
           queuedResponses.forEach((r) => assert.isAtLeast(r.diff, minDiff));
         });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -163,7 +163,7 @@ export class WebClient extends Methods {
     slackApiUrl = 'https://slack.com/api/',
     logger = undefined,
     logLevel = undefined,
-    maxRequestConcurrency = 3,
+    maxRequestConcurrency = 100,
     retryConfig = tenRetriesInAboutThirtyMinutes,
     agent = undefined,
     tls = undefined,


### PR DESCRIPTION
###  Summary

Fixes https://github.com/slackapi/node-slack-sdk/issues/1582

Sets the default `maxRequestionConcurrency` to 100 and updates relevant documentation and tests.

I've been unable to get the tests and linting running locally despite running `npm i` at root, `npm run setup` at root, and then `npm run test` at either root or in the specific package - so will be relying on GitHub actions to verify these pass.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
