### PR TITLE
Publish @slack/rtm-api@6.1.0

### DIFF
--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/rtm-api",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Official library for using the Slack Platform's Real Time Messaging API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

Updating `@slack/rtm-api@6.1.0`. This change is mostly needed because of the requested security update in https://github.com/slackapi/node-slack-sdk/issues/1590 and https://github.com/slackapi/node-slack-sdk/issues/1251, but is being updated to a new minor version due to other updates that have also been made to this package (and across other packages) since then (view all updates here: https://github.com/slackapi/node-slack-sdk/commits/main/packages/rtm-api).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
