### PR TITLE
Update websocket send errback

### DIFF
--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -561,7 +561,7 @@ export class RTMClient extends EventEmitter {
         this.logger.debug(`sending message on websocket: ${flatMessage}`);
 
         this.websocket.send(flatMessage, (error) => {
-          if (error !== undefined) {
+          if (error) {
             this.logger.error(`failed to send message on websocket: ${error.message}`);
             return reject(websocketErrorWithOriginal(error));
           }

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -561,7 +561,8 @@ export class RTMClient extends EventEmitter {
         this.logger.debug(`sending message on websocket: ${flatMessage}`);
 
         this.websocket.send(flatMessage, (error) => {
-          if (error) {
+          // ws success callback uses undefined for Node.js < 19, null for 19+
+          if (error !== undefined && error !== null) {
             this.logger.error(`failed to send message on websocket: ${error.message}`);
             return reject(websocketErrorWithOriginal(error));
           }


### PR DESCRIPTION
###  Summary

Node v19.5.0: A successful websocket send returns a `null` param, instead of undefined. Any sent message (including pings) causes a TypeError.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
