### PR TITLE
Add five missing admin APIs

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -900,7 +900,9 @@ export function buildThreadTsWarningMessage(method: string): string {
  * @param body 
  * @returns 
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function redact(body: any): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const flattened = Object.entries(body).map<[string, any] | []>(([key, value]) => {
     // no value provided
     if (value === undefined || value === null) {
@@ -924,6 +926,7 @@ function redact(body: any): any {
   });
 
   // return as object 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const initialValue: { [key: string]: any; } = {};
   return flattened.reduce(
     (accumulator, [key, value]) => {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -213,6 +213,11 @@ import {
   BookmarksEditResponse,
   BookmarksListResponse,
   BookmarksRemoveResponse,
+  AdminConversationsConvertToPublicResponse,
+  AdminConversationsLookupResponse,
+  AdminRolesAddAssignmentsResponse,
+  AdminRolesListAssignmentsResponse,
+  AdminRolesRemoveAssignmentsResponse,
 } from './response';
 
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
@@ -302,6 +307,10 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         bindApiCall<AdminConversationsConvertToPrivateArguments, AdminConversationsConvertToPrivateResponse>(
           this, 'admin.conversations.convertToPrivate',
         ),
+      convertToPublic:
+        bindApiCall<AdminConversationsConvertToPublicArguments, AdminConversationsConvertToPublicResponse>(
+          this, 'admin.conversations.convertToPublic',
+        ),
       create: bindApiCall<AdminConversationsCreateArguments, AdminConversationsCreateResponse>(this, 'admin.conversations.create'),
       delete: bindApiCall<AdminConversationsDeleteArguments, AdminConversationsDeleteResponse>(this, 'admin.conversations.delete'),
       disconnectShared:
@@ -352,6 +361,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         bindApiCall<AdminConversationsRemoveCustomRetentionArguments, AdminConversationsRemoveCustomRetentionResponse>(
           this, 'admin.conversations.removeCustomRetention',
         ),
+      lookup: bindApiCall<AdminConversationsLookupArguments, AdminConversationsLookupResponse>(this, 'admin.conversations.lookup'),
       search: bindApiCall<AdminConversationsSearchArguments, AdminConversationsSearchResponse>(this, 'admin.conversations.search'),
       setConversationPrefs:
         bindApiCall<AdminConversationsSetConversationPrefsArguments, AdminConversationsSetConversationPrefsResponse>(
@@ -419,6 +429,11 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
           this, 'admin.teams.settings.setName',
         ),
       },
+    },
+    roles: {
+      addAssignments: bindApiCall<AdminRolesAddAssignmentsArguments, AdminRolesAddAssignmentsResponse>(this, 'admin.roles.addAssignments'),
+      listAssignments: bindApiCall<AdminRolesListAssignmentsArguments, AdminRolesListAssignmentsResponse>(this, 'admin.roles.listAssignments'),
+      removeAssignments: bindApiCall<AdminRolesRemoveAssignmentsArguments, AdminRolesRemoveAssignmentsResponse>(this, 'admin.roles.removeAssignments'),
     },
     usergroups: {
       addChannels: bindApiCall<AdminUsergroupsAddChannelsArguments, AdminUsergroupsAddChannelsResponse>(
@@ -977,6 +992,9 @@ export interface AdminConversationsBulkMoveArguments extends WebAPICallOptions, 
 export interface AdminConversationsConvertToPrivateArguments extends WebAPICallOptions, TokenOverridable {
   channel_id: string;
 }
+export interface AdminConversationsConvertToPublicArguments extends WebAPICallOptions, TokenOverridable {
+  channel_id: string;
+}
 export interface AdminConversationsCreateArguments extends WebAPICallOptions, TokenOverridable {
   is_private: boolean;
   name: string;
@@ -991,6 +1009,13 @@ export interface AdminConversationsDisconnectSharedArguments extends WebAPICallO
   channel_id: string;
   leaving_team_ids?: string[];
 }
+export interface AdminConversationsLookupArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  last_message_activity_before: number;
+  team_ids: string[];
+  max_member_count?: number;
+}
+cursorPaginationEnabledMethods.add('admin.conversations.lookup');
 export interface AdminConversationsEKMListOriginalConnectedChannelInfoArguments
   extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   channel_ids?: string[];
@@ -1099,6 +1124,26 @@ cursorPaginationEnabledMethods.add('admin.inviteRequests.denied.list');
 export interface AdminInviteRequestsListArguments
   extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
   team_id: string;
+}
+cursorPaginationEnabledMethods.add('admin.inviteRequests.list');
+export interface AdminRolesAddAssignmentsArguments
+  extends WebAPICallOptions, TokenOverridable {
+  role_id: string;
+  entity_ids: string[];
+  user_ids: string[];
+}
+export interface AdminRolesListAssignmentsArguments
+  extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {
+  entity_ids?: string[];
+  role_ids?: string[];
+  sort_dir?: string;
+}
+cursorPaginationEnabledMethods.add('admin.roles.listAssignments');
+export interface AdminRolesRemoveAssignmentsArguments
+  extends WebAPICallOptions, TokenOverridable {
+  role_id: string;
+  entity_ids: string[];
+  user_ids: string[];
 }
 cursorPaginationEnabledMethods.add('admin.inviteRequests.list');
 export interface AdminTeamsAdminsListArguments extends WebAPICallOptions, TokenOverridable, CursorPaginationEnabled {

--- a/packages/web-api/src/response/AdminConversationsConvertToPublicResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsConvertToPublicResponse.ts
@@ -9,33 +9,13 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type BookmarksEditResponse = WebAPICallResult & {
-  bookmark?:          Bookmark;
+export type AdminConversationsConvertToPublicResponse = WebAPICallResult & {
   error?:             string;
   needed?:            string;
   ok?:                boolean;
   provided?:          string;
   response_metadata?: ResponseMetadata;
 };
-
-export interface Bookmark {
-  app_action_id?:           string;
-  app_id?:                  string;
-  channel_id?:              string;
-  date_created?:            number;
-  date_updated?:            number;
-  emoji?:                   string;
-  entity_id?:               string;
-  icon_url?:                string;
-  id?:                      string;
-  last_updated_by_team_id?: string;
-  last_updated_by_user_id?: string;
-  link?:                    string;
-  rank?:                    string;
-  shortcut_id?:             string;
-  title?:                   string;
-  type?:                    string;
-}
 
 export interface ResponseMetadata {
   messages?: string[];

--- a/packages/web-api/src/response/AdminConversationsLookupResponse.ts
+++ b/packages/web-api/src/response/AdminConversationsLookupResponse.ts
@@ -9,8 +9,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type BookmarksEditResponse = WebAPICallResult & {
-  bookmark?:          Bookmark;
+export type AdminConversationsLookupResponse = WebAPICallResult & {
+  channel_ids?:       string[];
   error?:             string;
   needed?:            string;
   ok?:                boolean;
@@ -18,25 +18,6 @@ export type BookmarksEditResponse = WebAPICallResult & {
   response_metadata?: ResponseMetadata;
 };
 
-export interface Bookmark {
-  app_action_id?:           string;
-  app_id?:                  string;
-  channel_id?:              string;
-  date_created?:            number;
-  date_updated?:            number;
-  emoji?:                   string;
-  entity_id?:               string;
-  icon_url?:                string;
-  id?:                      string;
-  last_updated_by_team_id?: string;
-  last_updated_by_user_id?: string;
-  link?:                    string;
-  rank?:                    string;
-  shortcut_id?:             string;
-  title?:                   string;
-  type?:                    string;
-}
-
 export interface ResponseMetadata {
-  messages?: string[];
+  next_cursor?: string;
 }

--- a/packages/web-api/src/response/AdminRolesAddAssignmentsResponse.ts
+++ b/packages/web-api/src/response/AdminRolesAddAssignmentsResponse.ts
@@ -9,32 +9,15 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type AuthTeamsListResponse = WebAPICallResult & {
-  error?:             string;
-  needed?:            string;
-  ok?:                boolean;
-  provided?:          string;
-  response_metadata?: ResponseMetadata;
-  teams?:             Team[];
+export type AdminRolesAddAssignmentsResponse = WebAPICallResult & {
+  error?:          string;
+  needed?:         string;
+  ok?:             boolean;
+  provided?:       string;
+  rejected_users?: RejectedUser[];
 };
 
-export interface ResponseMetadata {
-  next_cursor?: string;
-}
-
-export interface Team {
-  icon?: Icon;
-  id?:   string;
-  name?: string;
-}
-
-export interface Icon {
-  image_102?:     string;
-  image_132?:     string;
-  image_230?:     string;
-  image_34?:      string;
-  image_44?:      string;
-  image_68?:      string;
-  image_88?:      string;
-  image_default?: boolean;
+export interface RejectedUser {
+  error?: string;
+  id?:    string;
 }

--- a/packages/web-api/src/response/AdminRolesListAssignmentsResponse.ts
+++ b/packages/web-api/src/response/AdminRolesListAssignmentsResponse.ts
@@ -9,34 +9,23 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type BookmarksEditResponse = WebAPICallResult & {
-  bookmark?:          Bookmark;
+export type AdminRolesListAssignmentsResponse = WebAPICallResult & {
   error?:             string;
   needed?:            string;
   ok?:                boolean;
   provided?:          string;
   response_metadata?: ResponseMetadata;
+  role_assignments?:  RoleAssignment[];
 };
 
-export interface Bookmark {
-  app_action_id?:           string;
-  app_id?:                  string;
-  channel_id?:              string;
-  date_created?:            number;
-  date_updated?:            number;
-  emoji?:                   string;
-  entity_id?:               string;
-  icon_url?:                string;
-  id?:                      string;
-  last_updated_by_team_id?: string;
-  last_updated_by_user_id?: string;
-  link?:                    string;
-  rank?:                    string;
-  shortcut_id?:             string;
-  title?:                   string;
-  type?:                    string;
+export interface ResponseMetadata {
+  messages?:    string[];
+  next_cursor?: string;
 }
 
-export interface ResponseMetadata {
-  messages?: string[];
+export interface RoleAssignment {
+  date_create?: number;
+  entity_id?:   string;
+  role_id?:     string;
+  user_id?:     string;
 }

--- a/packages/web-api/src/response/AdminRolesRemoveAssignmentsResponse.ts
+++ b/packages/web-api/src/response/AdminRolesRemoveAssignmentsResponse.ts
@@ -9,32 +9,9 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../WebClient';
-export type AuthTeamsListResponse = WebAPICallResult & {
-  error?:             string;
-  needed?:            string;
-  ok?:                boolean;
-  provided?:          string;
-  response_metadata?: ResponseMetadata;
-  teams?:             Team[];
+export type AdminRolesRemoveAssignmentsResponse = WebAPICallResult & {
+  error?:    string;
+  needed?:   string;
+  ok?:       boolean;
+  provided?: string;
 };
-
-export interface ResponseMetadata {
-  next_cursor?: string;
-}
-
-export interface Team {
-  icon?: Icon;
-  id?:   string;
-  name?: string;
-}
-
-export interface Icon {
-  image_102?:     string;
-  image_132?:     string;
-  image_230?:     string;
-  image_34?:      string;
-  image_44?:      string;
-  image_68?:      string;
-  image_88?:      string;
-  image_default?: boolean;
-}

--- a/packages/web-api/src/response/BookmarksAddResponse.ts
+++ b/packages/web-api/src/response/BookmarksAddResponse.ts
@@ -19,6 +19,7 @@ export type BookmarksAddResponse = WebAPICallResult & {
 };
 
 export interface Bookmark {
+  app_action_id?:           string;
   app_id?:                  string;
   channel_id?:              string;
   date_created?:            number;

--- a/packages/web-api/src/response/BookmarksListResponse.ts
+++ b/packages/web-api/src/response/BookmarksListResponse.ts
@@ -19,6 +19,7 @@ export type BookmarksListResponse = WebAPICallResult & {
 };
 
 export interface Bookmark {
+  app_action_id?:           string;
   app_id?:                  string;
   channel_id?:              string;
   date_created?:            number;

--- a/packages/web-api/src/response/ChatPostMessageResponse.ts
+++ b/packages/web-api/src/response/ChatPostMessageResponse.ts
@@ -56,6 +56,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -237,6 +238,7 @@ export interface AccessoryElement {
   indent?:   number;
   offset?:   number;
   style?:    string;
+  text?:     string;
   type?:     string;
 }
 
@@ -356,6 +358,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -397,6 +400,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -547,6 +551,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -588,6 +593,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ChatScheduleMessageResponse.ts
+++ b/packages/web-api/src/response/ChatScheduleMessageResponse.ts
@@ -257,6 +257,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -298,6 +299,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ChatUpdateResponse.ts
+++ b/packages/web-api/src/response/ChatUpdateResponse.ts
@@ -262,6 +262,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -303,6 +304,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -468,6 +470,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -509,6 +512,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ConversationsHistoryResponse.ts
+++ b/packages/web-api/src/response/ConversationsHistoryResponse.ts
@@ -73,6 +73,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -373,6 +374,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -414,6 +416,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -564,6 +567,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -605,6 +609,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ConversationsInviteResponse.ts
+++ b/packages/web-api/src/response/ConversationsInviteResponse.ts
@@ -12,6 +12,7 @@ import { WebAPICallResult } from '../WebClient';
 export type ConversationsInviteResponse = WebAPICallResult & {
   channel?:  Channel;
   error?:    string;
+  errors?:   Error[];
   needed?:   string;
   ok?:       boolean;
   provided?: string;
@@ -54,4 +55,9 @@ export interface Purpose {
   creator?:  string;
   last_set?: number;
   value?:    string;
+}
+
+export interface Error {
+  error?: string;
+  ok?:    boolean;
 }

--- a/packages/web-api/src/response/ConversationsListConnectInvitesResponse.ts
+++ b/packages/web-api/src/response/ConversationsListConnectInvitesResponse.ts
@@ -31,7 +31,7 @@ export interface InviteElement {
 
 export interface Acceptance {
   accepting_team?:    IngTeam;
-  accepting_user?:    AcceptingUser;
+  accepting_user?:    TingUser;
   approval_status?:   string;
   date_accepted?:     number;
   date_invalid?:      number;
@@ -40,12 +40,13 @@ export interface Acceptance {
 }
 
 export interface IngTeam {
-  date_created?: number;
-  domain?:       string;
-  icon?:         Icon;
-  id?:           string;
-  is_verified?:  boolean;
-  name?:         string;
+  avatar_base_url?: string;
+  date_created?:    number;
+  domain?:          string;
+  icon?:            Icon;
+  id?:              string;
+  is_verified?:     boolean;
+  name?:            string;
 }
 
 export interface Icon {
@@ -60,12 +61,13 @@ export interface Icon {
   image_original?: string;
 }
 
-export interface AcceptingUser {
-  id?:      string;
-  name?:    string;
-  profile?: Profile;
-  team_id?: string;
-  updated?: number;
+export interface TingUser {
+  id?:                         string;
+  name?:                       string;
+  profile?:                    Profile;
+  team_id?:                    string;
+  updated?:                    number;
+  who_can_share_contact_card?: string;
 }
 
 export interface Profile {
@@ -104,30 +106,11 @@ export interface InviteInvite {
   date_created?:      number;
   date_invalid?:      number;
   id?:                string;
-  inviting_team?:     InvitingTeam;
-  inviting_user?:     InvitingUser;
+  inviting_team?:     IngTeam;
+  inviting_user?:     TingUser;
   link?:              string;
   recipient_email?:   string;
   recipient_user_id?: string;
-}
-
-export interface InvitingTeam {
-  avatar_base_url?: string;
-  date_created?:    number;
-  domain?:          string;
-  icon?:            Icon;
-  id?:              string;
-  is_verified?:     boolean;
-  name?:            string;
-}
-
-export interface InvitingUser {
-  id?:                         string;
-  name?:                       string;
-  profile?:                    Profile;
-  team_id?:                    string;
-  updated?:                    number;
-  who_can_share_contact_card?: string;
 }
 
 export interface ResponseMetadata {

--- a/packages/web-api/src/response/ConversationsOpenResponse.ts
+++ b/packages/web-api/src/response/ConversationsOpenResponse.ts
@@ -273,6 +273,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -314,6 +315,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/response/ConversationsRepliesResponse.ts
@@ -62,6 +62,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -362,6 +363,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -403,6 +405,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -553,6 +556,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -594,6 +598,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesInfoResponse.ts
+++ b/packages/web-api/src/response/FilesInfoResponse.ts
@@ -60,6 +60,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -101,6 +102,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesListResponse.ts
+++ b/packages/web-api/src/response/FilesListResponse.ts
@@ -45,6 +45,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -60,6 +61,7 @@ export interface File {
   lines?:                     number;
   lines_more?:                number;
   media_display_type?:        string;
+  media_progress?:            MediaProgress;
   mimetype?:                  string;
   mode?:                      string;
   mp4?:                       string;
@@ -85,6 +87,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -165,6 +168,12 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface MediaProgress {
+  duration_ms?:   number;
+  max_offset_ms?: number;
+  offset_ms?:     number;
 }
 
 export interface Reaction {

--- a/packages/web-api/src/response/FilesRemoteAddResponse.ts
+++ b/packages/web-api/src/response/FilesRemoteAddResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesRemoteInfoResponse.ts
+++ b/packages/web-api/src/response/FilesRemoteInfoResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesRemoteListResponse.ts
+++ b/packages/web-api/src/response/FilesRemoteListResponse.ts
@@ -45,6 +45,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -60,6 +61,7 @@ export interface File {
   lines?:                     number;
   lines_more?:                number;
   media_display_type?:        string;
+  media_progress?:            MediaProgress;
   mimetype?:                  string;
   mode?:                      string;
   mp4?:                       string;
@@ -67,8 +69,8 @@ export interface File {
   non_owner_editable?:        boolean;
   num_stars?:                 number;
   original_attachment_count?: number;
-  original_h?:                number;
-  original_w?:                number;
+  original_h?:                string;
+  original_w?:                string;
   permalink?:                 string;
   permalink_public?:          string;
   pinned_to?:                 string[];
@@ -85,44 +87,45 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
   thumb_1024_gif?:            string;
-  thumb_1024_h?:              number;
-  thumb_1024_w?:              number;
+  thumb_1024_h?:              string;
+  thumb_1024_w?:              string;
   thumb_160?:                 string;
   thumb_160_gif?:             string;
   thumb_160_h?:               string;
   thumb_160_w?:               string;
   thumb_360?:                 string;
   thumb_360_gif?:             string;
-  thumb_360_h?:               number;
-  thumb_360_w?:               number;
+  thumb_360_h?:               string;
+  thumb_360_w?:               string;
   thumb_480?:                 string;
   thumb_480_gif?:             string;
-  thumb_480_h?:               number;
-  thumb_480_w?:               number;
+  thumb_480_h?:               string;
+  thumb_480_w?:               string;
   thumb_64?:                  string;
   thumb_64_gif?:              string;
   thumb_64_h?:                string;
   thumb_64_w?:                string;
   thumb_720?:                 string;
   thumb_720_gif?:             string;
-  thumb_720_h?:               number;
-  thumb_720_w?:               number;
+  thumb_720_h?:               string;
+  thumb_720_w?:               string;
   thumb_80?:                  string;
   thumb_800?:                 string;
   thumb_800_gif?:             string;
-  thumb_800_h?:               number;
-  thumb_800_w?:               number;
+  thumb_800_h?:               string;
+  thumb_800_w?:               string;
   thumb_80_gif?:              string;
   thumb_80_h?:                string;
   thumb_80_w?:                string;
   thumb_960?:                 string;
   thumb_960_gif?:             string;
-  thumb_960_h?:               number;
-  thumb_960_w?:               number;
+  thumb_960_h?:               string;
+  thumb_960_w?:               string;
   thumb_gif?:                 string;
   thumb_pdf?:                 string;
   thumb_pdf_h?:               string;
@@ -165,6 +168,12 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface MediaProgress {
+  duration_ms?:   number;
+  max_offset_ms?: number;
+  offset_ms?:     number;
 }
 
 export interface Reaction {

--- a/packages/web-api/src/response/FilesRemoteShareResponse.ts
+++ b/packages/web-api/src/response/FilesRemoteShareResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesRemoteUpdateResponse.ts
+++ b/packages/web-api/src/response/FilesRemoteUpdateResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesRevokePublicURLResponse.ts
+++ b/packages/web-api/src/response/FilesRevokePublicURLResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesSharedPublicURLResponse.ts
+++ b/packages/web-api/src/response/FilesSharedPublicURLResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/FilesUploadResponse.ts
+++ b/packages/web-api/src/response/FilesUploadResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -85,6 +86,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/PinsListResponse.ts
+++ b/packages/web-api/src/response/PinsListResponse.ts
@@ -52,6 +52,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -93,6 +94,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ReactionsGetResponse.ts
+++ b/packages/web-api/src/response/ReactionsGetResponse.ts
@@ -258,6 +258,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -299,6 +300,7 @@ export interface File {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/ReactionsListResponse.ts
+++ b/packages/web-api/src/response/ReactionsListResponse.ts
@@ -27,6 +27,7 @@ export interface Item {
 
 export interface Message {
   app_id?:            string;
+  attachments?:       Attachment[];
   blocks?:            Block[];
   bot_id?:            string;
   bot_profile?:       BotProfile;
@@ -53,6 +54,97 @@ export interface Message {
   upload?:            boolean;
   user?:              string;
   username?:          string;
+}
+
+export interface Attachment {
+  actions?:               Action[];
+  app_id?:                string;
+  app_unfurl_url?:        string;
+  author_icon?:           string;
+  author_id?:             string;
+  author_link?:           string;
+  author_name?:           string;
+  author_subname?:        string;
+  blocks?:                Block[];
+  bot_id?:                string;
+  callback_id?:           string;
+  channel_id?:            string;
+  channel_name?:          string;
+  channel_team?:          string;
+  color?:                 string;
+  fallback?:              string;
+  fields?:                Field[];
+  filename?:              string;
+  files?:                 FileElement[];
+  footer?:                string;
+  footer_icon?:           string;
+  from_url?:              string;
+  id?:                    number;
+  image_bytes?:           number;
+  image_height?:          number;
+  image_url?:             string;
+  image_width?:           number;
+  indent?:                boolean;
+  is_app_unfurl?:         boolean;
+  is_msg_unfurl?:         boolean;
+  is_reply_unfurl?:       boolean;
+  is_thread_root_unfurl?: boolean;
+  metadata?:              Metadata;
+  mimetype?:              string;
+  mrkdwn_in?:             string[];
+  msg_subtype?:           string;
+  original_url?:          string;
+  pretext?:               string;
+  preview?:               Preview;
+  service_icon?:          string;
+  service_name?:          string;
+  service_url?:           string;
+  size?:                  number;
+  text?:                  string;
+  thumb_height?:          number;
+  thumb_url?:             string;
+  thumb_width?:           number;
+  title?:                 string;
+  title_link?:            string;
+  ts?:                    string;
+  url?:                   string;
+  video_html?:            string;
+  video_html_height?:     number;
+  video_html_width?:      number;
+  video_url?:             string;
+}
+
+export interface Action {
+  confirm?:          ActionConfirm;
+  data_source?:      string;
+  id?:               string;
+  min_query_length?: number;
+  name?:             string;
+  option_groups?:    ActionOptionGroup[];
+  options?:          SelectedOptionElement[];
+  selected_options?: SelectedOptionElement[];
+  style?:            string;
+  text?:             string;
+  type?:             string;
+  url?:              string;
+  value?:            string;
+}
+
+export interface ActionConfirm {
+  dismiss_text?: string;
+  ok_text?:      string;
+  text?:         string;
+  title?:        string;
+}
+
+export interface ActionOptionGroup {
+  options?: SelectedOptionElement[];
+  text?:    string;
+}
+
+export interface SelectedOptionElement {
+  text?:  string;
+  value?: string;
 }
 
 export interface Block {
@@ -102,7 +194,7 @@ export interface Accessory {
   action_id?:                       string;
   alt_text?:                        string;
   border?:                          number;
-  confirm?:                         Confirm;
+  confirm?:                         AccessoryConfirm;
   default_to_current_conversation?: boolean;
   elements?:                        AccessoryElement[];
   fallback?:                        string;
@@ -119,16 +211,16 @@ export interface Accessory {
   initial_conversations?:           string[];
   initial_date?:                    string;
   initial_date_time?:               number;
-  initial_option?:                  Option;
-  initial_options?:                 Option[];
+  initial_option?:                  InitialOptionElement;
+  initial_options?:                 InitialOptionElement[];
   initial_time?:                    string;
   initial_user?:                    string;
   initial_users?:                   string[];
   max_selected_items?:              number;
   min_query_length?:                number;
   offset?:                          number;
-  option_groups?:                   OptionGroup[];
-  options?:                         Option[];
+  option_groups?:                   AccessoryOptionGroup[];
+  options?:                         InitialOptionElement[];
   placeholder?:                     Description;
   response_url_enabled?:            boolean;
   style?:                           string;
@@ -139,7 +231,7 @@ export interface Accessory {
   value?:                           string;
 }
 
-export interface Confirm {
+export interface AccessoryConfirm {
   confirm?: Description;
   deny?:    Description;
   style?:   string;
@@ -193,16 +285,16 @@ export interface Filter {
   include?:                          string[];
 }
 
-export interface Option {
+export interface InitialOptionElement {
   description?: Description;
   text?:        Description;
   url?:         string;
   value?:       string;
 }
 
-export interface OptionGroup {
+export interface AccessoryOptionGroup {
   label?:   Description;
-  options?: Option[];
+  options?: InitialOptionElement[];
 }
 
 export interface Call {
@@ -279,6 +371,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -320,6 +413,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -437,20 +531,10 @@ export interface Transcription {
   status?: string;
 }
 
-export interface BotProfile {
-  app_id?:  string;
-  deleted?: boolean;
-  icons?:   Icons;
-  id?:      string;
-  name?:    string;
-  team_id?: string;
-  updated?: number;
-}
-
-export interface Icons {
-  image_36?: string;
-  image_48?: string;
-  image_72?: string;
+export interface Field {
+  short?: boolean;
+  title?: string;
+  value?: string;
 }
 
 export interface FileElement {
@@ -480,6 +564,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -521,6 +606,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -578,6 +664,44 @@ export interface FileElement {
   user_team?:                 string;
   username?:                  string;
   vtt?:                       string;
+}
+
+export interface Metadata {
+  extension?:   string;
+  format?:      string;
+  original_h?:  number;
+  original_w?:  number;
+  rotation?:    number;
+  thumb_160?:   boolean;
+  thumb_360_h?: number;
+  thumb_360_w?: number;
+  thumb_64?:    boolean;
+  thumb_80?:    boolean;
+  thumb_tiny?:  string;
+}
+
+export interface Preview {
+  can_remove?: boolean;
+  icon_url?:   string;
+  subtitle?:   Description;
+  title?:      Description;
+  type?:       string;
+}
+
+export interface BotProfile {
+  app_id?:  string;
+  deleted?: boolean;
+  icons?:   Icons;
+  id?:      string;
+  name?:    string;
+  team_id?: string;
+  updated?: number;
+}
+
+export interface Icons {
+  image_36?: string;
+  image_48?: string;
+  image_72?: string;
 }
 
 export interface Paging {

--- a/packages/web-api/src/response/RtmStartResponse.ts
+++ b/packages/web-api/src/response/RtmStartResponse.ts
@@ -168,6 +168,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -468,6 +469,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -509,6 +511,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -659,6 +662,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -700,6 +704,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/SearchAllResponse.ts
+++ b/packages/web-api/src/response/SearchAllResponse.ts
@@ -41,6 +41,7 @@ export interface FilesMatch {
   file_access?:          string;
   filetype?:             string;
   groups?:               string[];
+  has_more_shares?:      boolean;
   has_rich_preview?:     boolean;
   id?:                   string;
   image_exif_rotation?:  number;
@@ -191,6 +192,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -491,6 +493,7 @@ export interface File {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -532,6 +535,7 @@ export interface File {
   shares?:                    FileShares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/SearchFilesResponse.ts
+++ b/packages/web-api/src/response/SearchFilesResponse.ts
@@ -39,6 +39,7 @@ export interface Match {
   file_access?:          string;
   filetype?:             string;
   groups?:               string[];
+  has_more_shares?:      boolean;
   has_rich_preview?:     boolean;
   id?:                   string;
   image_exif_rotation?:  number;

--- a/packages/web-api/src/response/SearchMessagesResponse.ts
+++ b/packages/web-api/src/response/SearchMessagesResponse.ts
@@ -59,6 +59,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -359,6 +360,7 @@ export interface BlockFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -400,6 +402,7 @@ export interface BlockFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -550,6 +553,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -591,6 +595,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/StarsListResponse.ts
+++ b/packages/web-api/src/response/StarsListResponse.ts
@@ -66,6 +66,7 @@ export interface ItemFile {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -107,6 +108,7 @@ export interface ItemFile {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;
@@ -259,6 +261,7 @@ export interface Attachment {
   callback_id?:           string;
   channel_id?:            string;
   channel_name?:          string;
+  channel_team?:          string;
   color?:                 string;
   fallback?:              string;
   fields?:                Field[];
@@ -565,6 +568,7 @@ export interface FileElement {
   from?:                      Cc[];
   groups?:                    string[];
   has_more?:                  boolean;
+  has_more_shares?:           boolean;
   has_rich_preview?:          boolean;
   headers?:                   Headers;
   hls?:                       string;
@@ -606,6 +610,7 @@ export interface FileElement {
   shares?:                    Shares;
   simplified_html?:           string;
   size?:                      number;
+  source_team?:               string;
   subject?:                   string;
   subtype?:                   string;
   thumb_1024?:                string;

--- a/packages/web-api/src/response/index.ts
+++ b/packages/web-api/src/response/index.ts
@@ -19,6 +19,7 @@ export { AdminConversationsBulkArchiveResponse } from './AdminConversationsBulkA
 export { AdminConversationsBulkDeleteResponse } from './AdminConversationsBulkDeleteResponse';
 export { AdminConversationsBulkMoveResponse } from './AdminConversationsBulkMoveResponse';
 export { AdminConversationsConvertToPrivateResponse } from './AdminConversationsConvertToPrivateResponse';
+export { AdminConversationsConvertToPublicResponse } from './AdminConversationsConvertToPublicResponse';
 export { AdminConversationsCreateResponse } from './AdminConversationsCreateResponse';
 export { AdminConversationsDeleteResponse } from './AdminConversationsDeleteResponse';
 export { AdminConversationsDisconnectSharedResponse } from './AdminConversationsDisconnectSharedResponse';
@@ -27,6 +28,7 @@ export { AdminConversationsGetConversationPrefsResponse } from './AdminConversat
 export { AdminConversationsGetCustomRetentionResponse } from './AdminConversationsGetCustomRetentionResponse';
 export { AdminConversationsGetTeamsResponse } from './AdminConversationsGetTeamsResponse';
 export { AdminConversationsInviteResponse } from './AdminConversationsInviteResponse';
+export { AdminConversationsLookupResponse } from './AdminConversationsLookupResponse';
 export { AdminConversationsRemoveCustomRetentionResponse } from './AdminConversationsRemoveCustomRetentionResponse';
 export { AdminConversationsRenameResponse } from './AdminConversationsRenameResponse';
 export { AdminConversationsRestrictAccessAddGroupResponse } from './AdminConversationsRestrictAccessAddGroupResponse';
@@ -50,6 +52,9 @@ export { AdminInviteRequestsApprovedListResponse } from './AdminInviteRequestsAp
 export { AdminInviteRequestsDeniedListResponse } from './AdminInviteRequestsDeniedListResponse';
 export { AdminInviteRequestsDenyResponse } from './AdminInviteRequestsDenyResponse';
 export { AdminInviteRequestsListResponse } from './AdminInviteRequestsListResponse';
+export { AdminRolesAddAssignmentsResponse } from './AdminRolesAddAssignmentsResponse';
+export { AdminRolesListAssignmentsResponse } from './AdminRolesListAssignmentsResponse';
+export { AdminRolesRemoveAssignmentsResponse } from './AdminRolesRemoveAssignmentsResponse';
 export { AdminTeamsAdminsListResponse } from './AdminTeamsAdminsListResponse';
 export { AdminTeamsCreateResponse } from './AdminTeamsCreateResponse';
 export { AdminTeamsListResponse } from './AdminTeamsListResponse';

--- a/prod-server-integration-tests/test/admin-web-api-roles.js
+++ b/prod-server-integration-tests/test/admin-web-api-roles.js
@@ -1,4 +1,4 @@
-// npx mocha --timeout 10000 test/admin-web-api-users-unsupportedVersions-export.js
+// npx mocha --timeout 10000 npm test test/admin-web-api-roles.js
 // tail -f logs/console.log | jq
 require('mocha');
 const { assert } = require('chai');
@@ -12,14 +12,16 @@ const logger = winston.createLogger({
   ],
 });
 
-describe('admin.users.unsupportedVersions.export', function () {
+describe('admin.roles.*', function () {
   it('should work', async function () {
     const orgAdminClient = new WebClient(process.env.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN, { logger, });
-    const response = await orgAdminClient.admin.users.unsupportedVersions.export({
-      date_end_of_support: Math.floor(+new Date() / 1000) + 60 * 60 * 24 *365,
-      date_sessions_started: 0,
-    });
+    const response = await orgAdminClient.admin.roles.listAssignments({
+      role_ids: ["Rl0A"],
+      limit: 3,
+      sort_dir: "desc",
+    })
     logger.info(response);
     assert.isUndefined(response.error);
+    // TODO: add/removeAssignments
   });
 });


### PR DESCRIPTION
This pull requset adds the following admin APIs:

- admin.roles.addAssignments
- admin.roles.listAssignments
- admin.roles.removeAssignments
- admin.conversations.convertToPublic
- admin.conversations.lookup

It resolves #1570 

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
