### PR TITLE
Improve the default OAuth page renderer

### DIFF
--- a/packages/oauth/src/callback-options.spec.ts
+++ b/packages/oauth/src/callback-options.spec.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import { IncomingMessage, ServerResponse } from 'http';
 
-import { CallbackOptions } from './callback-options';
+import { CallbackOptions, escapeHtml } from './callback-options';
 import { MissingStateError } from './errors';
 
 describe('CallbackOptions', async () => {
@@ -51,5 +51,10 @@ describe('CallbackOptions', async () => {
     callbackOptions.failure!(error, options, req, resp);
   });
 
+  it('should escape special characters when using the default page rendering', async () => {
+    assert.strictEqual(escapeHtml('slack://app?team=T111&id=A111'), 'slack://app?team=T111&amp;id=A111');
+    assert.strictEqual(escapeHtml('https://www.example.com?foo=bar&baz=123'), 'https://www.example.com?foo=bar&amp;baz=123');
+    assert.strictEqual(escapeHtml('<b>test</b>'), '&lt;b&gt;test&lt;/b&gt;');
+  });
   // TODO: tests for default callbacks
 });

--- a/packages/oauth/src/callback-options.ts
+++ b/packages/oauth/src/callback-options.ts
@@ -104,7 +104,7 @@ export function defaultCallbackSuccess(
   }
   const htmlResponse = `<html>
   <head>
-  <meta http-equiv="refresh" content="0; URL=${redirectUrl}">
+  <meta http-equiv="refresh" content="0; URL=${escapeHtml(redirectUrl)}">
   <style>
   body {
     padding: 10px 15px;
@@ -115,7 +115,7 @@ export function defaultCallbackSuccess(
   </head>
   <body>
   <h2>Thank you!</h2>
-  <p>Redirecting to the Slack App... click <a href="${redirectUrl}">here</a>. If you use the browser version of Slack, click <a href="${browserUrl}" target="_blank">this link</a> instead.</p>
+  <p>Redirecting to the Slack App... click <a href="${escapeHtml(redirectUrl)}">here</a>. If you use the browser version of Slack, click <a href="${escapeHtml(browserUrl)}" target="_blank">this link</a> instead.</p>
   </body>
   </html>`;
   res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -152,7 +152,7 @@ export function defaultCallbackFailure(
   </head>
   <body>
   <h2>Oops, Something Went Wrong!</h2>
-  <p>Please try again or contact the app owner (reason: ${error.code})</p>
+  <p>Please try again or contact the app owner (reason: ${escapeHtml(error.code)})</p>
   </body>
   </html>`;
   res.end(html);
@@ -169,4 +169,15 @@ function isOrgInstall(installation: Installation): installation is OrgInstallati
 
 function isNotOrgInstall(installation: Installation): installation is Installation<'v1' | 'v2', false> {
   return !(isOrgInstall(installation));
+}
+
+export function escapeHtml(input: string | undefined | null): string {
+  if (input) {
+    return input.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#x27;');
+  }
+  return '';
 }


### PR DESCRIPTION
###  Summary

This pull request improves the default OAuth page rendering code not to embed unescaped parameters in web page content. See also: https://github.com/slackapi/python-slack-sdk/pull/1352

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
