### PR TITLE
Publish @slack/oauth@2.6.1

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

We will release a new version of `@slack/oauth` shortly. The release includes https://github.com/slackapi/node-slack-sdk/pull/1604, which is a security fix.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
