### PR TITLE
Fix bug with `files.uploadV2` to ensure complete file is uploaded

### DIFF
--- a/packages/web-api/src/file-upload.spec.js
+++ b/packages/web-api/src/file-upload.spec.js
@@ -1,7 +1,7 @@
 require('mocha');
 const { assert } = require('chai');
 const sinon = require('sinon');
-const { createReadStream, writeFileSync, unlinkSync, statSync, read } = require('fs');
+const { createReadStream, statSync, writeFileSync, unlinkSync } = require('fs');
 const { ErrorCode } = require('./errors');
 const { 
   getFileDataAsStream,

--- a/packages/web-api/src/file-upload.ts
+++ b/packages/web-api/src/file-upload.ts
@@ -160,6 +160,8 @@ export async function getFileDataAsStream(readable: Readable): Promise<Buffer> {
       while ((chunk = readable.read()) !== null) {
         chunks.push(chunk);
       }
+    });
+    readable.on('end', () => {
       if (chunks.length > 0) {
         const content = Buffer.concat(chunks);
         resolve(content);


### PR DESCRIPTION
###  Summary

Fix #1601

* Adds a test based on @mwbeckner's example and confirms that we are currently failing this case.
![Screenshot 2023-05-01 at 12 05 55 AM](https://user-images.githubusercontent.com/55667998/235420964-e832e92a-a8a3-4f30-a8a7-e961a2c4386c.png)
* Updates the `getFileDateAsStream` method to resolve once the stream ends. And we are now passing our test
![Screenshot 2023-05-01 at 12 07 50 AM](https://user-images.githubusercontent.com/55667998/235421083-382f1e58-5a63-4af8-b72a-12f97eb67ec4.png)

Thanks all your patience as I've worked through my checklist to finally get to this item! And to @mwbeckner for reporting the initial issue w/ repro steps! 🙇‍♀️ 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
