### PR TITLE
Add metadata to incoming webhooks parameters

### DIFF
--- a/packages/webhook/src/IncomingWebhook.spec.js
+++ b/packages/webhook/src/IncomingWebhook.spec.js
@@ -47,6 +47,21 @@ describe('IncomingWebhook', function () {
           this.scope.done();
         });
       });
+
+      it('should send metadata', function () {
+        const result = this.webhook.send({
+          text: 'Hello',
+          response_type: 'in_channel',
+          metadata: {
+            event_type: 'foo',
+            event_payload: { foo: 'bar'},
+          }
+        });
+        return result.then((result) => {
+          assert.strictEqual(result.text, 'ok');
+          this.scope.done();
+        });
+      });
     });
 
     describe('when the call fails', function () {

--- a/packages/webhook/src/IncomingWebhook.ts
+++ b/packages/webhook/src/IncomingWebhook.ts
@@ -68,6 +68,7 @@ export class IncomingWebhook {
     try {
       const response = await this.axios.post(this.url, payload);
       return this.buildResult(response);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       // Wrap errors in this packages own error types (abstract the implementation details' types)
       if (error.response !== undefined) {
@@ -111,6 +112,11 @@ export interface IncomingWebhookSendArguments extends IncomingWebhookDefaultArgu
   blocks?: (KnownBlock | Block)[];
   unfurl_links?: boolean;
   unfurl_media?: boolean;
+  metadata?: {
+    event_type: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event_payload: Record<string, any>;
+  };
 }
 
 export interface IncomingWebhookResult {


### PR DESCRIPTION
###  Summary

As pointed out at [slackapi/bolt-js#1819](https://github.com/slackapi/bolt-js/issues/1819), metadata argument must be supported when posting a message using response_url and incoming webhooks

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
