### PR TITLE
Add `author_subname` type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -464,6 +464,7 @@ export interface MessageAttachment {
   author_name?: string;
   author_link?: string; // author_name must be present
   author_icon?: string; // author_name must be present
+  author_subname?: string;
   title?: string;
   title_link?: string; // title must be present
   text?: string; // either this or fallback must be defined


### PR DESCRIPTION
Hello! I would like to start by expressing my sincere appreciation for your consistent contributions to this project. 
Thank you so much! 

###  Summary

Add `author_subname` for message,  the section indicated by the arrow.

<img width="674" alt="スクリーンショット 2023-05-05 19 03 22" src="https://user-images.githubusercontent.com/23626334/236429952-8dbc409e-213b-4713-b5f9-1cb12fe860b3.png">

---

Other language API Client  ex. [slack-go/slack](https://github.com/slack-go/slack) 

https://github.com/slack-go/slack/blob/c4095cb17cf21c2b2b9c459d5512d14ca5143f64/attachments.go#L70-L71

```go
AuthorName    string `json:"author_name,omitempty"`
AuthorSubname string `json:"author_subname,omitempty"`
```

---

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
