### PR TITLE
Tweak debug logs in SocketModeClient

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -742,7 +742,9 @@ export class SocketModeClient extends EventEmitter {
 
     // Define Ack
     const ack = async (response: Record<string, unknown>): Promise<void> => {
-      this.logger.debug(`Calling ack() - type: ${event.type}, envelope_id: ${event.envelope_id}, data: ${response}`);
+      if (this.logger.getLevel() === LogLevel.DEBUG) {
+        this.logger.debug(`Calling ack() - type: ${event.type}, envelope_id: ${event.envelope_id}, data: ${JSON.stringify(response)}`);
+      }
       await this.send(event.envelope_id, response);
     };
 


### PR DESCRIPTION
###  Summary

This pull request improves the minor error in debug logs inside SocketModeClient:

```
[DEBUG]  socket-mode:SocketModeClient:0 Calling ack() - type: slash_commands, envelope_id: 93d32efc-f8b5-47d6-9350-a794d90bea7f, data: [object Object]
```

>data: [object Object]

The above part does not provide meaningful information.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
