### PR TITLE
Mark stars.* API methods as deprecated

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -820,7 +820,7 @@ function parseRetryHeaders(response: AxiosResponse): number | undefined {
 function warnDeprecations(method: string, logger: Logger): void {
   const deprecatedConversationsMethods = ['channels.', 'groups.', 'im.', 'mpim.'];
 
-  const deprecatedMethods = ['admin.conversations.whitelist.'];
+  const deprecatedMethods = ['admin.conversations.whitelist.', 'stars.'];
 
   const isDeprecatedConversations = deprecatedConversationsMethods.some((depMethod) => {
     const re = new RegExp(`^${depMethod}`);


### PR DESCRIPTION
###  Summary

see also: https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
