### PR TITLE
feat: add context to rate-limited event

### DIFF
--- a/docs/_packages/web_api.md
+++ b/docs/_packages/web_api.md
@@ -633,8 +633,8 @@ const token = process.env.SLACK_TOKEN;
 
 const web = new WebClient(token);
 
-web.on(WebClientEvent.RATE_LIMITED, (numSeconds) => {
-  console.log(`A rate-limiting error occurred and the app is going to retry in ${numSeconds} seconds.`);
+web.on(WebClientEvent.RATE_LIMITED, (numSeconds, { url }) => {
+  console.log(`A rate-limiting error occurred while calling ${url} and the app is going to retry in ${numSeconds} seconds.`);
 });
 ```
 

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1143,9 +1143,9 @@ describe('WebClient', function () {
           .reply(429, {}, { 'retry-after': 0 });
         const client = new WebClient(token, { rejectRateLimitedCalls: true });
         client.on('rate_limited', spy);
-        client.apiCall('method')
+        client.apiCall('method', { foo: 'bar' })
           .catch((err) => {
-            assert(spy.calledOnceWith(0))
+            assert(spy.calledOnceWith(0, sinon.match({ url: 'method', body: { foo: 'bar' } })))
             scope.done();
             done();
           });
@@ -1213,9 +1213,9 @@ describe('WebClient', function () {
         .reply(429, {}, { 'retry-after': 0 });
       const client = new WebClient(token, { retryConfig: { retries: 0 } });
       client.on('rate_limited', spy);
-      client.apiCall('method')
+      client.apiCall('method', { foo: 'bar' })
         .catch((err) => {
-          assert(spy.calledOnceWith(0))
+          assert(spy.calledOnceWith(0, sinon.match({ url: 'method', body: { foo: 'bar' } })))
           scope.done();
           done();
         });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -563,7 +563,7 @@ export class WebClient extends Methods {
         if (response.status === 429) {
           const retrySec = parseRetryHeaders(response);
           if (retrySec !== undefined) {
-            this.emit(WebClientEvent.RATE_LIMITED, retrySec);
+            this.emit(WebClientEvent.RATE_LIMITED, retrySec, { url, body });
             if (this.rejectRateLimitedCalls) {
               throw new AbortError(rateLimitedErrorWithDelay(retrySec));
             }


### PR DESCRIPTION
###  Summary

Add api request url and body to `WebClientEvent.RATE_LIMITED` event parameters

Resolves https://github.com/slackapi/node-slack-sdk/issues/1636

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
