### PR TITLE
Add rich text types

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -1,6 +1,6 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/block-elements
 
-import { Actionable, Confirmable, Dispatchable, Focusable, Placeholdable } from './extensions';
+import { Actionable, Confirmable, Dispatchable, Focusable, Placeholdable, RichTextStyleable } from './extensions';
 import { Option, PlainTextElement, PlainTextOption } from './composition-objects';
 
 /**
@@ -675,6 +675,200 @@ export interface WorkflowButton extends Confirmable {
 }
 
 /**
+ * @description A broadcast mention element for use in a rich text message.
+ */
+export interface RichTextBroadcastMention extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `broadcast`.
+   */
+  type: 'broadcast';
+  /**
+   * @description The range of the broadcast; can be one of `here`, `channel` and `everyone`.
+   */
+  range: 'here' | 'channel' | 'everyone';
+}
+
+/**
+ * @description A hex color element for use in a rich text message.
+ */
+export interface RichTextColor extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `color`.
+   */
+  type: 'color';
+  /**
+   * @description The hex value for the color.
+   */
+  value: string;
+}
+
+/**
+ * @description A channel mention element for use in a rich text message.
+ */
+export interface RichTextChannelMention extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `channel`.
+   */
+  type: 'channel';
+  /**
+   * @description The encoded channel ID, e.g. C1234ABCD.
+   */
+  channel_id: string;
+}
+
+/**
+ * @description A date element for use in a rich text message.
+ */
+export interface RichTextDate extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `date`.
+   */
+  type: 'date';
+  /**
+   * @description A UNIX timestamp for the date to be displayed in seconds.
+   */
+  timestamp: number;
+  /**
+   * @description A template string containing curly-brace-enclosed tokens to substitute your provided `timestamp`
+   * in a particularly-formatted way. For example: `Posted at {date_long}`. The available date formatting tokens are:
+   * - `{day_divider_pretty}`: Shows `today`, `yesterday` or `tomorrow` if applicable. Otherwise, if the date is in
+   *   current year, uses the `{date_long}` format without the year. Otherwise, falls back to using the `{date_long}`
+   *   format.
+   * - `{date_num}`: Shows date as YYYY-MM-DD.
+   * - `{date_slash}`: Shows date as DD/MM/YYYY (subject to locale preferences).
+   * - `{date_long}`: Shows date as a long-form sentence including day-of-week, e.g. `Monday, December 23rd, 2013`.
+   * - `{date_long_full}`: Shows date as a long-form sentence without day-of-week, e.g. `August 9, 2020`.
+   * - `{date_long_pretty}`: Shows `yesterday`, `today` or `tomorrow`, otherwise uses the `{date_long}` format.
+   * - `{date}`: Same as `{date_long_full}` but without the year.
+   * - `{date_pretty}`: Shows `today`, `yesterday` or `tomorrow` if applicable, otherwise uses the `{date}` format.
+   * - `{date_short}`: Shows date using short month names without day-of-week, e.g. `Aug 9, 2020`.
+   * - `{date_short_pretty}`: Shows `today`, `yesterday` or `tomorrow` if applicable, otherwise uses the `{date_short}`
+   *   format.
+   * - `{time}`: Depending on user preferences, shows just the time-of-day portion of the timestamp using either 12 or
+   *   24 hour clock formats, e.g. `2:34 PM` or `14:34`.
+   * - `{time_secs}`: Depending on user preferences, shows just the time-of-day portion of the timestamp using either 12
+   *   or 24 hour clock formats, including seconds, e.g. `2:34:56 PM` or `14:34:56`.
+   * - `{ago}`: A human-readable period of time, e.g. `3 minutes ago`, `4 hours ago`, `2 days ago`.
+   * TODO: test/document `{member_local_time}`, `{status_expiration}` and `{calendar_header}`
+   */
+  format: string;
+  /**
+   * @description URL to link the entire `format` string to.
+   */
+  url?: string;
+  /**
+   * @description Text to display in place of the date should parsing, formatting or displaying fails.
+   */
+  fallback?: string;
+}
+
+/**
+ * @description An emoji element for use in a rich text message.
+ */
+export interface RichTextEmoji extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `emoji`.
+   */
+  type: 'emoji';
+  /**
+   * @description Name of emoji, without colons or skin tones, e.g. `wave`
+   */
+  name: string;
+  /**
+   * @description Lowercase hexadecimal Unicode representation of a standard emoji (not for use with custom emoji).
+   */
+  unicode?: string;
+  /**
+   * @description URL of emoji asset. Only used when sharing custom emoji across workspaces.
+   */
+  url?: string;
+}
+
+/**
+ * @description A link element for use in a rich text message.
+ */
+export interface RichTextLink extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `link`.
+   */
+  type: 'link';
+  /**
+   * @description The text to link.
+   */
+  text?: string;
+  /**
+   * @description TODO: ?
+   */
+  unsafe?: boolean;
+  /**
+   * @description URL to link to.
+   */
+  url: string;
+}
+
+/**
+ * @description A workspace or team mention element for use in a rich text message.
+ */
+export interface RichTextTeamMention extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `team`.
+   */
+  type: 'team';
+  /**
+   * @description The encoded team ID, e.g. T1234ABCD.
+   */
+  team_id: string;
+}
+
+/**
+ * @description A generic text element for use in a rich text message.
+ */
+export interface RichTextText extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `text`.
+   */
+  type: 'text';
+  /**
+   * @description The text to render.
+   */
+  text: string;
+}
+
+/**
+ * @description A user mention element for use in a rich text message.
+ */
+export interface RichTextUserMention extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `user`.
+   */
+  type: 'user';
+  /**
+   * @description The encoded user ID, e.g. U1234ABCD.
+   */
+  user_id: string;
+}
+
+/**
+ * @description A usergroup mention element for use in a rich text message.
+ */
+export interface RichTextUsergroupMention extends RichTextStyleable {
+  /**
+   * @description The type of element. In this case `type` is always `usergroup`.
+   */
+  type: 'usergroup';
+  /**
+   * @description The encoded usergroup ID, e.g. S1234ABCD.
+   */
+  usergroup_id: string;
+}
+
+/**
+ * @description Union of rich text sub-elements for use within rich text blocks.
+ */
+export type RichTextElement = RichTextBroadcastMention | RichTextColor | RichTextChannelMention | RichTextDate |
+RichTextEmoji | RichTextLink | RichTextTeamMention | RichTextText | RichTextUserMention | RichTextUsergroupMention;
+
+/**
  * @description A section block within a rich text field.
  */
 export interface RichTextSection {
@@ -682,12 +876,47 @@ export interface RichTextSection {
    * @description The type of element. In this case `type` is always `rich_text_section`.
    */
   type: 'rich_text_section';
-  elements: {}[];
+  elements: RichTextElement[];
 }
 
+/**
+ * @description A list block within a rich text field.
+ */
+export interface RichTextList {
+  /**
+   * @description The type of element. In this case `type` is always `rich_text_list`.
+   */
+  type: 'rich_text_list';
+  /**
+   * @description An array of {@link RichTextSection} elements comprising each list item.
+   */
+  elements: RichTextSection[];
+  /**
+   * @description The type of list. Can be either `bullet` (the list points are all rendered the same way) or `ordered`
+   * (the list points increase numerically from 1).
+   */
+  style: 'bullet' | 'ordered';
+  /**
+   * @description The style of the list points. Can be a number from `0` (default) to `8`. Yields a different character
+   * or characters rendered as the list points. Also affected by the `style` property.
+   */
+  indent?: number;
+  /**
+   * @description TODO: The offset of the list. Must be a number that is at least `0`.
+   */
+  offset?: number;
+  /**
+   * @description Whether to render a quote-block-like border on the inline side of the list. `0` renders no border
+   * while `1` renders a border.
+   */
+  border?: 0 | 1;
+}
+
+/*
 export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
   type: 'rich_text_input';
   initial_value?: RichTextBlock;
   dispatch_action_config?: DispatchActionConfig;
   focus_on_load?: boolean;
 }
+*/

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -673,3 +673,10 @@ export interface WorkflowButton extends Confirmable {
    */
   accessibility_label?: string;
 }
+
+export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
+  type: 'rich_text_input';
+  initial_value?: RichTextBlock;
+  dispatch_action_config?: DispatchActionConfig;
+  focus_on_load?: boolean;
+}

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -674,6 +674,17 @@ export interface WorkflowButton extends Confirmable {
   accessibility_label?: string;
 }
 
+/**
+ * @description A section block within a rich text field.
+ */
+export interface RichTextSection {
+  /**
+   * @description The type of element. In this case `type` is always `rich_text_section`.
+   */
+  type: 'rich_text_section';
+  elements: {}[];
+}
+
 export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
   type: 'rich_text_input';
   initial_value?: RichTextBlock;

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -2,6 +2,7 @@
 
 import { Actionable, Confirmable, Dispatchable, Focusable, Placeholdable, RichTextStyleable } from './extensions';
 import { Option, PlainTextElement, PlainTextOption } from './composition-objects';
+import { RichTextBlock } from './blocks';
 
 /**
  * @description Allows users a direct path to performing basic actions.
@@ -902,10 +903,6 @@ export interface RichTextList {
    */
   indent?: number;
   /**
-   * @description TODO: The offset of the list. Must be a number that is at least `0`.
-   */
-  offset?: number;
-  /**
    * @description Whether to render a quote-block-like border on the inline side of the list. `0` renders no border
    * while `1` renders a border.
    */
@@ -945,11 +942,19 @@ export interface RichTextPreformatted {
   border?: 0 | 1;
 }
 
-/*
-export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
+/**
+ * @description A rich text input creates a composer/WYSIWYG editor for entering formatted text, offering nearly the
+ * same experience you have writing messages in Slack.
+ * @see {@link https://api.slack.com/reference/block-kit/block-elements#rich_text_input Rich-text input element reference}.
+ * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
+ */
+export interface RichTextInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+  /**
+   * @description The type of element. In this case `type` is always `rich_text_input`.
+   */
   type: 'rich_text_input';
+  /**
+   * @description Initial contents of the input when it is loaded.
+   */
   initial_value?: RichTextBlock;
-  dispatch_action_config?: DispatchActionConfig;
-  focus_on_load?: boolean;
 }
-*/

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -926,6 +926,25 @@ export interface RichTextQuote {
   elements: RichTextElement[];
 }
 
+/**
+ * @description A block of preformatted text within a rich text field.
+ */
+export interface RichTextPreformatted {
+  /**
+   * @description The type of element. In this case `type` is always `rich_text_preformatted`.
+   */
+  type: 'rich_text_preformatted';
+  /**
+   * @description An array of either {@link RichTextLink} or {@link RichTextText} comprising the preformatted text.
+   */
+  elements: (RichTextText | RichTextLink)[];
+  /**
+   * @description Whether to render a quote-block-like border on the inline side of the preformatted text.
+   * `0` renders no border, while `1` renders a border. Defaults to `0`.
+   */
+  border?: 0 | 1;
+}
+
 /*
 export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
   type: 'rich_text_input';

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -912,6 +912,20 @@ export interface RichTextList {
   border?: 0 | 1;
 }
 
+/**
+ * @description A quote block within a rich text field.
+ */
+export interface RichTextQuote {
+  /**
+   * @description The type of element. In this case `type` is always `rich_text_quote`.
+   */
+  type: 'rich_text_quote';
+  /**
+   * @description An array of {@link RichTextElement} comprising the quote block.
+   */
+  elements: RichTextElement[];
+}
+
 /*
 export interface RichTextInput extends Action, Dispatchable, Focusable, Placeholdable {
   type: 'rich_text_input';

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
 import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextInput } from './block-elements';
+import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput } from './block-elements';
 import { Actionable } from './extensions';
 
 export interface Block {
@@ -33,7 +33,7 @@ export interface ActionsBlock extends Block {
    * There is a maximum of 25 elements in each action block.
    */
   elements: (Button | Checkboxes | Datepicker | DateTimepicker | MultiSelect | Overflow | RadioButtons | Select |
-  Timepicker | WorkflowButton | RichTextInput)[];
+  Timepicker | WorkflowButton)[]; // TODO: add RichTextInput
 }
 
 /**
@@ -265,8 +265,5 @@ export interface RichTextBlock extends Block {
    * @description The type of block. For a rich text block, `type` is always `rich_text`.
    */
   type: 'rich_text',
-  elements: {
-    type: 'rich_text_section' | 'rich_text_list' | 'rich_text_quote' | 'rich_text_performatted';
-    elements: object[];
-  }[];
+  elements: (RichTextSection | RichTextList)[]; // TODO: 'rich_text_quote' | 'rich_text_performatted';
 }

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
 import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput } from './block-elements';
+import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput, RichTextQuote } from './block-elements';
 import { Actionable } from './extensions';
 
 export interface Block {
@@ -265,5 +265,5 @@ export interface RichTextBlock extends Block {
    * @description The type of block. For a rich text block, `type` is always `rich_text`.
    */
   type: 'rich_text',
-  elements: (RichTextSection | RichTextList)[]; // TODO: 'rich_text_quote' | 'rich_text_performatted';
+  elements: (RichTextSection | RichTextList | RichTextQuote)[]; // TODO:'rich_text_performatted';
 }

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,8 +1,8 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
 import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput, RichTextQuote, RichTextPreformatted } from './block-elements';
 import { Actionable } from './extensions';
+import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextQuote, RichTextPreformatted, RichTextInput } from './block-elements';
 
 export interface Block {
   type: string;
@@ -33,7 +33,7 @@ export interface ActionsBlock extends Block {
    * There is a maximum of 25 elements in each action block.
    */
   elements: (Button | Checkboxes | Datepicker | DateTimepicker | MultiSelect | Overflow | RadioButtons | Select |
-  Timepicker | WorkflowButton)[]; // TODO: add RichTextInput
+  Timepicker | WorkflowButton | RichTextInput)[];
 }
 
 /**
@@ -159,7 +159,7 @@ export interface InputBlock extends Block {
    * @description A block element.
    */
   element: Select | MultiSelect | Datepicker | Timepicker | DateTimepicker | PlainTextInput | URLInput | EmailInput
-  | NumberInput | RadioButtons | Checkboxes;
+  | NumberInput | RadioButtons | Checkboxes | RichTextInput;
   /**
    * @description A boolean that indicates whether or not the use of elements in this block should dispatch a
    * {@link https://api.slack.com/reference/interaction-payloads/block-actions block_actions payload}. Defaults to `false`.

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -261,6 +261,9 @@ export interface VideoBlock extends Block {
 }
 
 export interface RichTextBlock extends Block {
+  /**
+   * @description The type of block. For a rich text block, `type` is always `rich_text`.
+   */
   type: 'rich_text',
   elements: {
     type: 'rich_text_section' | 'rich_text_list' | 'rich_text_quote' | 'rich_text_performatted';

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
 import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton } from './block-elements';
+import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextInput } from './block-elements';
 import { Actionable } from './extensions';
 
 export interface Block {
@@ -17,7 +17,7 @@ export interface Block {
 }
 
 export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock |
-SectionBlock | InputBlock | FileBlock | HeaderBlock | VideoBlock;
+SectionBlock | InputBlock | FileBlock | HeaderBlock | VideoBlock | RichTextBlock;
 
 /**
  * @description Holds multiple interactive elements.
@@ -28,13 +28,12 @@ export interface ActionsBlock extends Block {
    * @description The type of block. For an actions block, `type` is always `actions`.
    */
   type: 'actions';
-  // TODO: add rich text input to this list once ready
   /**
    * @description An array of {@link InteractiveElements} objects.
    * There is a maximum of 25 elements in each action block.
    */
   elements: (Button | Checkboxes | Datepicker | DateTimepicker | MultiSelect | Overflow | RadioButtons | Select |
-  Timepicker | WorkflowButton)[];
+  Timepicker | WorkflowButton | RichTextInput)[];
 }
 
 /**
@@ -259,4 +258,12 @@ export interface VideoBlock extends Block {
    * @description Description for video using a {@link PlainTextElement} object.
    */
   description?: PlainTextElement;
+}
+
+export interface RichTextBlock extends Block {
+  type: 'rich_text',
+  elements: {
+    type: 'rich_text_section' | 'rich_text_list' | 'rich_text_quote' | 'rich_text_performatted';
+    elements: object[];
+  }[];
 }

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
 import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput, RichTextQuote } from './block-elements';
+import { Button, Checkboxes, Datepicker, DateTimepicker, EmailInput, ImageElement, MultiSelect, NumberInput, Overflow, PlainTextInput, RadioButtons, Select, Timepicker, URLInput, WorkflowButton, RichTextSection, RichTextList, RichTextInput, RichTextQuote, RichTextPreformatted } from './block-elements';
 import { Actionable } from './extensions';
 
 export interface Block {
@@ -265,5 +265,5 @@ export interface RichTextBlock extends Block {
    * @description The type of block. For a rich text block, `type` is always `rich_text`.
    */
   type: 'rich_text',
-  elements: (RichTextSection | RichTextList | RichTextQuote)[]; // TODO:'rich_text_performatted';
+  elements: (RichTextSection | RichTextList | RichTextQuote | RichTextPreformatted)[];
 }

--- a/packages/types/src/block-kit/extensions.ts
+++ b/packages/types/src/block-kit/extensions.ts
@@ -49,3 +49,23 @@ export interface Dispatchable {
    */
   dispatch_action_config?: DispatchActionConfig;
 }
+
+/**
+ * @description For use styling Rich Text message sub-elements.
+ */
+export interface RichTextStyleable {
+  /**
+   * @description A limited style object for styling rich text message elements
+   * (excluding pre-formatted, or code, elements).
+   */
+  style?: {
+    bold?: boolean;
+    italic?: boolean;
+    strike?: boolean;
+    highlight?: boolean;
+    /* TODO: model these?
+    client_highlight?: boolean;
+    unlink?: boolean;
+    */
+  };
+}


### PR DESCRIPTION
###  Summary

This PR adds types for the `rich_text` block and many rich text elements, with the main one being `rich_text_input`, but many others that make up rich text messages (text, links, user/channel/group mentions, preformatted text, quotes, lists - everything in the message composer).
