### PR TITLE
Lerna: don't hoist sub-package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "test": "lerna run test",
     "lint": "lerna run lint",
-    "setup": "lerna bootstrap --no-ci --hoist",
+    "setup": "lerna bootstrap --no-ci",
     "ref-docs": "lerna run ref-docs:model --no-bail; lerna run start --scope @slack/sdk-ref-docs"
   },
   "devDependencies": {


### PR DESCRIPTION
Using the `--hoist` command on lerna setup seems to cause issues in CI (see e.g. [this PR build](https://github.com/slackapi/node-slack-sdk/actions/runs/5868507849/job/15911512934)). This change fixed the issue locally on my system. Hoping that is the same in this PR!