### PR TITLE
Remove Lerna and related root npm run scripts, fix types in rtm-api

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,31 +1,31 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: Node.js Build and Test
 
 on:
   push:
     branches:
       - main
   pull_request:
-  
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
-
+        node-version: [18.x, 20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run setup
-    - run: npm run test
-    # - run: npm run coverage
+    - name: Get Development Dependencies
+      run: npm i
+    - name: Build and Run Tests in Each Package
+      run: |
+        for pkg in packages/logger packages/oauth packages/rtm-api packages/socket-mode packages/types packages/web-api packages/webhook; do
+          pushd ${pkg}
+          npm install || npm list
+          npm test
+          popd
+        done

--- a/package.json
+++ b/package.json
@@ -1,13 +1,7 @@
 {
-  "scripts": {
-    "test": "lerna run test",
-    "lint": "lerna run lint",
-    "setup": "lerna bootstrap --no-ci --hoist",
-    "ref-docs": "lerna run ref-docs:model --no-bail; lerna run start --scope @slack/sdk-ref-docs"
-  },
+  "name": "node-slack-sdk",
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-plugin-jsdoc": "^30.6.1",
-    "lerna": "^5.5.0"
+    "eslint-plugin-jsdoc": "^30.6.1"
   }
 }

--- a/packages/rtm-api/src/KeepAlive.ts
+++ b/packages/rtm-api/src/KeepAlive.ts
@@ -39,12 +39,12 @@ export class KeepAlive extends EventEmitter {
   /**
    * A timer for when to send the next ping if no other outgoing message is sent.
    */
-  private pingTimer?: NodeJS.Timer;
+  private pingTimer?: NodeJS.Timeout;
 
   /**
    * A timer for when to stop listening for an incoming event that acknowledges the ping (counts as a pong)
    */
-  private pongTimer?: NodeJS.Timer;
+  private pongTimer?: NodeJS.Timeout;
 
   /**
    * The message ID of the latest ping sent, or undefined is there hasn't been one sent.


### PR DESCRIPTION
### TODO

- [ ] update the required checks on this repo's settings and/or the versions of node we run tests against in this PR

###  Summary

Lerna, which is, or at least was, a monorepo management package, is now a few major versions ahead and its feature set has changed drastically. I do not believe it is suitable for our use case in this repo anymore. The commands we use it for are no longer supported in the newer versions.

Additionally, for the rtm-api package, depending on which version of the `@types/node` dependency you chanced upon retrieving, you may get a build error! For me, for example, I had no issues building the package as-is if I used `@types/node@20.4.9`. But, GitHub CI was using `@types/node@20.5.3` (see for example [this build](https://github.com/filmaj/node-slack-sdk/actions/runs/5955355744/job/16153831621) on my fork). I updated the type for one of the properties in this package to pass this failing build.

I updated the GitHub Actions workflow to not rely on Lerna anymore and simply iterate into each non-deprecated package, install its dependencies and run the tests. I also updated the workflow to only run tests against node v18 and v20, as v16 will be EOL'ed in 2 weeks.

Further discussion should be had about updating all of these packages' `engines` field and start moving up the minimum supported node version and releasing new major versions (I think?) as a result.

As an alternative, I tried using npm workspaces but encountered several issues with the `npm` CLI, the most serious of which was that `test` runs within sub-packages that errored would not cause `npm` to exit with a non-zero exit code (which would be reported as a success on GitHub Actions).