### PR TITLE
@slack/webhook: set min node to 18, prep for major release

### DIFF
--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -1,7 +1,12 @@
 # Slack Incoming Webhooks
 
 The `@slack/webhook` package contains a helper for making requests to Slack's [Incoming
-Webhooks](https://api.slack.com/incoming-webhooks). Use it in your app to send a notification to a channel.
+Webhooks](https://api.slack.com/messaging/webhooks). Use it in your app to send a notification to a channel.
+
+## Requirements
+This package supports Node v18 and higher. It's highly recommended to use [the latest LTS version of
+node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
+from that version.
 
 ## Installation
 
@@ -15,15 +20,11 @@ $ npm install @slack/webhook
 
 <!-- END: Remove before copying into the docs directory -->
 
----
-
 ### Initialize the webhook
 
-The package exports a `IncomingWebhook` class. You'll need to initialize it with the URL you received from Slack.
-
-The URL can come from installation in your development workspace, which is shown right in the app configuration pages.
-Or, the URL could be in the response from [`oauth.v2.access`](https://api.slack.com/methods/oauth.v2.access) when the app is
-distributed and installed into another workspace.
+The package exports an `IncomingWebhook` class. You'll need to initialize it with the URL you received from Slack.
+To create a webhook URL, follow the instructions in the [Getting started with Incoming Webhooks](https://api.slack.com/messaging/webhooks#getting_started)
+guide.
 
 ```javascript
 const { IncomingWebhook } = require('@slack/webhook');
@@ -59,7 +60,7 @@ const webhook = new IncomingWebhook(url, {
 
 ### Send a notification
 
-Something interesting just happened in your app, so its time to send the notification! Just call the
+Something interesting just happened in your app, so it's time to send the notification! Just call the
 `.send(options)` method on the webhook. The `options` parameter is an object that should describe the contents of
 the message. The method returns a `Promise` that resolves once the notification is sent.
 
@@ -83,7 +84,7 @@ const webhook = new IncomingWebhook(url);
 
 The webhook allows you to customize the HTTP
 [`Agent`](https://nodejs.org/docs/latest/api/http.html#http_class_http_agent) used to create the connection to Slack.
-Using this option is the best way to make all requests from your app through a proxy, which is a common requirement in
+Using this option is the best way to make all requests from your app go through a proxy, which is a common requirement in
 many corporate settings.
 
 In order to create an `Agent` from some proxy information (such as a host, port, username, and password), you can use
@@ -99,7 +100,7 @@ Import the `HttpsProxyAgent` class, and create an instance that can be used as t
 
 ```javascript
 const { IncomingWebhook } = require('@slack/webhook');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const url = process.env.SLACK_WEBHOOK_URL;
 
 // One of the ways you can configure HttpsProxyAgent is using a simple string.

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -18,8 +18,8 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">= 12.13.0",
-    "npm": ">= 6.12.0"
+    "node": ">= 18",
+    "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
   "homepage": "https://slack.dev/node-slack-sdk/webhook",
@@ -34,36 +34,36 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "eslint --ext .ts src",
-    "test": "npm run lint && npm run build && nyc mocha --config .mocharc.json src/*.spec.js",
-    "coverage": "codecov -F webhook --root=$PWD",
+    "mocha": "mocha --config .mocharc.json src/*.spec.js",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "npm run build && nyc --reporter=text-summary npm run mocha",
     "ref-docs:model": "api-extractor run"
   },
   "dependencies": {
-    "@slack/types": "^1.2.1",
-    "@types/node": ">=12.0.0",
-    "axios": "^0.27.2"
+    "@slack/types": "^2.9.0",
+    "@types/node": ">=18.0.0",
+    "axios": "^1.5.1"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.3.4",
-    "@typescript-eslint/eslint-plugin": "^4.4.1",
-    "@typescript-eslint/parser": "^4.4.0",
-    "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.6",
-    "chai": "^4.2.0",
-    "codecov": "^3.2.0",
-    "eslint": "^7.32.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-airbnb-typescript": "^12.3.1",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsdoc": "^30.6.1",
+    "@microsoft/api-extractor": "^7.38.0",
+    "@typescript-eslint/eslint-plugin": "^6.4.1",
+    "@typescript-eslint/parser": "^6.4.0",
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
+    "chai": "^4.3.8",
+    "eslint": "^8.47.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-plugin-import": "^2.28.1",
+    "eslint-plugin-jsdoc": "^46.5.0",
     "eslint-plugin-node": "^11.1.0",
-    "mocha": "^9.1.0",
-    "nock": "^13.0.0",
-    "nyc": "^14.1.1",
+    "mocha": "^10.2.0",
+    "nock": "^13.3.3",
+    "nyc": "^15.1.0",
     "shx": "^0.3.2",
-    "sinon": "^7.2.7",
-    "source-map-support": "^0.5.10",
-    "ts-node": "^8.0.3",
+    "sinon": "^15.2.0",
+    "source-map-support": "^0.5.21",
+    "ts-node": "^8.2.0",
     "typescript": "^4.1.0"
   }
 }

--- a/packages/webhook/src/IncomingWebhook.ts
+++ b/packages/webhook/src/IncomingWebhook.ts
@@ -44,6 +44,7 @@ export class IncomingWebhook {
       proxy: false,
       timeout: defaults.timeout,
       headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         'User-Agent': getUserAgent(),
       },
     });


### PR DESCRIPTION
Update dependencies to latest versions to 18, fix linter and typescript warnings, in prep for a major version release.

Following the same process as for the `@slack/logger` package (#1650).