### PR TITLE
Update files.upload.v2 internals due to server-side improvements

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1540,7 +1540,8 @@ describe('WebClient', function () {
       }]
     });
 
-    it('is called when request_file_info is true or undefined', async () => {
+    // since v7, the behavior has been changed
+    it('is not called when request_file_info is true or undefined', async () => {
       client.getFileInfo = sinon.spy();
       // set initial files upload arguments with request_file_info true
       const withRequestFileInfoTrue = {
@@ -1549,14 +1550,16 @@ describe('WebClient', function () {
         request_file_info: true,
       };
       await client.filesUploadV2(withRequestFileInfoTrue);
-      assert.equal(client.getFileInfo.called, true);
+      // since v7, the behavior has been changed
+      assert.equal(client.getFileInfo.called, false);
 
       const withRequestFileInfoOmitted = {
         file: Buffer.from('test'),
         filename: 'test.txt',
       }
       await client.filesUploadV2(withRequestFileInfoOmitted);
-      assert.equal(client.getFileInfo.calledTwice, true);
+      // since v7, the behavior has been changed
+      assert.equal(client.getFileInfo.calledTwice, false);
     });
     it('is not called when request_file_info is set as false', async () => {
       client.getFileInfo = sinon.spy();

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -408,8 +408,6 @@ export class WebClient extends Methods {
    * 
    * **#3**: Complete uploads {@link https://api.slack.com/methods/files.completeUploadExternal files.completeUploadExternal}
    * 
-   * **#4**: Unless `request_file_info` set to false, call {@link https://api.slack.com/methods/files.info files.info} for
-   * each file uploaded and returns that data. Requires that your app have `files:read` scope.
    * @param options
    */
   public async filesUploadV2(options: FilesUploadV2Arguments): Promise<WebAPICallResult> {
@@ -429,13 +427,7 @@ export class WebClient extends Methods {
     // 3
     const completion = await this.completeFileUploads(fileUploads);
     
-    // 4 
-    let res = completion;
-    if (options.request_file_info ?? true) {
-      res = await this.getFileInfo(fileUploads);
-    }
-
-    return { ok: true, files: res };
+    return { ok: true, files: completion };
   }
 
   /**
@@ -470,19 +462,6 @@ export class WebClient extends Methods {
     return Promise.all(
       toComplete.map((job: FilesCompleteUploadExternalArguments) => this.files.completeUploadExternal(job)),
     );
-  }
-
-  /**
-   * Call {@link https://api.slack.com/methods/files.info files.info} for
-   * each file uploaded and returns relevant data. Requires that your app have `files:read` scope, to
-   * turn off, set `request_file_info` set to false.
-   * @param fileUploads
-   * @returns
-   */
-  private async getFileInfo(fileUploads: FileUploadV2Job[]):
-  Promise<Array<WebAPICallResult>> {
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    return Promise.all(fileUploads.map((job) => this.files.info({ file: job.file_id! })));
   }
 
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1884,7 +1884,7 @@ interface FileUpload {
 
 export interface FilesUploadV2Arguments extends FileUploadV2, WebAPICallOptions, TokenOverridable {
   file_uploads?: Omit<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
-  request_file_info?: boolean;
+  request_file_info?: boolean; // since v7, this flag is no longer used
 }
 
 export type FileUploadV2 = FileUpload & {

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1884,7 +1884,10 @@ interface FileUpload {
 
 export interface FilesUploadV2Arguments extends FileUploadV2, WebAPICallOptions, TokenOverridable {
   file_uploads?: Omit<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
-  request_file_info?: boolean; // since v7, this flag is no longer used
+  /**
+   * @deprecated Since v7, this flag is no longer used. You can safely remove it from your code.
+   */
+  request_file_info?: boolean;
 }
 
 export type FileUploadV2 = FileUpload & {

--- a/packages/web-api/src/response/FilesCompleteUploadExternalResponse.ts
+++ b/packages/web-api/src/response/FilesCompleteUploadExternalResponse.ts
@@ -18,6 +18,57 @@ export type FilesCompleteUploadExternalResponse = WebAPICallResult & {
 };
 
 export interface File {
-  id?:    string;
-  title?: string;
+  channels?:             string[];
+  comments_count?:       number;
+  created?:              number;
+  display_as_bot?:       boolean;
+  edit_link?:            string;
+  editable?:             boolean;
+  external_type?:        string;
+  file_access?:          string;
+  filetype?:             string;
+  groups?:               string[];
+  has_more_shares?:      boolean;
+  has_rich_preview?:     boolean;
+  id?:                   string;
+  ims?:                  string[];
+  is_external?:          boolean;
+  is_public?:            boolean;
+  is_starred?:           boolean;
+  lines?:                number;
+  lines_more?:           number;
+  media_display_type?:   string;
+  mimetype?:             string;
+  mode?:                 string;
+  name?:                 string;
+  permalink?:            string;
+  permalink_public?:     string;
+  pretty_type?:          string;
+  preview?:              string;
+  preview_highlight?:    string;
+  preview_is_truncated?: boolean;
+  public_url_shared?:    boolean;
+  shares?:               Shares;
+  size?:                 number;
+  timestamp?:            number;
+  title?:                string;
+  url_private?:          string;
+  url_private_download?: string;
+  user?:                 string;
+  user_team?:            string;
+  username?:             string;
+}
+
+export interface Shares {
+  public?: { [key: string]: Public[] };
+}
+
+export interface Public {
+  channel_name?:      string;
+  reply_count?:       number;
+  reply_users?:       string[];
+  reply_users_count?: number;
+  share_user_id?:     string;
+  team_id?:           string;
+  ts?:                string;
 }


### PR DESCRIPTION
###  Summary

This pull request updates the internals of files.upload.v2 method to eliminate `files.info` API calls, which are no longer necessary because the server-side now returns the same metadata as part of `files.completeUploadExternal` API responses.

See also:
* https://github.com/slackapi/python-slack-sdk/pull/1408
* https://github.com/slackapi/java-slack-sdk/releases/tag/v1.34.0

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
