### PR TITLE
`npm link` up the packages in this repo during CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,4 +26,11 @@ jobs:
       working-directory: ${{ matrix.package }}
       run: |
         npm install || npm list
+        # depending on which package we are testing, also npm link up other dependent packages
+        case "$PWD" in
+          */webhook) pushd ../types && npm i && popd && npm link ../types;;
+          */web-api) pushd ../types && npm i && popd && npm link ../types && pushd ../logger && npm i && popd && npm link ../logger;;
+          # TODO: add oauth and socket-mode here once those packages have new major versions released
+          *) ;; # default
+        esac
         npm test

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -406,7 +406,6 @@ export class WebClient extends Methods {
    * URLs returned from step 1 (e.g. https://files.slack.com/upload/v1/...\")
    * 
    * **#3**: Complete uploads {@link https://api.slack.com/methods/files.completeUploadExternal files.completeUploadExternal}
-   * 
    * @param options
    */
   public async filesUploadV2(options: FilesUploadV2Arguments): Promise<WebAPICallResult> {


### PR DESCRIPTION
Allowing for type-level integration testing. Just a small awareness boost, to understand if changes in one of the packages in this monorepo will affect another package in this monorepo that depends on it.

Also fix linter warning re: JSdoc