### PR TITLE
Remove warning from chat.update

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -211,7 +211,6 @@ describe('WebClient', function () {
         { method: 'chat.postEphemeral', args: { channel: "C123", blocks: [] } },
         { method: 'chat.postMessage', args: { channel: "C123", blocks: [] } },
         { method: 'chat.scheduleMessage', args: { channel: "C123", post_at: "100000000", blocks: [] } },
-        { method: 'chat.update', args: { channel: "C123", ts: "123.456", blocks: [] } },
       ];
       const warningTestPatterns = textWarningTestPatterns.concat(attachmentWarningTestPatterns);
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -824,7 +824,7 @@ function warnDeprecations(method: string, logger: Logger): void {
  * @param options arguments for the Web API method
  */
 function warnIfFallbackIsMissing(method: string, logger: Logger, options?: WebAPICallOptions): void {
-  const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+  const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage'];
   const isTargetMethod = targetMethods.includes(method);
 
   const hasAttachments = (args: WebAPICallOptions) => Array.isArray(args.attachments) && args.attachments.length;


### PR DESCRIPTION
###  Summary

Recent changes to the chat.update API makes this warnings inaccurate and should not show to the user.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
