### PR TITLE
chore: Upgrade axios to 1.6.0 to resolve CVE-2023-45857

### DIFF
--- a/packages/interactive-messages/package.json
+++ b/packages/interactive-messages/package.json
@@ -58,7 +58,7 @@
     "@types/lodash.isregexp": "^4.0.6",
     "@types/lodash.isstring": "^4.0.6",
     "@types/node": ">=12.0.0",
-    "axios": "^0.27.2",
+    "axios": "^1.6.0",
     "debug": "^3.1.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isplainobject": "^4.0.6",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -48,7 +48,7 @@
     "@slack/logger": "^4.0.0",
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
-    "axios": "^1.5.1",
+    "axios": "^1.6.0",
     "eventemitter3": "^5.0.1",
     "form-data": "^4.0.0",
     "is-electron": "2.2.2",

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
-    "axios": "^1.5.1"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.38.0",


### PR DESCRIPTION
###  Summary

* Upgraded axios to 1.6.0 to resolve CVE-2023-45857.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
