### PR TITLE
rtm-api: add support for custom webClient

### DIFF
--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -348,9 +348,10 @@ export class RTMClient extends EventEmitter {
     serverPongTimeout,
     replyAckOnReconnectTimeout = 2000,
     tls = undefined,
+    webClient,
   }: RTMClientOptions = {}) {
     super();
-    this.webClient = new WebClient(token, {
+    this.webClient = webClient || new WebClient(token, {
       slackApiUrl,
       logger,
       logLevel,
@@ -672,6 +673,7 @@ export default RTMClient;
  */
 
 export interface RTMClientOptions {
+  webClient?: WebClient;
   slackApiUrl?: string;
   logger?: Logger;
   logLevel?: LogLevel;

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -593,12 +593,7 @@ export class RTMClient extends EventEmitter {
     if (this.agentConfig !== undefined) {
       options.agent = this.agentConfig;
     }
-    this.websocket = new WebSocket(url, {
-      ...options,
-      headers: {
-        ...(this.webClient.headers || {}),
-      },
-    });
+    this.websocket = new WebSocket(url, options);
 
     // attach event listeners
     this.websocket.addEventListener('open', (event) => this.stateMachine.handle('websocket open', event));

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -593,7 +593,12 @@ export class RTMClient extends EventEmitter {
     if (this.agentConfig !== undefined) {
       options.agent = this.agentConfig;
     }
-    this.websocket = new WebSocket(url, options);
+    this.websocket = new WebSocket(url, {
+      ...options,
+      headers: {
+        ...(this.webClient.headers || {}),
+      },
+    });
 
     // attach event listeners
     this.websocket.addEventListener('open', (event) => this.stateMachine.handle('websocket open', event));


### PR DESCRIPTION
###  Summary

- Adding optional parameter to get more flexibility with webClient construction  

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
