### PR TITLE
rtm-api, socket-mode, oauth: Bump web-api to latest v6.11.2 to address underlying axios security vulnerabilities

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/web-api": "^6.3.0",
+    "@slack/web-api": "^6.11.2",
     "@types/jsonwebtoken": "^8.3.7",
     "@types/node": ">=12",
     "jsonwebtoken": "^9.0.0",

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/web-api": "^5.3.0",
+    "@slack/web-api": "^6.11.2",
     "@types/node": ">=12.0.0",
     "@types/p-queue": "^2.3.2",
     "@types/ws": "^7.4.7",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/web-api": "^6.2.3",
+    "@slack/web-api": "^6.11.2",
     "@types/node": ">=12.0.0",
     "@types/p-queue": "^2.3.2",
     "@types/ws": "^7.4.7",


### PR DESCRIPTION
Fixes #1719

