### PR TITLE
Publish patch versions of oauth, socket-mode and rtm-api to address downstream axios security vulns

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/rtm-api",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Official library for using the Slack Platform's Real Time Messaging API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
`slack/oauth@2.6.2`, `@slack/rtm-api@6.2.1` and `@slack/socket-mode@1.3.2`