### PR TITLE
web-api: prevent apps.event.authorizations.list API from ever sending token in the body

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1288,6 +1288,39 @@ describe('WebClient', function () {
     });
   });
 
+  describe('apps.event.authorizations.list API', function () {
+    it('should not send the token in the body if token is passed as a method argument', function () {
+      const client = new WebClient();
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(200, (_uri, body) => {
+          assert.notInclude(body, token);
+          console.log('body is', body);
+          return { ok: true }
+        });
+      return client.apps.event.authorizations.list({
+        token,
+      })
+        .then(() => {
+          scope.done();
+        });
+    });
+    it('should not send the token in the body if token passed as client constructor', function () {
+      const client = new WebClient(token);
+      const scope = nock('https://slack.com')
+        .post(/api/)
+        .reply(200, (_uri, body) => {
+          assert.notInclude(body, token);
+          return { ok: true }
+        });
+      return client.apps.event.authorizations.list({
+      })
+        .then(() => {
+          scope.done();
+        });
+    });
+  });
+
   describe('getAllFileUploads', () => {
     const client = new WebClient(token);
     it('adds a single file data to uploads with content supplied', async () => {

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -549,6 +549,7 @@ export class WebClient extends Methods {
           config.responseType = 'arraybuffer';
         }
         // apps.event.authorizations.list will reject HTTP requests that send token in the body
+        // TODO: consider applying this change to all methods - though that will require thorough integration testing
         if (url.endsWith('apps.event.authorizations.list')) {
           // eslint-disable-next-line no-param-reassign
           delete body.token;


### PR DESCRIPTION
Sending `token` in the body for the `apps.event.authorizations.list` API will cause the API to return an error ([see the last sentence in this doc](https://api.slack.com/methods/apps.event.authorizations.list#how)).

This fixes #1498.

Additionally, this PR compiles all headers when logging them out in debug mode - even the ones axios sets by default. This critically also includes the token if the token is passed in to WebClient constructor. I made this change and included it here as otherwise determining the full list of headers sent by web-api was challenging. Optionally, this logging feature can be removed if people have opinions about it. Previously, the debug output would look like this:

```
[DEBUG]  web-api:WebClient:0 apiCall('apps.event.authorizations.list') start
[DEBUG]  web-api:WebClient:0 http request url: https://slack.com/api/apps.event.authorizations.list
[DEBUG]  web-api:WebClient:0 http request body: {"event_context":"4-eyJldCI6Im1lc3NhZ2UiLCJ0aWQiOiJUMDI5VjY0NjhSTCIsImFpZCI6IkEwNjAxUkVRTDkzIiwiY2lkIjoiQzAyOVlUNUtFTUIifQ"}
[DEBUG]  web-api:WebClient:0 http request headers: {}
```

Note the request headers are stated to be empty (when passing a token into the `WebClient` constructor). Impossible, as the token needs to be provided SOMEHOW!

With the logging changes introduced in this PR, the same call as above now yields:

```
[DEBUG]  web-api:WebClient:0 apiCall('apps.event.authorizations.list') start
[DEBUG]  web-api:WebClient:0 http request url: https://slack.com/api/apps.event.authorizations.list
[DEBUG]  web-api:WebClient:0 http request body: {"event_context":"4-eyJldCI6Im1lc3NhZ2UiLCJ0aWQiOiJUMDI5VjY0NjhSTCIsImFpZCI6IkEwNjAxUkVRTDkzIiwiY2lkIjoiQzAyOVlUNUtFTUIifQ"}
[DEBUG]  web-api:WebClient:0 http request headers: {"User-Agent":"@slack:web-api/7.0.1 node/18.15.0 darwin/23.2.0","Authorization":"[[REDACTED]]","Accept":"application/json, text/plain, */*"}
```