### PR TITLE
Fix update image block type

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -8,7 +8,12 @@ import {
   Placeholdable,
   RichTextStyleable,
 } from './extensions';
-import { Option, PlainTextElement, PlainTextOption } from './composition-objects';
+import {
+  Option,
+  PlainTextElement,
+  PlainTextOption,
+  SlackFile,
+} from './composition-objects';
 import { RichTextBlock } from './blocks';
 
 /**
@@ -79,7 +84,11 @@ export interface Checkboxes extends Actionable, Confirmable, Focusable {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#datepicker Date picker element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface Datepicker extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface Datepicker
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `datepicker`.
    */
@@ -117,7 +126,11 @@ export interface DateTimepicker extends Actionable, Confirmable, Focusable {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#email Email input element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface EmailInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+export interface EmailInput
+  extends Actionable,
+    Dispatchable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `email_text_input`.
    */
@@ -152,24 +165,40 @@ export interface FileInput extends Actionable {
 }
 
 /**
+ * @description Object for image which contains a image_url.
+ */
+export interface UrlImageObject {
+  /**
+   * @description The URL of the image to be displayed.
+   */
+  image_url: string;
+}
+
+/**
+ * @description Object for image which contains a slack_file.
+ */
+export interface SlackFileImageObject {
+  /**
+   * @description The slack file of the image to be displayed.
+   */
+  slack_file: SlackFile;
+}
+
+/**
  * @description Displays an image as part of a larger block of content. Use this `image` block if you want a block with
  * only an image in it.
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#image Image element reference}.
  */
-export interface ImageElement {
+export type ImageElement = {
   /**
    * @description The type of element. In this case `type` is always `image`.
    */
   type: 'image';
   /**
-   * @description The URL of the image to be displayed.
-   */
-  image_url: string;
-  /**
    * @description A plain-text summary of the image. This should not contain any markup.
    */
   alt_text: string;
-}
+} & (UrlImageObject | SlackFileImageObject);
 
 /*
  * Multi-select and Select menus follow
@@ -185,7 +214,12 @@ export interface ImageElement {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#select Select menu element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export type Select = UsersSelect | StaticSelect | ConversationsSelect | ChannelsSelect | ExternalSelect;
+export type Select =
+  | UsersSelect
+  | StaticSelect
+  | ConversationsSelect
+  | ChannelsSelect
+  | ExternalSelect;
 
 /**
  * @description Allows users to select multiple items from a list of options.
@@ -198,7 +232,11 @@ export type Select = UsersSelect | StaticSelect | ConversationsSelect | Channels
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
 export type MultiSelect =
-  MultiUsersSelect | MultiStaticSelect | MultiConversationsSelect | MultiChannelsSelect | MultiExternalSelect;
+  | MultiUsersSelect
+  | MultiStaticSelect
+  | MultiConversationsSelect
+  | MultiChannelsSelect
+  | MultiExternalSelect;
 
 /**
  * @description This select menu will populate its options with a list of Slack users visible to the current user in the
@@ -206,7 +244,11 @@ export type MultiSelect =
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#users_select Select menu of users reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface UsersSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface UsersSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `users_select`.
    */
@@ -223,7 +265,11 @@ export interface UsersSelect extends Actionable, Confirmable, Focusable, Placeho
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#users_multi_select Multi-select menu of users reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface MultiUsersSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface MultiUsersSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `multi_users_select`.
    */
@@ -244,7 +290,11 @@ export interface MultiUsersSelect extends Actionable, Confirmable, Focusable, Pl
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#static_select Select menu of static options reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface StaticSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface StaticSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `static_select`.
    */
@@ -281,7 +331,11 @@ export interface StaticSelect extends Actionable, Confirmable, Focusable, Placeh
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#static_multi_select Multi-select menu of static options reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface MultiStaticSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface MultiStaticSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `multi_static_select`.
    */
@@ -322,7 +376,11 @@ export interface MultiStaticSelect extends Actionable, Confirmable, Focusable, P
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#conversations_select Select menu of conversations reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface ConversationsSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface ConversationsSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `conversations_select`.
    */
@@ -349,7 +407,8 @@ export interface ConversationsSelect extends Actionable, Confirmable, Focusable,
   /**
    * @description A filter object that reduces the list of available conversations using the specified criteria.
    */
-  filter?: { // TODO: breaking change: replace with ConversationFilter object from composition-objects
+  filter?: {
+    // TODO: breaking change: replace with ConversationFilter object from composition-objects
     include?: ('im' | 'mpim' | 'private' | 'public')[];
     exclude_external_shared_channels?: boolean;
     exclude_bot_users?: boolean;
@@ -364,7 +423,11 @@ export interface ConversationsSelect extends Actionable, Confirmable, Focusable,
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select Multi-select menu of conversations reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface MultiConversationsSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface MultiConversationsSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `conversations_select`.
    */
@@ -388,7 +451,8 @@ export interface MultiConversationsSelect extends Actionable, Confirmable, Focus
   /**
    * @description A filter object that reduces the list of available conversations using the specified criteria.
    */
-  filter?: { // TODO: breaking change: replace with ConversationFilter object from composition-objects
+  filter?: {
+    // TODO: breaking change: replace with ConversationFilter object from composition-objects
     include?: ('im' | 'mpim' | 'private' | 'public')[];
     exclude_external_shared_channels?: boolean;
     exclude_bot_users?: boolean;
@@ -401,7 +465,11 @@ export interface MultiConversationsSelect extends Actionable, Confirmable, Focus
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#channels_select Select menu of public channels reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface ChannelsSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface ChannelsSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `channels_select`.
    */
@@ -427,12 +495,16 @@ export interface ChannelsSelect extends Actionable, Confirmable, Focusable, Plac
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#channel_multi_select Multi-select menu of public channels reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface MultiChannelsSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface MultiChannelsSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `multi_channels_select`.
    */
   type: 'multi_channels_select';
-  // TODO: breaking change: change type to enforce "at least one" array restriction
+  // TODO: breaking change: change type to enforce 'at least one' array restriction
   /**
    * @description An array of one or more IDs of any valid public channel to be pre-selected when the menu loads.
    */
@@ -450,7 +522,11 @@ export interface MultiChannelsSelect extends Actionable, Confirmable, Focusable,
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#external_select Select menu of external data source reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface ExternalSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface ExternalSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `external_select`.
    */
@@ -473,7 +549,11 @@ export interface ExternalSelect extends Actionable, Confirmable, Focusable, Plac
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#external_multi_select Multi-select menu of external data source reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface MultiExternalSelect extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface MultiExternalSelect
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `multi_external_select`.
    */
@@ -507,7 +587,11 @@ export interface MultiExternalSelect extends Actionable, Confirmable, Focusable,
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#number Number input element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface NumberInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+export interface NumberInput
+  extends Actionable,
+    Dispatchable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `number_input`.
    */
@@ -532,7 +616,7 @@ export interface NumberInput extends Actionable, Dispatchable, Focusable, Placeh
 
 /**
  * @description Allows users to press a button to view a list of options.
- * Unlike the select menu, there is no typeahead field, and the button always appears with an ellipsis ("…") rather
+ * Unlike the select menu, there is no typeahead field, and the button always appears with an ellipsis ('…') rather
  * than customizable text. As such, it is usually used if you want a more compact layout than a select menu, or to
  * supply a list of less visually important actions after a row of buttons. You can also specify simple URL links as
  * overflow menu options, instead of actions.
@@ -556,7 +640,11 @@ export interface Overflow extends Actionable, Confirmable {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#input Plain-text input element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface PlainTextInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+export interface PlainTextInput
+  extends Actionable,
+    Dispatchable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `plain_text_input`.
    */
@@ -610,7 +698,11 @@ export interface RadioButtons extends Actionable, Confirmable, Focusable {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#timepicker Time picker element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface Timepicker extends Actionable, Confirmable, Focusable, Placeholdable {
+export interface Timepicker
+  extends Actionable,
+    Confirmable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `timepicker`.
    */
@@ -622,7 +714,7 @@ export interface Timepicker extends Actionable, Confirmable, Focusable, Placehol
    */
   initial_time?: string;
   /**
-   * @description A string in the IANA format, e.g. "America/Chicago". The timezone is displayed to end users as hint
+   * @description A string in the IANA format, e.g. 'America/Chicago'. The timezone is displayed to end users as hint
    * text underneath the time picker. It is also passed to the app upon certain interactions, such as view_submission.
    */
   timezone?: string;
@@ -633,7 +725,11 @@ export interface Timepicker extends Actionable, Confirmable, Focusable, Placehol
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#url URL input element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface URLInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+export interface URLInput
+  extends Actionable,
+    Dispatchable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `url_text_input`.
    */
@@ -687,7 +783,7 @@ export interface WorkflowButton extends Confirmable {
          */
         value: string;
       }[];
-    }
+    };
   };
   /**
    * @description Decorates buttons with alternative visual color schemes. Use this option with restraint.
@@ -896,8 +992,17 @@ export interface RichTextUsergroupMention extends RichTextStyleable {
 /**
  * @description Union of rich text sub-elements for use within rich text blocks.
  */
-export type RichTextElement = RichTextBroadcastMention | RichTextColor | RichTextChannelMention | RichTextDate |
-RichTextEmoji | RichTextLink | RichTextTeamMention | RichTextText | RichTextUserMention | RichTextUsergroupMention;
+export type RichTextElement =
+  | RichTextBroadcastMention
+  | RichTextColor
+  | RichTextChannelMention
+  | RichTextDate
+  | RichTextEmoji
+  | RichTextLink
+  | RichTextTeamMention
+  | RichTextText
+  | RichTextUserMention
+  | RichTextUsergroupMention;
 
 /**
  * @description A section block within a rich text field.
@@ -978,7 +1083,11 @@ export interface RichTextPreformatted {
  * @see {@link https://api.slack.com/reference/block-kit/block-elements#rich_text_input Rich-text input element reference}.
  * @see {@link https://api.slack.com/interactivity/handling This is an interactive component - see our guide to enabling interactivity}.
  */
-export interface RichTextInput extends Actionable, Dispatchable, Focusable, Placeholdable {
+export interface RichTextInput
+  extends Actionable,
+    Dispatchable,
+    Focusable,
+    Placeholdable {
   /**
    * @description The type of element. In this case `type` is always `rich_text_input`.
    */

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -12,7 +12,8 @@ import {
   Option,
   PlainTextElement,
   PlainTextOption,
-  SlackFile,
+  UrlImageObject,
+  SlackFileImageObject,
 } from './composition-objects';
 import { RichTextBlock } from './blocks';
 
@@ -162,26 +163,6 @@ export interface FileInput extends Actionable {
    * `10`. Defaults to `10` if not specified.
    */
   max_files?: number;
-}
-
-/**
- * @description Object for image which contains a image_url.
- */
-export interface UrlImageObject {
-  /**
-   * @description The URL of the image to be displayed.
-   */
-  image_url: string;
-}
-
-/**
- * @description Object for image which contains a slack_file.
- */
-export interface SlackFileImageObject {
-  /**
-   * @description The slack file of the image to be displayed.
-   */
-  slack_file: SlackFile;
 }
 
 /**

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
-import { PlainTextElement, MrkdwnElement } from "./composition-objects";
-import { Actionable } from "./extensions";
+import { PlainTextElement, MrkdwnElement } from './composition-objects';
+import { Actionable } from './extensions';
 import {
   Button,
   Checkboxes,
@@ -24,7 +24,7 @@ import {
   RichTextQuote,
   RichTextPreformatted,
   RichTextInput,
-} from "./block-elements";
+} from './block-elements';
 
 export interface Block {
   type: string;
@@ -38,17 +38,8 @@ export interface Block {
   block_id?: string;
 }
 
-export type KnownBlock =
-  | ImageBlock
-  | ContextBlock
-  | ActionsBlock
-  | DividerBlock
-  | SectionBlock
-  | InputBlock
-  | FileBlock
-  | HeaderBlock
-  | VideoBlock
-  | RichTextBlock;
+export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock |
+SectionBlock | InputBlock | FileBlock | HeaderBlock | VideoBlock | RichTextBlock;
 
 /**
  * @description Holds multiple interactive elements.
@@ -58,24 +49,13 @@ export interface ActionsBlock extends Block {
   /**
    * @description The type of block. For an actions block, `type` is always `actions`.
    */
-  type: "actions";
+  type: 'actions';
   /**
    * @description An array of {@link InteractiveElements} objects.
    * There is a maximum of 25 elements in each action block.
    */
-  elements: (
-    | Button
-    | Checkboxes
-    | Datepicker
-    | DateTimepicker
-    | MultiSelect
-    | Overflow
-    | RadioButtons
-    | Select
-    | Timepicker
-    | WorkflowButton
-    | RichTextInput
-  )[];
+  elements: (Button | Checkboxes | Datepicker | DateTimepicker | MultiSelect | Overflow | RadioButtons | Select |
+  Timepicker | WorkflowButton | RichTextInput)[];
 }
 
 /**
@@ -86,7 +66,7 @@ export interface ContextBlock extends Block {
   /**
    * @description The type of block. For a context block, `type` is always `context`.
    */
-  type: "context";
+  type: 'context';
   // TODO: use the future planned plaintext/mrkdwn union here instead
   /**
    * @description An array of {@link ImageElement}, {@link PlainTextElement} or {@link MrkdwnElement} objects.
@@ -104,7 +84,7 @@ export interface DividerBlock extends Block {
   /**
    * @description The type of block. For a divider block, `type` is always `divider`.
    */
-  type: "divider";
+  type: 'divider';
 }
 
 /**
@@ -118,7 +98,7 @@ export interface FileBlock extends Block {
   /**
    * @description The type of block. For a file block, `type` is always `file`.
    */
-  type: "file";
+  type: 'file';
   /**
    * @description At the moment, source will always be `remote` for a remote file.
    */
@@ -138,7 +118,7 @@ export interface HeaderBlock extends Block {
   /**
    * @description The type of block. For a header block, `type` is always `header`.
    */
-  type: "header";
+  type: 'header';
   /**
    * @description The text for the block, in the form of a {@link PlainTextElement}.
    * Maximum length for the text in this field is 150 characters.
@@ -154,7 +134,7 @@ export interface ImageBlock extends Block {
   /**
    * @description The type of block. For an image block, `type` is always `image`.
    */
-  type: "image";
+  type: 'image';
   /**
    * @description The URL of the image to be displayed. Maximum length for this field is 3000 characters.
    */
@@ -194,7 +174,7 @@ export interface InputBlock extends Block {
   /**
    * @description The type of block. For an input block, `type` is always `input`.
    */
-  type: "input";
+  type: 'input';
   /**
    * @description A label that appears above an input element in the form of a {@link PlainTextElement} object.
    * Maximum length for the text in this field is 2000 characters.
@@ -213,20 +193,8 @@ export interface InputBlock extends Block {
   /**
    * @description A block element.
    */
-  element:
-    | Select
-    | MultiSelect
-    | Datepicker
-    | Timepicker
-    | DateTimepicker
-    | PlainTextInput
-    | URLInput
-    | EmailInput
-    | NumberInput
-    | RadioButtons
-    | Checkboxes
-    | RichTextInput
-    | FileInput;
+  element: Select | MultiSelect | Datepicker | Timepicker | DateTimepicker | PlainTextInput | URLInput | EmailInput
+  | NumberInput | RadioButtons | Checkboxes | RichTextInput | FileInput;
   /**
    * @description A boolean that indicates whether or not the use of elements in this block should dispatch a
    * {@link https://api.slack.com/reference/interaction-payloads/block-actions block_actions payload}. Defaults to `false`.
@@ -246,7 +214,7 @@ export interface SectionBlock extends Block {
   /**
    * @description The type of block. For a section block, `type` is always `section`.
    */
-  type: "section";
+  type: 'section';
   /**
    * @description The text for the block, in the form of a text object. Minimum length for the `text` in this field is
    * 1 and maximum length is 3000 characters. This field is not required if a valid array of `fields` objects is
@@ -263,17 +231,16 @@ export interface SectionBlock extends Block {
   /**
    * @description One of the compatible element objects.
    */
-  accessory?:
-    | Button
-    | Overflow
-    | Datepicker
-    | Timepicker
-    | Select
-    | MultiSelect
-    | Actionable
-    | ImageElement
-    | RadioButtons
-    | Checkboxes;
+  accessory?: Button
+  | Overflow
+  | Datepicker
+  | Timepicker
+  | Select
+  | MultiSelect
+  | Actionable
+  | ImageElement
+  | RadioButtons
+  | Checkboxes;
 }
 
 /**
@@ -286,7 +253,7 @@ export interface VideoBlock extends Block {
   /**
    * @description The type of block. For a video block, `type` is always `video`.
    */
-  type: "video";
+  type: 'video';
   /**
    * @description The URL to be embedded. Must match any existing
    * {@link https://api.slack.com/reference/messaging/link-unfurling#configuring_domains unfurl domains} within the app
@@ -332,11 +299,6 @@ export interface RichTextBlock extends Block {
   /**
    * @description The type of block. For a rich text block, `type` is always `rich_text`.
    */
-  type: "rich_text";
-  elements: (
-    | RichTextSection
-    | RichTextList
-    | RichTextQuote
-    | RichTextPreformatted
-  )[];
+  type: 'rich_text',
+  elements: (RichTextSection | RichTextList | RichTextQuote | RichTextPreformatted)[];
 }

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,6 +1,6 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
-import { PlainTextElement, MrkdwnElement } from './composition-objects';
+import { PlainTextElement, MrkdwnElement} from './composition-objects';
 import { Actionable } from './extensions';
 import {
   Button,
@@ -24,9 +24,11 @@ import {
   RichTextQuote,
   RichTextPreformatted,
   RichTextInput,
+  UrlImageObject,
+  SlackFileImageObject
 } from './block-elements';
 
-export interface Block {
+export type Block = {
   type: string;
   /**
    * @description A string acting as a unique identifier for a block. If not specified, a `block_id` will be generated.
@@ -130,28 +132,11 @@ export interface HeaderBlock extends Block {
  * @description Displays an image. A simple image block, designed to make those cat photos really pop.
  * @see {@link https://api.slack.com/reference/block-kit/blocks#image Image block reference}.
  */
-export interface ImageBlock extends Block {
+type ImageBlock = {
   /**
    * @description The type of block. For an image block, `type` is always `image`.
    */
   type: 'image';
-  /**
-   * @description The URL of the image to be displayed. Maximum length for this field is 3000 characters.
-   */
-  image_url?: string;
-  /**
-   * @description A Slack image file object that defines the source of the image.
-   */
-  slack_file?: {
-    /**
-     * @description This URL can be the url_private or the permalink of the Slack file.
-     */
-    url?: string;
-    /**
-     * @description Slack ID of the file.
-     */
-    id?: string;
-  };
   /**
    * @description A plain-text summary of the image. This should not contain any markup.
    * Maximum length for this field is 2000 characters.
@@ -162,7 +147,8 @@ export interface ImageBlock extends Block {
    * Maximum length for the text in this field is 2000 characters.
    */
   title?: PlainTextElement;
-}
+} & Block & (UrlImageObject | SlackFileImageObject)
+
 
 /**
  * @description Collects information from users via block elements.

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,7 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
-import { PlainTextElement, MrkdwnElement } from './composition-objects';
-import { Actionable } from './extensions';
+import { PlainTextElement, MrkdwnElement } from "./composition-objects";
+import { Actionable } from "./extensions";
 import {
   Button,
   Checkboxes,
@@ -24,7 +24,7 @@ import {
   RichTextQuote,
   RichTextPreformatted,
   RichTextInput,
-} from './block-elements';
+} from "./block-elements";
 
 export interface Block {
   type: string;
@@ -38,8 +38,17 @@ export interface Block {
   block_id?: string;
 }
 
-export type KnownBlock = ImageBlock | ContextBlock | ActionsBlock | DividerBlock |
-SectionBlock | InputBlock | FileBlock | HeaderBlock | VideoBlock | RichTextBlock;
+export type KnownBlock =
+  | ImageBlock
+  | ContextBlock
+  | ActionsBlock
+  | DividerBlock
+  | SectionBlock
+  | InputBlock
+  | FileBlock
+  | HeaderBlock
+  | VideoBlock
+  | RichTextBlock;
 
 /**
  * @description Holds multiple interactive elements.
@@ -49,13 +58,24 @@ export interface ActionsBlock extends Block {
   /**
    * @description The type of block. For an actions block, `type` is always `actions`.
    */
-  type: 'actions';
+  type: "actions";
   /**
    * @description An array of {@link InteractiveElements} objects.
    * There is a maximum of 25 elements in each action block.
    */
-  elements: (Button | Checkboxes | Datepicker | DateTimepicker | MultiSelect | Overflow | RadioButtons | Select |
-  Timepicker | WorkflowButton | RichTextInput)[];
+  elements: (
+    | Button
+    | Checkboxes
+    | Datepicker
+    | DateTimepicker
+    | MultiSelect
+    | Overflow
+    | RadioButtons
+    | Select
+    | Timepicker
+    | WorkflowButton
+    | RichTextInput
+  )[];
 }
 
 /**
@@ -66,7 +86,7 @@ export interface ContextBlock extends Block {
   /**
    * @description The type of block. For a context block, `type` is always `context`.
    */
-  type: 'context';
+  type: "context";
   // TODO: use the future planned plaintext/mrkdwn union here instead
   /**
    * @description An array of {@link ImageElement}, {@link PlainTextElement} or {@link MrkdwnElement} objects.
@@ -84,7 +104,7 @@ export interface DividerBlock extends Block {
   /**
    * @description The type of block. For a divider block, `type` is always `divider`.
    */
-  type: 'divider';
+  type: "divider";
 }
 
 /**
@@ -98,7 +118,7 @@ export interface FileBlock extends Block {
   /**
    * @description The type of block. For a file block, `type` is always `file`.
    */
-  type: 'file';
+  type: "file";
   /**
    * @description At the moment, source will always be `remote` for a remote file.
    */
@@ -118,7 +138,7 @@ export interface HeaderBlock extends Block {
   /**
    * @description The type of block. For a header block, `type` is always `header`.
    */
-  type: 'header';
+  type: "header";
   /**
    * @description The text for the block, in the form of a {@link PlainTextElement}.
    * Maximum length for the text in this field is 150 characters.
@@ -134,11 +154,24 @@ export interface ImageBlock extends Block {
   /**
    * @description The type of block. For an image block, `type` is always `image`.
    */
-  type: 'image';
+  type: "image";
   /**
    * @description The URL of the image to be displayed. Maximum length for this field is 3000 characters.
    */
-  image_url: string;
+  image_url?: string;
+  /**
+   * @description A Slack image file object that defines the source of the image.
+   */
+  slack_file?: {
+    /**
+     * @description This URL can be the url_private or the permalink of the Slack file.
+     */
+    url?: string;
+    /**
+     * @description Slack ID of the file.
+     */
+    id?: string;
+  };
   /**
    * @description A plain-text summary of the image. This should not contain any markup.
    * Maximum length for this field is 2000 characters.
@@ -161,7 +194,7 @@ export interface InputBlock extends Block {
   /**
    * @description The type of block. For an input block, `type` is always `input`.
    */
-  type: 'input';
+  type: "input";
   /**
    * @description A label that appears above an input element in the form of a {@link PlainTextElement} object.
    * Maximum length for the text in this field is 2000 characters.
@@ -180,8 +213,20 @@ export interface InputBlock extends Block {
   /**
    * @description A block element.
    */
-  element: Select | MultiSelect | Datepicker | Timepicker | DateTimepicker | PlainTextInput | URLInput | EmailInput
-  | NumberInput | RadioButtons | Checkboxes | RichTextInput | FileInput;
+  element:
+    | Select
+    | MultiSelect
+    | Datepicker
+    | Timepicker
+    | DateTimepicker
+    | PlainTextInput
+    | URLInput
+    | EmailInput
+    | NumberInput
+    | RadioButtons
+    | Checkboxes
+    | RichTextInput
+    | FileInput;
   /**
    * @description A boolean that indicates whether or not the use of elements in this block should dispatch a
    * {@link https://api.slack.com/reference/interaction-payloads/block-actions block_actions payload}. Defaults to `false`.
@@ -201,7 +246,7 @@ export interface SectionBlock extends Block {
   /**
    * @description The type of block. For a section block, `type` is always `section`.
    */
-  type: 'section';
+  type: "section";
   /**
    * @description The text for the block, in the form of a text object. Minimum length for the `text` in this field is
    * 1 and maximum length is 3000 characters. This field is not required if a valid array of `fields` objects is
@@ -218,16 +263,17 @@ export interface SectionBlock extends Block {
   /**
    * @description One of the compatible element objects.
    */
-  accessory?: Button
-  | Overflow
-  | Datepicker
-  | Timepicker
-  | Select
-  | MultiSelect
-  | Actionable
-  | ImageElement
-  | RadioButtons
-  | Checkboxes;
+  accessory?:
+    | Button
+    | Overflow
+    | Datepicker
+    | Timepicker
+    | Select
+    | MultiSelect
+    | Actionable
+    | ImageElement
+    | RadioButtons
+    | Checkboxes;
 }
 
 /**
@@ -240,7 +286,7 @@ export interface VideoBlock extends Block {
   /**
    * @description The type of block. For a video block, `type` is always `video`.
    */
-  type: 'video';
+  type: "video";
   /**
    * @description The URL to be embedded. Must match any existing
    * {@link https://api.slack.com/reference/messaging/link-unfurling#configuring_domains unfurl domains} within the app
@@ -286,6 +332,11 @@ export interface RichTextBlock extends Block {
   /**
    * @description The type of block. For a rich text block, `type` is always `rich_text`.
    */
-  type: 'rich_text',
-  elements: (RichTextSection | RichTextList | RichTextQuote | RichTextPreformatted)[];
+  type: "rich_text";
+  elements: (
+    | RichTextSection
+    | RichTextList
+    | RichTextQuote
+    | RichTextPreformatted
+  )[];
 }

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,6 +1,7 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
 
-import { PlainTextElement, MrkdwnElement} from './composition-objects';
+import { PlainTextElement, MrkdwnElement, UrlImageObject,
+  SlackFileImageObject} from './composition-objects';
 import { Actionable } from './extensions';
 import {
   Button,
@@ -24,11 +25,9 @@ import {
   RichTextQuote,
   RichTextPreformatted,
   RichTextInput,
-  UrlImageObject,
-  SlackFileImageObject
 } from './block-elements';
 
-export type Block = {
+export interface Block {
   type: string;
   /**
    * @description A string acting as a unique identifier for a block. If not specified, a `block_id` will be generated.
@@ -132,7 +131,7 @@ export interface HeaderBlock extends Block {
  * @description Displays an image. A simple image block, designed to make those cat photos really pop.
  * @see {@link https://api.slack.com/reference/block-kit/blocks#image Image block reference}.
  */
-type ImageBlock = {
+export type ImageBlock = {
   /**
    * @description The type of block. For an image block, `type` is always `image`.
    */
@@ -148,7 +147,6 @@ type ImageBlock = {
    */
   title?: PlainTextElement;
 } & Block & (UrlImageObject | SlackFileImageObject)
-
 
 /**
  * @description Collects information from users via block elements.

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -209,7 +209,7 @@ interface SlackFileViaId {
 /**
  * @description Defines an object containing Slack file information to be used in an image block or image element.
  * This {@link file https://api.slack.com/types/file} must be an image and you must provide either the URL or ID. In addition, the user posting these blocks must
- * have access to this file. If both are provided then the payload will be rejected. Currently only png, jpg, jpeg, and
+ * have access to this file. If both are provided then the payload will be rejected. Currently only `png`, `jpg`, `jpeg`, and
  *  gif Slack image files are supported.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#slack_file Slack File object reference}.
  */

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -200,7 +200,7 @@ interface SlackFileViaUrl {
   url: string;
 }
 /**
- * @description This ID can be the file ID or the file comment ID.
+ * @description `id` of the {@link Slack file https://api.slack.com/types/file}.
  */
 interface SlackFileViaId {
   id: string;

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -210,7 +210,7 @@ interface SlackFileViaId {
  * @description Defines an object containing Slack file information to be used in an image block or image element.
  * This {@link file https://api.slack.com/types/file} must be an image and you must provide either the URL or ID. In addition, the user posting these blocks must
  * have access to this file. If both are provided then the payload will be rejected. Currently only `png`, `jpg`, `jpeg`, and
- *  gif Slack image files are supported.
+ *  `gif` Slack image files are supported.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#slack_file Slack File object reference}.
  */
 export type SlackFile = SlackFileViaUrl | SlackFileViaId;

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -163,11 +163,11 @@ type Conversation = 'im' | 'mpim' | 'private' | 'public';
 
 interface BaseConversationFilter {
   /**
-  * @description Indicates which type of conversations should be included in the list. When this field is provided, any
-  * conversations that do not match will be excluded. You should provide an array of strings from the following options:
-  * `im`, `mpim`, `private`, and `public`. The array cannot be empty.
-  */
-  include?: [Conversation, ...Conversation[]]; // TS gymnastics for "at least one item"
+   * @description Indicates which type of conversations should be included in the list. When this field is provided, any
+   * conversations that do not match will be excluded. You should provide an array of strings from the following options:
+   * `im`, `mpim`, `private`, and `public`. The array cannot be empty.
+   */
+  include?: [Conversation, ...Conversation[]]; // TS gymnastics for 'at least one item'
   /**
    * @description Indicates whether to exclude external {@link https://api.slack.com/enterprise/shared-channels shared channels}
    * from conversation lists. This field will not exclude users from shared channels. Defaults to `false`.
@@ -184,4 +184,33 @@ interface BaseConversationFilter {
  * conversations select menu or a conversations multi-select menu.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#filter_conversations Conversation filter object reference}.
  */
-export type ConversationFilter = (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'include'>>) | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'exclude_bot_users'>>) | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'exclude_external_shared_channels'>>);
+export type ConversationFilter =
+  | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'include'>>)
+  | (BaseConversationFilter &
+      Required<Pick<BaseConversationFilter, 'exclude_bot_users'>>)
+  | (BaseConversationFilter &
+      Required<
+        Pick<BaseConversationFilter, 'exclude_external_shared_channels'>
+      >);
+
+/**
+ * @description This URL can be the url_private or the permalink of the Slack file.
+ */
+interface SlackFileViaUrl {
+  url: string;
+}
+/**
+ * @description This ID can be the file ID or the file comment ID.
+ */
+interface SlackFileViaId {
+  id: string;
+}
+
+/**
+ * @description Defines an object containing Slack file information to be used in an image block or image element.
+ * This file must be an image and you must provide either the URL or ID. In addition, the user posting these blocks must
+ * have access to this file. If both are provided then the payload will be rejected. Currently only png, jpg, jpeg, and
+ *  gif Slack image files are supported.
+ * @see {@link https://api.slack.com/reference/block-kit/composition-objects#slack_file Slack File object reference}.
+ */
+export type SlackFile = SlackFileViaUrl | SlackFileViaId;

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -194,7 +194,7 @@ export type ConversationFilter =
       >);
 
 /**
- * @description This URL can be the url_private or the permalink of the Slack file.
+ * @description This URL can be the `url_private` or the `permalink` of the {@link Slack file https://api.slack.com/types/file}.
  */
 interface SlackFileViaUrl {
   url: string;

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -208,7 +208,7 @@ interface SlackFileViaId {
 
 /**
  * @description Defines an object containing Slack file information to be used in an image block or image element.
- * This file must be an image and you must provide either the URL or ID. In addition, the user posting these blocks must
+ * This {@link file https://api.slack.com/types/file} must be an image and you must provide either the URL or ID. In addition, the user posting these blocks must
  * have access to this file. If both are provided then the payload will be rejected. Currently only png, jpg, jpeg, and
  *  gif Slack image files are supported.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#slack_file Slack File object reference}.

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -163,11 +163,11 @@ type Conversation = 'im' | 'mpim' | 'private' | 'public';
 
 interface BaseConversationFilter {
   /**
-   * @description Indicates which type of conversations should be included in the list. When this field is provided, any
-   * conversations that do not match will be excluded. You should provide an array of strings from the following options:
-   * `im`, `mpim`, `private`, and `public`. The array cannot be empty.
-   */
-  include?: [Conversation, ...Conversation[]]; // TS gymnastics for 'at least one item'
+  * @description Indicates which type of conversations should be included in the list. When this field is provided, any
+  * conversations that do not match will be excluded. You should provide an array of strings from the following options:
+  * `im`, `mpim`, `private`, and `public`. The array cannot be empty.
+  */
+  include?: [Conversation, ...Conversation[]]; // TS gymnastics for "at least one item"
   /**
    * @description Indicates whether to exclude external {@link https://api.slack.com/enterprise/shared-channels shared channels}
    * from conversation lists. This field will not exclude users from shared channels. Defaults to `false`.
@@ -184,14 +184,26 @@ interface BaseConversationFilter {
  * conversations select menu or a conversations multi-select menu.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#filter_conversations Conversation filter object reference}.
  */
-export type ConversationFilter =
-  | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'include'>>)
-  | (BaseConversationFilter &
-      Required<Pick<BaseConversationFilter, 'exclude_bot_users'>>)
-  | (BaseConversationFilter &
-      Required<
-        Pick<BaseConversationFilter, 'exclude_external_shared_channels'>
-      >);
+export type ConversationFilter = (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'include'>>) | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'exclude_bot_users'>>) | (BaseConversationFilter & Required<Pick<BaseConversationFilter, 'exclude_external_shared_channels'>>);
+/**
+ * @description Object for image which contains a image_url.
+ */
+export interface UrlImageObject {
+  /**
+   * @description The URL of the image to be displayed.
+   */
+  image_url: string;
+}
+
+/**
+ * @description Object for image which contains a slack_file.
+ */
+export interface SlackFileImageObject {
+  /**
+   * @description The slack file of the image to be displayed.
+   */
+  slack_file: SlackFile;
+}
 
 /**
  * @description This URL can be the `url_private` or the `permalink` of the {@link Slack file https://api.slack.com/types/file}.


### PR DESCRIPTION
###  Summary

This update adds the newly available slack_file object to the imageBlock and sets the image_url to be optional

### Requirements (place an `x` in each `[ ]`)

* [X ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
