### PR TITLE
web-api(fix): include file or contents types in file_uploads arguments

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -519,7 +519,7 @@ export class WebClient extends Methods {
     }
 
     // add multiple files data when file_uploads is supplied
-    if (options.file_uploads) {
+    if ('file_uploads' in options) {
       fileUploads = fileUploads.concat(await getMultipleFileUploadJobs(options, this.logger));
     }
     return fileUploads;

--- a/packages/web-api/src/types/helpers.ts
+++ b/packages/web-api/src/types/helpers.ts
@@ -1,0 +1,2 @@
+/** Omit all keys K from possible union types T */
+export type ExcludeFromUnion<T, K extends string> = T extends T ? Omit<T, K> : never;

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -6,6 +6,7 @@ import type {
   TraditionalPagingEnabled,
 } from './common';
 import type { FilesGetUploadURLExternalResponse } from '../response/index';
+import type { ExcludeFromUnion } from '../helpers';
 
 interface FileArgument {
   /** @description Encoded file ID. */
@@ -149,7 +150,7 @@ export type FileUploadV2 = FileUpload & {
 
 // https://slack.dev/node-slack-sdk/web-api#upload-a-file
 export type FilesUploadV2Arguments = FileUploadV2 & TokenOverridable & {
-  file_uploads?: Omit<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
+  file_uploads?: ExcludeFromUnion<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
 };
 
 // Helper type intended for internal use in filesUploadV2 client method

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -148,10 +148,15 @@ export type FileUploadV2 = FileUpload & {
   snippet_type?: string;
 };
 
+interface FilesUploadV2ArgumentsMultipleFiles {
+  file_uploads: ExcludeFromUnion<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
+}
+
 // https://slack.dev/node-slack-sdk/web-api#upload-a-file
-export type FilesUploadV2Arguments = FileUploadV2 & TokenOverridable & {
-  file_uploads?: ExcludeFromUnion<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
-};
+export type FilesUploadV2Arguments = TokenOverridable & (
+  | FileUploadV2
+  | (Omit<FileUploadV2, 'file' | 'content'> & FilesUploadV2ArgumentsMultipleFiles)
+);
 
 // Helper type intended for internal use in filesUploadV2 client method
 // Includes additional metadata required to complete a single file upload job


### PR DESCRIPTION
###  Summary

This PR ensures both the `file` and `content` arguments are included in the type for `file_uploads`. Fixes #1743.

### Reviewers

The following snippets can be used to ensure these types are available! Using TypeScript or JSDoc is recommended to experience the full typing experience.

#### Single file uploads

Everything should remain working just as expected:

```ts
(async () => {
    const web = new WebClient(token);
    const result = await web.files.uploadV2({
        channel_id: "C0123456789",
        filename: "GREETINGS.txt",
        content: "hello world",
    });
    console.log(result);
})();
```

#### Multiple file uploads

Multiple file uploads can be done without needing to specify a top-level `file` or `content`. These attributes are still allowed and will be uploaded if provided, but aren't required anymore!

But the main fix of this PR is exposing the types for the `file` and `content` within `file_uploads`:

```ts
(async () => {
    const web = new WebClient(token);
    const result = await web.files.uploadV2({
        channel_id: "C0123456789",
        file_uploads: [
            {
                filename: "README.md",
                file: "./README.md",
            },
            {
                filename: "GREETINGS.txt",
                content: "hello world",
            },
        ]
    });
    console.log(result);
})();
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).