### PR TITLE
web-api(chore): release @slack/web-api@7.0.2

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

This PR bumps the version of `@slack/web-api` to `7.0.2` to release patches made for [the web-api@7.0.2 milestone](https://github.com/slackapi/node-slack-sdk/milestone/78?closed=1).

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).