### PR TITLE
Add missing "border" proerty to "rich_text_quote" block element

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -951,6 +951,11 @@ export interface RichTextQuote {
    * @description An array of {@link RichTextElement} comprising the quote block.
    */
   elements: RichTextElement[];
+  /**
+   * @description Whether to render a quote-block-like border on the inline side of the text quote.
+   * `0` renders no border, while `1` renders a border. Defaults to `0`.
+   */
+  border?: 0 | 1;
 }
 
 /**


### PR DESCRIPTION
###  Summary

This pull request resolves a bug where the "border" property in "rich_text_quote" block element is missing in https://github.com/slackapi/node-slack-sdk/pull/1643 changes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
