### PR TITLE
Fix: Add missing 'new' keyword in rate limit error throwing

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -594,7 +594,7 @@ export class WebClient extends Methods {
             // resume the request queue and throw a non-abort error to signal a retry
             this.requestQueue.start();
             // TODO: We may want to have more detailed info such as team_id, params except tokens, and so on.
-            throw Error(`A rate limit was exceeded (url: ${url}, retry-after: ${retrySec})`);
+            throw new Error(`A rate limit was exceeded (url: ${url}, retry-after: ${retrySec})`);
           } else {
             // TODO: turn this into some CodedError
             throw new AbortError(new Error(`Retry header did not contain a valid timeout (url: ${url}, retry-after header: ${response.headers['retry-after']})`));


### PR DESCRIPTION
###  Summary
Although both expressions work in JavaScript, the standard practice is to use new when instantiating error objects to ensure proper behavior and readability. This change, while not affecting functionality, aligns our code with conventional JavaScript practices.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
