### PR TITLE
Release `@slack/socket-mode` v1.3.4

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
Maintenance release on previous 1.x line (so base target is the branch `socket-mode-1.3.x`) that includes additional debug logging.