### PR TITLE
Prep for major release of rtm-api

### DIFF
--- a/packages/rtm-api/.mocharc.json
+++ b/packages/rtm-api/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": ["ts-node/register", "source-map-support/register"],
+  "timeout": 3000
+}

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -430,7 +430,7 @@ const rtm = new RTMClient(token, {
 
 ## Requirements
 
-This package supports Node v14 and higher. It's highly recommended to use [the latest LTS version of
+This package supports Node v18 and higher. It's highly recommended to use [the latest LTS version of
 node](https://github.com/nodejs/Release#release-schedule), and the documentation is written using syntax and features
 from that version.
 
@@ -440,6 +440,3 @@ If you get stuck, we're here to help. The following are the best ways to get ass
 
   * [Issue Tracker](http://github.com/slackapi/node-slack-sdk/issues) for questions, feature requests, bug reports and
     general discussion related to these packages. Try searching before you create a new issue.
-  * [Email us](mailto:developers@slack.com) in Slack developer support: `developers@slack.com`
-  * [Bot Developers Hangout](https://community.botkit.ai/): a Slack community for developers
-    building all types of bots. You can find the maintainers and users of these packages in **#sdk-node-slack-sdk**.

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -22,8 +22,8 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">= 12.13.0",
-    "npm": ">= 6.12.0"
+    "node": ">=18",
+    "npm": ">=8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
   "homepage": "https://slack.dev/node-slack-sdk/rtm-api",
@@ -37,34 +37,33 @@
     "prepare": "npm run build",
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist",
-    "lint": "eslint --ext .ts src",
-    "test": "npm run lint && npm run build && echo \"Tests are not implemented.\" && exit 0",
+    "lint": "eslint --fix --ext .ts src",
+    "test": "npm run lint && npm run build",
     "ref-docs:model": "api-extractor run"
   },
   "dependencies": {
-    "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/web-api": "^6.11.2",
-    "@types/node": ">=12.0.0",
-    "@types/p-queue": "^2.3.2",
-    "@types/ws": "^7.4.7",
-    "eventemitter3": "^3.1.0",
+    "@slack/logger": "^4",
+    "@slack/web-api": "^7",
+    "@types/node": ">=18",
+    "eventemitter3": "^5",
     "finity": "^0.5.4",
-    "p-cancelable": "^1.1.0",
-    "p-queue": "^2.4.2",
-    "ws": "^7.5.3"
+    "p-cancelable": "^2",
+    "p-queue": "^6",
+    "ws": "^8"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.38.0",
-    "@typescript-eslint/eslint-plugin": "^6.4.1",
-    "@typescript-eslint/parser": "^6.4.0",
-    "eslint": "^8.47.0",
-    "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-airbnb-typescript": "^17.1.0",
-    "eslint-plugin-import": "^2.28.1",
+    "@microsoft/api-extractor": "^7",
+    "@typescript-eslint/eslint-plugin": "^6",
+    "@typescript-eslint/parser": "^6",
+    "@types/ws": "^8",
+    "eslint": "^8",
+    "eslint-config-airbnb-base": "^15",
+    "eslint-config-airbnb-typescript": "^17",
+    "eslint-plugin-import": "^2",
     "eslint-plugin-import-newlines": "^1.3.4",
-    "eslint-plugin-jsdoc": "^46.5.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-jsdoc": "^48",
+    "eslint-plugin-node": "^11",
     "shx": "^0.3.2",
-    "typescript": "^4.1.0"
+    "typescript": "5.3.3"
   }
 }

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -38,7 +38,8 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist",
     "lint": "eslint --fix --ext .ts src",
-    "test": "npm run lint && npm run build",
+    "test": "npm run lint && npm run build && npm run test:integration",
+    "test:integration": "mocha --config .mocharc.json test/integration.spec.js",
     "ref-docs:model": "api-extractor run"
   },
   "dependencies": {
@@ -55,7 +56,11 @@
     "@microsoft/api-extractor": "^7",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
+    "@types/chai": "^4",
+    "@types/mocha": "^10",
+    "@types/sinon": "^17",
     "@types/ws": "^8",
+    "chai": "^4",
     "eslint": "^8",
     "eslint-config-airbnb-base": "^15",
     "eslint-config-airbnb-typescript": "^17",
@@ -63,7 +68,11 @@
     "eslint-plugin-import-newlines": "^1.3.4",
     "eslint-plugin-jsdoc": "^48",
     "eslint-plugin-node": "^11",
+    "mocha": "^10",
     "shx": "^0.3.2",
+    "sinon": "^17",
+    "source-map-support": "^0.5.21",
+    "ts-node": "^10",
     "typescript": "5.3.3"
   }
 }

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -621,13 +621,13 @@ export class RTMClient extends EventEmitter {
    * `onmessage` handler for the client's websocket. This will parse the payload and dispatch the relevant events for
    * each incoming message.
    */
-  private onWebsocketMessage({ data }: { data: string }): void {
-    this.logger.debug(`received message on websocket: ${data}`);
+  private onWebsocketMessage(data: WebSocket.RawData): void {
+    this.logger.debug(`received message on websocket: ${data.toString()}`);
 
     // parse message into slack event
     let event;
     try {
-      event = JSON.parse(data);
+      event = JSON.parse(data.toString());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (parseError: any) {
       // prevent application from crashing on a bad message, but log an error to bring attention

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -137,7 +137,7 @@ export class RTMClient extends EventEmitter {
               // determine which Web API method to use for the connection
               const connectMethod = this.useRtmConnect ? 'rtm.connect' : 'rtm.start';
 
-              return this.webClient.apiCall(connectMethod, this.startOpts !== undefined ? this.startOpts : {})
+              return this.webClient.apiCall(connectMethod, this.startOpts !== undefined ? { ...this.startOpts } : {})
                 .then((result: WebAPICallResult) => {
                   const startData = result as RTMStartResult;
 
@@ -601,7 +601,7 @@ export class RTMClient extends EventEmitter {
       this.logger.error(`A websocket error occurred: ${event.message}`);
       this.emit('error', websocketErrorWithOriginal(event.error));
     });
-    this.websocket.addEventListener('message', this.onWebsocketMessage.bind(this));
+    this.websocket.on('message', this.onWebsocketMessage.bind(this));
   }
 
   /**

--- a/packages/rtm-api/src/RTMClient.ts
+++ b/packages/rtm-api/src/RTMClient.ts
@@ -122,6 +122,7 @@ export class RTMClient extends EventEmitter {
     /* eslint-disable @typescript-eslint/indent, newline-per-chained-call */
       .initialState('disconnected')
         .on('start').transitionTo('connecting')
+        .on('explicit disconnect').transitionTo('disconnected')
         .onEnter(() => {
           // each client should start out with the outgoing event queue paused
           this.logger.debug('pausing outgoing event queue');

--- a/packages/rtm-api/test/integration.spec.js
+++ b/packages/rtm-api/test/integration.spec.js
@@ -1,0 +1,89 @@
+const { assert } = require('chai');
+const { RTMClient } = require('../src/RTMClient');
+const { LogLevel } = require('../src/logger');
+const { WebSocketServer} = require('ws');
+const { createServer } = require('http');
+const sinon = require('sinon');
+
+const HTTP_PORT = 12345;
+const WSS_PORT = 23456;
+// Basic HTTP server to 'fake' behaviour of `apps.connections.open` endpoint
+let server = null;
+
+// Basic WS server to fake slack WS endpoint
+let wss = null;
+let exposed_ws_connection = null;
+
+// Socket mode client pointing to the above two posers
+let client = null;
+
+describe('Integration tests with a WebSocket server', () => {
+  beforeEach(() => {
+    server = createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: true,
+        url: `ws://localhost:${WSS_PORT}/`,
+        self: { id: 'elclassico' },
+        team: { id: 'T12345' },
+      }));
+    });
+    server.listen(HTTP_PORT);
+    wss = new WebSocketServer({ port: WSS_PORT });
+    wss.on('connection', (ws) => {
+      ws.on('error', (err) => {
+        assert.fail(err);
+      });
+      // Send `Event.ServerHello`
+      ws.send(JSON.stringify({type: 'hello'}));
+      exposed_ws_connection = ws;
+    });
+  });
+  afterEach(() => {
+    server.close();
+    server = null;
+    wss.close();
+    wss = null;
+    exposed_ws_connection = null;
+    client = null;
+  });
+  describe('establishing connection, receiving valid messages', () => {
+    beforeEach(() => {
+      client = new RTMClient('token', {
+        slackApiUrl: `http://localhost:${HTTP_PORT}/`,
+        logLevel: LogLevel.DEBUG,
+      });
+    });
+    it('connects to a server via `start()` and gracefully disconnects via `disconnect()`', async () => {
+      await client.start();
+      await sleep(50); // TODO: this is due to `start()` resolving once the authenticated event is raised
+      // however, the handshake on the WS side still needs to complete at this point, so calling disconnect()
+      // will raise an error.
+      await client.disconnect();
+    });
+    it('can listen on slack event types and receive payload properties', async () => {
+      client.on('connected', () => {
+        exposed_ws_connection.send(JSON.stringify({
+          type: 'team_member_joined',
+          envelope_id: 12345,
+        }));
+      });
+      await client.start();
+      await new Promise((res, _rej) => {
+        client.on('team_member_joined', (evt) => {
+          assert.equal(evt.envelope_id, 12345);
+          res();
+        });
+      });
+      await client.disconnect();
+    });
+    it.only('should not raise an exception if calling disconnect() when already disconnected', async () => {
+      // https://github.com/slackapi/node-slack-sdk/issues/842
+      await client.disconnect();
+    });
+  });
+});
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/rtm-api/test/integration.spec.js
+++ b/packages/rtm-api/test/integration.spec.js
@@ -77,7 +77,7 @@ describe('Integration tests with a WebSocket server', () => {
       });
       await client.disconnect();
     });
-    it.only('should not raise an exception if calling disconnect() when already disconnected', async () => {
+    it('should not raise an exception if calling disconnect() when already disconnected', async () => {
       // https://github.com/slackapi/node-slack-sdk/issues/842
       await client.disconnect();
     });


### PR DESCRIPTION
Mainly updating dependencies and dropping support for node below 18.

BUT! I am worried that this package has no tests. Esp. since I updated to the latest major of `websockets` which has some breaking changes.

Can I manually test an RTM app these days? I have no idea. EDIT: YES it's possible! I tested a RTM app w/ the old package prior to this change, works fine. Also tested it with the changes in this PR, also works OK!

~Another thought: maybe I copy the basic web socket server integration test suite I added to the socket mode package into here (or factor the server out into a `utils/` dir or something in this repo and re-use it in both packages?). Then I could at least add some smoke test-style integration tests? That should in theory also be able to write a test for #842 and thus feel confident about a fix.~ I did this! This package now includes basic integration tests. I was able to even add a test to confirm #842 is an issue and added a fix that passes the test 😄 