### PR TITLE
web-api(fix): oauth.v2.exchange method requires a token parameter

### DIFF
--- a/packages/web-api/src/types/request/oauth.ts
+++ b/packages/web-api/src/types/request/oauth.ts
@@ -8,4 +8,7 @@ export interface OAuthAccessArguments extends OAuthCredentials {
 // https://api.slack.com/methods/oauth.v2.access
 export interface OAuthV2AccessArguments extends OAuthCredentials, OAuthGrantRefresh {}
 // https://api.slack.com/methods/oauth.v2.exchange
-export interface OAuthV2ExchangeArguments extends Pick<OAuthCredentials, 'client_id' | 'client_secret'> {}
+export interface OAuthV2ExchangeArguments extends Pick<OAuthCredentials, 'client_id' | 'client_secret'> {
+  /** @description The legacy xoxb or xoxp token being migrated. */
+  token: string;
+}

--- a/packages/web-api/test/types/methods/oauth.test-d.ts
+++ b/packages/web-api/test/types/methods/oauth.test-d.ts
@@ -41,12 +41,28 @@ expectAssignable<Parameters<typeof web.oauth.v2.access>>([{
 expectError(web.oauth.v2.exchange()); // lacking argument
 expectError(web.oauth.v2.exchange({})); // empty argument
 expectError(web.oauth.v2.exchange({
-  client_id: 'C1234', // missing client_secret
+  client_id: 'C1234', // missing client_secret, token
 }));
 expectError(web.oauth.v2.exchange({
-  client_secret: '1234.567', // missing `client_id`
+  client_secret: '1234.567', // missing `client_id`, token
+}));
+expectError(web.oauth.v2.exchange({
+  token: 'xoxp-blah', // missing `client_id`, client_secret
+}));
+expectError(web.oauth.v2.exchange({
+  client_id: 'C1234',
+  client_secret: '1234.567', // missing token
+}));
+expectError(web.oauth.v2.exchange({
+  client_id: 'C1234',
+  token: 'xoxb-blah', // missing client_secret
+}));
+expectError(web.oauth.v2.exchange({
+  client_secret: '1234.567',
+  token: 'xoxb-blah', // missing client_id
 }));
 // -- happy path
 expectAssignable<Parameters<typeof web.oauth.v2.exchange>>([{
+  token: 'xoxb-blah',
   ...creds,
 }]);


### PR DESCRIPTION
###  Summary

The `oauth.v2.exchange` method requires a token parameter.

This fixes #1778.