### PR TITLE
providing a way to disable message content being logged

### DIFF
--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -2,7 +2,7 @@ require('mocha');
 const fs = require('fs');
 const path = require('path');
 const { Agent } = require('https');
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 const { WebClient, buildThreadTsWarningMessage } = require('./WebClient');
 const { ErrorCode } = require('./errors');
 const { LogLevel } = require('./logger');
@@ -1609,6 +1609,46 @@ describe('WebClient', function () {
       };
       await client.filesUploadV2(withRequestFileInfoFalse);
       assert.equal(client.getFileInfo.called, false);
+    });
+  });
+
+  describe('has an option to suppress request error from Axios', () => {
+    it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is absent', async () => {
+      const client = new WebClient(token,  {
+        timeout: 10,
+        retryConfig: rapidRetryPolicy,
+      });
+      try {
+        await client.conversations.list()
+      } catch(err) {
+        expect(err).to.haveOwnProperty('original')
+      }
+    });
+
+    it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is set to true', async () => {
+      const client = new WebClient(token,  {
+        timeout: 10,
+        retryConfig: rapidRetryPolicy,
+        attachOriginalToWebAPIRequestError: true,
+      });
+      try {
+        await client.conversations.list()
+      } catch(err) {
+        expect(err).to.haveOwnProperty('original')
+      }
+    });
+
+    it('the \'original\' property is not attached when the option, attachOriginalToWebAPIRequestError is set to false', async () => {
+      const client = new WebClient(token,  {
+        timeout: 10,
+        retryConfig: rapidRetryPolicy,
+        attachOriginalToWebAPIRequestError: false,
+      });
+      try {
+        await client.conversations.list()
+      } catch(err) {
+        expect(err).not.to.haveOwnProperty('original')
+      }
     });
   });
 

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1621,7 +1621,9 @@ describe('WebClient', function () {
     })
 
     it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is absent', async () => {
-      const client = new WebClient(token);
+      const client = new WebClient(token, {
+        retryConfig: { retries: 0 },
+      });
 
       client.apiCall('conversations/list').catch((error) => {
         expect(error).to.haveOwnProperty('original')
@@ -1634,6 +1636,7 @@ describe('WebClient', function () {
     it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is set to true', async () => {
       const client = new WebClient(token,  {
         attachOriginalToWebAPIRequestError: true,
+        retryConfig: { retries: 0 },
       });
 
       client.apiCall('conversations/list').catch((error) => {
@@ -1646,6 +1649,7 @@ describe('WebClient', function () {
     it('the \'original\' property is not attached when the option, attachOriginalToWebAPIRequestError is set to false', async () => {
       const client = new WebClient(token,  {
         attachOriginalToWebAPIRequestError: false,
+        retryConfig: { retries: 0 },
       });
 
       client.apiCall('conversations/list').catch((error) => {

--- a/packages/web-api/src/WebClient.spec.js
+++ b/packages/web-api/src/WebClient.spec.js
@@ -1613,42 +1613,46 @@ describe('WebClient', function () {
   });
 
   describe('has an option to suppress request error from Axios', () => {
+
+    beforeEach(function () {
+      this.scope = nock('https://slack.com')
+      .post(/api/)
+      .replyWithError('Request failed!!')
+    })
+
     it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is absent', async () => {
-      const client = new WebClient(token,  {
-        timeout: 10,
-        retryConfig: rapidRetryPolicy,
+      const client = new WebClient(token);
+
+      client.apiCall('conversations/list').catch((error) => {
+        expect(error).to.haveOwnProperty('original')
+        this.scope.done();
+        done();
       });
-      try {
-        await client.conversations.list()
-      } catch(err) {
-        expect(err).to.haveOwnProperty('original')
-      }
+
     });
 
     it('the \'original\' property is attached when the option, attachOriginalToWebAPIRequestError is set to true', async () => {
       const client = new WebClient(token,  {
-        timeout: 10,
-        retryConfig: rapidRetryPolicy,
         attachOriginalToWebAPIRequestError: true,
       });
-      try {
-        await client.conversations.list()
-      } catch(err) {
-        expect(err).to.haveOwnProperty('original')
-      }
+
+      client.apiCall('conversations/list').catch((error) => {
+        expect(error).to.haveOwnProperty('original')
+        this.scope.done();
+        done();
+      });
     });
 
     it('the \'original\' property is not attached when the option, attachOriginalToWebAPIRequestError is set to false', async () => {
       const client = new WebClient(token,  {
-        timeout: 10,
-        retryConfig: rapidRetryPolicy,
         attachOriginalToWebAPIRequestError: false,
       });
-      try {
-        await client.conversations.list()
-      } catch(err) {
-        expect(err).not.to.haveOwnProperty('original')
-      }
+
+      client.apiCall('conversations/list').catch((error) => {
+        expect(error).not.to.haveOwnProperty('original')
+        this.scope.done();
+        done();
+      });
     });
   });
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -166,6 +166,12 @@ export class WebClient extends Methods {
    * This object's teamId value
    */
   private teamId?: string;
+  
+  /**
+   * Configuration to opt-out of attaching the original property to WebAPIRequestError.
+   * See {@link https://github.com/slackapi/node-slack-sdk/issues/1751} for more details.
+   */
+  private attachOriginalToWebAPIRequestError: boolean;
 
   /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
@@ -182,6 +188,7 @@ export class WebClient extends Methods {
     rejectRateLimitedCalls = false,
     headers = {},
     teamId = undefined,
+    attachOriginalToWebAPIRequestError = true,
   }: WebClientOptions = {}) {
     super();
 
@@ -195,6 +202,7 @@ export class WebClient extends Methods {
     this.tlsConfig = tls !== undefined ? tls : {};
     this.rejectRateLimitedCalls = rejectRateLimitedCalls;
     this.teamId = teamId;
+    this.attachOriginalToWebAPIRequestError = attachOriginalToWebAPIRequestError;
 
     // Logging
     if (typeof logger !== 'undefined') {
@@ -613,7 +621,7 @@ export class WebClient extends Methods {
         const e = error as any;
         this.logger.warn('http request failed', e.message);
         if (e.request) {
-          throw requestErrorWithOriginal(e);
+          throw requestErrorWithOriginal(e, this.attachOriginalToWebAPIRequestError);
         }
         throw error;
       }

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -70,6 +70,13 @@ export interface WebClientOptions {
   rejectRateLimitedCalls?: boolean;
   headers?: Record<string, string>;
   teamId?: string;
+  /**
+ * Indicates whether to attach the original error to a Web API request error.
+ * When set to true, the original error object will be attached to the Web API request error.
+ * @type {boolean}
+ * @default true
+ */
+  attachOriginalToWebAPIRequestError?: boolean,
 }
 
 export type TLSOptions = Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
@@ -168,8 +175,8 @@ export class WebClient extends Methods {
   private teamId?: string;
   
   /**
-   * Configuration to opt-out of attaching the original property to WebAPIRequestError.
-   * See {@link https://github.com/slackapi/node-slack-sdk/issues/1751} for more details.
+   * Configuration to opt-out of attaching the original error
+   * (obtained from the HTTP client) to WebAPIRequestError.
    */
   private attachOriginalToWebAPIRequestError: boolean;
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -173,7 +173,7 @@ export class WebClient extends Methods {
    * This object's teamId value
    */
   private teamId?: string;
-  
+
   /**
    * Configuration to opt-out of attaching the original error
    * (obtained from the HTTP client) to WebAPIRequestError.

--- a/packages/web-api/src/errors.ts
+++ b/packages/web-api/src/errors.ts
@@ -80,8 +80,8 @@ export function requestErrorWithOriginal(original: Error, attachOriginal: boolea
     new Error(`A request error occurred: ${original.message}`),
     ErrorCode.RequestError,
   ) as Partial<WebAPIRequestError>;
-  if(attachOriginal) {
-    error.original = original
+  if (attachOriginal) {
+    error.original = original;
   }
   return (error as WebAPIRequestError);
 }

--- a/packages/web-api/src/errors.ts
+++ b/packages/web-api/src/errors.ts
@@ -73,13 +73,16 @@ export function errorWithCode(error: Error, code: ErrorCode): CodedError {
 /**
  * A factory to create WebAPIRequestError objects
  * @param original - original error
+ * @param attachOriginal - config indicating if 'original' property should be added on the error object
  */
-export function requestErrorWithOriginal(original: Error): WebAPIRequestError {
+export function requestErrorWithOriginal(original: Error, attachOriginal: boolean): WebAPIRequestError {
   const error = errorWithCode(
     new Error(`A request error occurred: ${original.message}`),
     ErrorCode.RequestError,
   ) as Partial<WebAPIRequestError>;
-  error.original = original;
+  if(attachOriginal) {
+    error.original = original
+  }
   return (error as WebAPIRequestError);
 }
 


### PR DESCRIPTION
###  Summary

In this PR, we aim to prevent the logging of message content when a request error occurs while attempting to invoke any of Slack's web APIs.

It solves [this issue](https://github.com/slackapi/node-slack-sdk/issues/1751).

#### The problem at a glace -
The Error type - `WebAPIRequestError`, contains a property called `original` which holds the raw error received from `axios`.
The `config` property within this `original` is a part of the error data received from `axios`.
This `config` property might in turn hold a `data` property, which is the "message" we are trying to opt-out of showing.

#### Tests conducted -
1. Error log with the opt-out config -
![Error with config](https://github.com/slackapi/node-slack-sdk/assets/30025212/b4584ba0-076c-45b3-93d8-e95bd9810155)
Note: The `original` property is missing from the Error object.

2. Error log without adding the config - 
![Error without config](https://github.com/slackapi/node-slack-sdk/assets/30025212/2fa3fe43-17fe-438d-aba3-d8d905603f81)
Note: The `original` property is present in the Error object along with all the details of the request.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
