### PR TITLE
cli-test: ensure skipping update is truly the default

### DIFF
--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -53,6 +53,10 @@ describe('SlackCLIProcess class', () => {
         cmd = new SlackCLIProcess('help', { skipUpdate: true });
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(runAsyncSpy, '--skip-update');
+        runAsyncSpy.resetHistory();
+        cmd = new SlackCLIProcess('help', {}); // empty global options; so undefined skipUpdate option
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(runAsyncSpy, '--skip-update');
       });
     });
     describe('command options', () => {

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -90,7 +90,7 @@ export class SlackCLIProcess {
       if (opts.qa || opts.dev) {
         cmd += ' --slackdev';
       }
-      if (opts.skipUpdate) {
+      if (opts.skipUpdate || opts.skipUpdate === undefined) {
         cmd += ' --skip-update';
       }
       if (opts.team) {

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -68,7 +68,7 @@ export const shell = {
    * - Execute child process with the command
    * - Wait for the command to complete and return the standard output
    * @param command cli command, e.g. <cli> --version or any shell command
-   * @param skipUpdate skip auto update notification
+   * @param shellOpts various shell spawning options available to customize
    * @returns command stdout
    */
   runCommandSync: function runSyncCommand(


### PR DESCRIPTION
fixes bug where global CLI options were provided but skipUpdate was `undefined`