### PR TITLE
chore: replace `master` branch refs with `main`

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -53,7 +53,7 @@ If the contribution doesn't meet the above criteria, you may fail our automated 
 3.  :herb: Create a new branch and check it out.
 4.  :crystal_ball: Make your changes and commit them locally. Magic happens here!
 5.  :arrow_heading_up: Push your new branch to your fork. (e.g. `git push username fix-issue-16`).
-6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `master` in this
+6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `main` in this
     repository.
 
 ## Maintainers

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,7 +11,7 @@ Describe your issue here.
 - [ ] discussion
 
 ### Requirements (place an `x` in each of the `[ ]`)
-* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,7 +26,7 @@ sidebar_style: main
 
                 <ul class="sidebar_menu_list footer_nav">
                     <li><a href="{{ site.code_of_conduct_url }}">Code of Conduct</a></li>
-                    <li><a href="https://github.com/{{ site.github_username }}/{{ site.repo_name }}/blob/master/.github/contributing.md">Contributing</a></li>
+                    <li><a href="https://github.com/{{ site.github_username }}/{{ site.repo_name }}/blob/main/.github/contributing.md">Contributing</a></li>
                     <li><a href="{{ site.cla_url }}">Contributor License Agreement</a></li>
                 </ul>
 

--- a/docs/_main/about.md
+++ b/docs/_main/about.md
@@ -8,5 +8,5 @@ hidden: true
 {{ site.title }} is proudly maintained with :sparkling_heart: by the Slack Platform team
 
   * [Code of Conduct]({{ site.code_of_conduct_url }})
-  * [Contributing](https://github.com/{{ site.github_username }}/{{ site.repo_name }}/blob/master/.github/contributing.md)
+  * [Contributing](https://github.com/{{ site.github_username }}/{{ site.repo_name }}/blob/main/.github/contributing.md)
   * [Contributor License Agreement]({{ site.cla_url }})

--- a/docs/_packages/webhook.md
+++ b/docs/_packages/webhook.md
@@ -10,7 +10,7 @@ order: 6
 
 [![build-ci](https://github.com/slackapi/node-slack-sdk/workflows/CI%20Build/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions?query=workflow%3A%22CI+Build%22)
 <!-- TODO: per-flag badge https://docs.codecov.io/docs/flags#section-flag-badges-and-graphs -->
-[![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
+[![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
 <!-- TODO: npm versions with scoped packages: https://github.com/rvagg/nodei.co/issues/24 -->
 
 The `@slack/webhook` package contains a helper for making requests to Slack's [Incoming

--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -147,5 +147,5 @@ function logConfigurationError(envVarNames) {
   const description = envVarNames.length > 1 ?
     `${envVarNames.join(', ')} environment variables` :
     `${envVarNames[0]} environment variable`;
-  console.log(`***\nCould not start up the application. Have you set your ${description}?\n\nSee https://github.com/slackapi/node-slack-sdk/blob/master/examples/greet-and-react/README.md#run-locally-or-\n`);
+  console.log(`***\nCould not start up the application. Have you set your ${description}?\n\nSee https://github.com/slackapi/node-slack-sdk/blob/main/examples/greet-and-react/README.md#run-locally-or-\n`);
 }


### PR DESCRIPTION
###  Summary

Replaces references to `master` branch to `main` branch around the repo

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
