### PR TITLE
chore: update Github Actions badges syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Slack SDK
 
-[![build-ci](https://github.com/slackapi/node-slack-sdk/workflows/Node.js/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions?query=workflow%3A%22Node.js%22)
+[![build-ci](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml)
 <!-- TODO: npm versions with scoped packages: https://github.com/rvagg/nodei.co/issues/24 -->
 ___
 

--- a/docs/_packages/webhook.md
+++ b/docs/_packages/webhook.md
@@ -8,7 +8,7 @@ order: 6
 
 # Slack Incoming Webhooks
 
-[![build-ci](https://github.com/slackapi/node-slack-sdk/workflows/CI%20Build/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions?query=workflow%3A%22CI+Build%22)
+[![build-ci](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml)
 <!-- TODO: per-flag badge https://docs.codecov.io/docs/flags#section-flag-badges-and-graphs -->
 [![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
 <!-- TODO: npm versions with scoped packages: https://github.com/rvagg/nodei.co/issues/24 -->


### PR DESCRIPTION
###  Summary

GH Actions workflow status badge in `webhook.md` [is broken](https://github.com/slackapi/node-slack-sdk/blob/bb21de97383e6894a710f7c3ff80d38db478433d/docs/_packages/webhook.md)

Also, the one in `README.md` is not using [latest syntax for workflow status badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)

Updating all of them to use latest syntax for GH Actions workflows syntax

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
