### PR TITLE
docs: update Typescript minimum version: v7 + link

### DIFF
--- a/docs/_main/typescript.md
+++ b/docs/_main/typescript.md
@@ -12,7 +12,9 @@ This page helps describe how to use this package from a project that also uses T
 
 ### Minimum version
 
-The latest major versions of the `@slack/web-api`, `@slack/rtm-api`, and `@slack/webhook` packages (v6.x) are supported to build against the minimum TypeScript version v4.1.0. See also: https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6
+Latest major versions of `@slack/web-api`, `@slack/rtm-api`, and `@slack/webhook` packages are supported to build against TypeScript version 5.3.x. You can try to use a greater minor version of Typescript like 5.4 or above, but beware that [API Breaking Changes](https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes) can be introduced in minor Typescript versions that break compatibility.
+
+The v6 versions of `@slack/web-api`, `@slack/rtm-api`, and `@slack/webhook` packages are supported to build against the minimum TypeScript version v4.1.0. See also [v5 to v6 migration guide](https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6) for more details.
 
 The v5 versions of `@slack/web-api`, `@slack/rtm-api`, and `@slack/webhook` packages are supported to build against TypeScript v3.3.0 or higher. The v4 versions of the `@slack/web-api`, `@slack/rtm-api`, and `@slack/webhook` packages are supported to build against TypeScript v2.7.0 or higher.
 


### PR DESCRIPTION
###  Summary

Updates [Typescript minimum version docs](https://slack.dev/node-slack-sdk/typescript):
 - Migration guide link is not turned into a link. Adding explicit md link syntax.
 - Docs talk about latest version being 6.x whilst latest are 7.x. Update accordingly
 - Add section about latest version 7.x
 - Use `of` / `of the` consistently

#### About 7.x support:

I've seen `typescript` dependency [is pinned to `5.3.3` in `package.json`](https://github.com/slackapi/node-slack-sdk/blob/%40slack/web-api%407.0.4/packages/web-api/package.json#L87). [Update & pinning strategy changed in v7](https://github.com/slackapi/node-slack-sdk/pull/1724) from `~4.1` to `5.3.3`. Dep is no longer a range like but a specific pinned version. Reason stated in the strategy change PR is that Typescript [introduces breaking changes in minor versions](https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes). So claiming support for `5.3.x` given API breaking changes shouldn't happen in patch releases. But also expose the fact that greater minor versions may be used though things may break.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
