### PR TITLE
types: export helper union types

### DIFF
--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -228,7 +228,8 @@ export type RichTextBlockElement = RichTextSection | RichTextList | RichTextQuot
  * WYSIWYG message composer, so all messages sent by end-users will have this format. Use this block to include
  * user-defined formatted text in your Block Kit payload. While it is possible to format text with `mrkdwn`,
  * `rich_text` is strongly preferred and allows greater flexibility.
- * You might encounter a `rich_text` block in a message payload, as a built-in type in workflow apps, or as output of the {@link RichTextInput}.
+ * You might encounter a `rich_text` block in a message payload, as a built-in type in workflow apps, or as output of
+ * the {@link RichTextInput}.
  * @see {@link https://api.slack.com/reference/block-kit/blocks#rich_text Rich text block reference}.
  */
 export interface RichTextBlock extends Block {

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -1,8 +1,8 @@
 // This file contains objects documented here: https://api.slack.com/reference/block-kit/blocks
-
 import {
   PlainTextElement,
   MrkdwnElement,
+  TextObject,
   UrlImageObject,
   SlackFileImageObject,
 } from './composition-objects';
@@ -72,12 +72,11 @@ export interface ContextBlock extends Block {
    * @description The type of block. For a context block, `type` is always `context`.
    */
   type: 'context';
-  // TODO: use the future planned plaintext/mrkdwn union here instead
   /**
    * @description An array of {@link ImageElement}, {@link PlainTextElement} or {@link MrkdwnElement} objects.
    * Maximum number of items is 10.
    */
-  elements: (ImageElement | PlainTextElement | MrkdwnElement)[];
+  elements: (ImageElement | TextObject)[];
 }
 
 /**
@@ -204,18 +203,18 @@ export interface SectionBlock extends Block {
    */
   type: 'section';
   /**
-   * @description The text for the block, in the form of a text object. Minimum length for the `text` in this field is
+   * @description The text for the block, in the form of a {@link TextObject}. Minimum length for the `text` in this field is
    * 1 and maximum length is 3000 characters. This field is not required if a valid array of `fields` objects is
    * provided instead.
    */
-  text?: PlainTextElement | MrkdwnElement;
+  text?: TextObject;
   /**
    * @description Required if no `text` is provided. An array of text objects. Any text objects included with `fields`
    * will be rendered in a compact format that allows for 2 columns of side-by-side text. Maximum number of items is 10.
    * Maximum length for the text in each item is 2000 characters.
    * {@link https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22text%22:%22A%20message%20*with%20some%20bold%20text*%20and%20_some%20italicized%20text_.%22,%22type%22:%22mrkdwn%22%7D,%22fields%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Priority*%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Type*%22%7D,%7B%22type%22:%22plain_text%22,%22text%22:%22High%22%7D,%7B%22type%22:%22plain_text%22,%22text%22:%22String%22%7D%5D%7D%5D%7D Click here for an example}.
    */
-  fields?: (PlainTextElement | MrkdwnElement)[]; // either this or text must be defined
+  fields?: (TextObject)[]; // either this or text must be defined
   /**
    * @description One of the compatible element objects.
    */

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -115,8 +115,13 @@ export interface OptionGroup {
   options: Option[];
 }
 
-// TODO: (additive change) maybe worth adding a TextObject union for both PlainTextElement and MrkdwnElement, if they
-// are meant to be used this way, as they seem to be documented together? https://api.slack.com/reference/block-kit/composition-objects#text
+/**
+ * @description Defines an object containing some text. Can be either a {@link PlainTextElement} or a
+ * {@link MrkdwnElement}.
+ * @see {@link https://api.slack.com/reference/block-kit/composition-objects#text Text object reference}.
+ */
+export type TextObject = PlainTextElement | MrkdwnElement;
+
 /**
  * @description Defines an object containing some text.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#text Text object reference}.

--- a/packages/types/src/message-attachments.ts
+++ b/packages/types/src/message-attachments.ts
@@ -1,5 +1,5 @@
 import { PlainTextElement } from './block-kit/composition-objects';
-import { Block, KnownBlock } from './block-kit/blocks';
+import { AnyBlock } from './block-kit/blocks';
 
 // TODO: breaking changes, use discriminated union for `fallback`, `text` and `block` properties, maybe LegacyAttachment
 // vs. BlocksAttachment? as per https://api.slack.com/reference/messaging/attachments#legacy_fields
@@ -18,7 +18,7 @@ export interface MessageAttachment {
    * @description An array of {@link KnownBlock layout blocks} in the same format
    * {@link https://api.slack.com/block-kit/building as described in the building blocks guide}.
    */
-  blocks?: (KnownBlock | Block)[];
+  blocks?: AnyBlock[];
   /**
    * @description A plain text summary of the attachment used in clients that
    * don't show formatted text (e.g. mobile notifications).

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -1,10 +1,10 @@
-import { Block, KnownBlock } from './block-kit/blocks';
+import { AnyBlock } from './block-kit/blocks';
 import { PlainTextElement } from './block-kit/composition-objects';
 
 // Reference: https://api.slack.com/surfaces/app-home#composing
 export interface HomeView {
   type: 'home';
-  blocks: (KnownBlock | Block)[];
+  blocks: AnyBlock[];
   private_metadata?: string;
   callback_id?: string;
   external_id?: string;
@@ -14,7 +14,7 @@ export interface HomeView {
 export interface ModalView {
   type: 'modal';
   title: PlainTextElement;
-  blocks: (KnownBlock | Block)[];
+  blocks: AnyBlock[];
   close?: PlainTextElement;
   submit?: PlainTextElement;
   private_metadata?: string;
@@ -30,7 +30,7 @@ export interface ModalView {
  */
 export interface WorkflowStepView {
   type: 'workflow_step';
-  blocks: (KnownBlock | Block)[];
+  blocks: AnyBlock[];
   private_metadata?: string;
   callback_id?: string;
   submit_disabled?: boolean; // defaults to false


### PR DESCRIPTION
###  Summary

This PR fixes #1818. It exports a bunch of helper unions that we use when authoring these types, but that we've heard from the community that they could possibly want to use themselves in their apps (see #1227).