### PR TITLE
feat: user id map in MigrationExchangeResponse as map

### DIFF
--- a/packages/web-api/src/types/response/MigrationExchangeResponse.ts
+++ b/packages/web-api/src/types/response/MigrationExchangeResponse.ts
@@ -17,9 +17,6 @@ export type MigrationExchangeResponse = WebAPICallResult & {
   ok?:               boolean;
   provided?:         string;
   team_id?:          string;
-  user_id_map?:      UseridMap;
+  user_id_map?:      { [key: string]: string };
   warning?:          string;
 };
-
-export interface UseridMap {
-}


### PR DESCRIPTION
###  Summary

Fixes #1584

In https://github.com/slackapi/java-slack-sdk/pull/1325 , JSON samples were updated so that `quicktype` properly infers `user_id_map` property type of `MigrationExchangeResponse` as a type.

Here the type is updated after running the response types generation script

Note that I manually discarded many changes after type generation: fields were added, new responses, ... In order to keep it in scope. Also some changes were related to code formatting and couldn't find the formatter tool & config used for the project if any.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
