### PR TITLE
feat: set QA apihost

### DIFF
--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -28,8 +28,8 @@ describe('SlackCLIProcess class', () => {
 
   describe('CLI flag handling', () => {
     describe('global options', () => {
-      it('should map qa or dev options to --slackdev', async () => {
-        let cmd = new SlackCLIProcess('help', { qa: true });
+      it('should map dev option to --slackdev', async () => {
+        let cmd = new SlackCLIProcess('help', { dev: true });
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--slackdev');
         spawnProcessSpy.resetHistory();
@@ -37,9 +37,16 @@ describe('SlackCLIProcess class', () => {
         await cmd.execAsync();
         sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--slackdev');
         spawnProcessSpy.resetHistory();
-        cmd = new SlackCLIProcess('help', { dev: true });
+      });
+      it('should map qa option to QA host', async () => {
+        let cmd = new SlackCLIProcess('help', { qa: true });
         await cmd.execAsync();
-        sandbox.assert.calledWithMatch(spawnProcessSpy, '--slackdev');
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--apihost qa.slack.com');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help');
+        await cmd.execAsync();
+        sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--apihost qa.slack.com');
+        spawnProcessSpy.resetHistory();
       });
       it('should default to passing --skip-update but allow overriding that', async () => {
         let cmd = new SlackCLIProcess('help');

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -12,7 +12,7 @@ export interface SlackCLIGlobalOptions {
    */
   dev?: boolean;
   /**
-   * @description Whether the command should interact with dev.slack (`--slackdev`)
+   * @description Whether the command should interact with qa.slack (`--apihost qa.slack.com`)
    */
   qa?: boolean;
   /**
@@ -87,7 +87,10 @@ export class SlackCLIProcess {
     let cmd = `${process.env.SLACK_CLI_PATH}`;
     if (this.globalOptions) {
       const opts = this.globalOptions;
-      if (opts.qa || opts.dev) {
+      if (opts.qa) {
+        cmd += ' --apihost qa.slack.com';
+      }
+      if (opts.dev) {
         cmd += ' --slackdev';
       }
       if (opts.skipUpdate || opts.skipUpdate === undefined) {


### PR DESCRIPTION
###  Summary

For QA environments, we might want to set API host to QA rather than dev

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
