### PR TITLE
feat(web-api): run response generation script

### DIFF
--- a/packages/web-api/src/types/response/AdminAppsActivitiesListResponse.ts
+++ b/packages/web-api/src/types/response/AdminAppsActivitiesListResponse.ts
@@ -79,6 +79,7 @@ export interface Config {
 
 export interface TripInformation {
   channel_id?: string;
+  list_id?:    string;
   message_ts?: string;
   reaction?:   string;
   user_id?:    string;

--- a/packages/web-api/src/types/response/AdminConversationsSearchResponse.ts
+++ b/packages/web-api/src/types/response/AdminConversationsSearchResponse.ts
@@ -47,6 +47,7 @@ export interface Conversation {
   is_pending_ext_shared?:         boolean;
   is_private?:                    boolean;
   last_activity_ts?:              number;
+  lists?:                         Canvas;
   member_count?:                  number;
   name?:                          string;
   pending_connected_team_ids?:    string[];

--- a/packages/web-api/src/types/response/AdminInviteRequestsApprovedListResponse.ts
+++ b/packages/web-api/src/types/response/AdminInviteRequestsApprovedListResponse.ts
@@ -15,6 +15,7 @@ export type AdminInviteRequestsApprovedListResponse = WebAPICallResult & {
   needed?:            string;
   ok?:                boolean;
   provided?:          string;
+  response_metadata?: ResponseMetadata;
 };
 
 export interface ApprovedRequest {
@@ -51,4 +52,8 @@ export interface InviteRequest {
   id?:            string;
   invite_type?:   string;
   requester_ids?: string[];
+}
+
+export interface ResponseMetadata {
+  next_cursor?: string;
 }

--- a/packages/web-api/src/types/response/AdminInviteRequestsDeniedListResponse.ts
+++ b/packages/web-api/src/types/response/AdminInviteRequestsDeniedListResponse.ts
@@ -10,11 +10,12 @@
 
 import { WebAPICallResult } from '../../WebClient';
 export type AdminInviteRequestsDeniedListResponse = WebAPICallResult & {
-  denied_requests?: DeniedRequest[];
-  error?:           string;
-  needed?:          string;
-  ok?:              boolean;
-  provided?:        string;
+  denied_requests?:   DeniedRequest[];
+  error?:             string;
+  needed?:            string;
+  ok?:                boolean;
+  provided?:          string;
+  response_metadata?: ResponseMetadata;
 };
 
 export interface DeniedRequest {
@@ -35,4 +36,8 @@ export interface InviteRequest {
   invite_type?:    string;
   request_reason?: string;
   requester_ids?:  string[];
+}
+
+export interface ResponseMetadata {
+  next_cursor?: string;
 }

--- a/packages/web-api/src/types/response/AdminInviteRequestsListResponse.ts
+++ b/packages/web-api/src/types/response/AdminInviteRequestsListResponse.ts
@@ -10,11 +10,12 @@
 
 import { WebAPICallResult } from '../../WebClient';
 export type AdminInviteRequestsListResponse = WebAPICallResult & {
-  error?:           string;
-  invite_requests?: InviteRequest[];
-  needed?:          string;
-  ok?:              boolean;
-  provided?:        string;
+  error?:             string;
+  invite_requests?:   InviteRequest[];
+  needed?:            string;
+  ok?:                boolean;
+  provided?:          string;
+  response_metadata?: ResponseMetadata;
 };
 
 export interface InviteRequest {
@@ -26,4 +27,8 @@ export interface InviteRequest {
   invite_type?:    string;
   request_reason?: string;
   requester_ids?:  string[];
+}
+
+export interface ResponseMetadata {
+  next_cursor?: string;
 }

--- a/packages/web-api/src/types/response/AdminUsergroupsListChannelsResponse.ts
+++ b/packages/web-api/src/types/response/AdminUsergroupsListChannelsResponse.ts
@@ -53,10 +53,11 @@ export interface Channel {
 }
 
 export interface Properties {
-  posting_restricted_to?: PostingRestrictedTo;
+  posting_restricted_to?: RestrictedTo;
+  threads_restricted_to?: RestrictedTo;
 }
 
-export interface PostingRestrictedTo {
+export interface RestrictedTo {
   type?: string[];
 }
 

--- a/packages/web-api/src/types/response/CanvasesAccessDeleteResponse.ts
+++ b/packages/web-api/src/types/response/CanvasesAccessDeleteResponse.ts
@@ -13,7 +13,9 @@ export type CanvasesAccessDeleteResponse = WebAPICallResult & {
   error?:                        string;
   failed_to_update_channel_ids?: string[];
   failed_to_update_user_ids?:    string[];
+  needed?:                       string;
   ok?:                           boolean;
+  provided?:                     string;
   response_metadata?:            ResponseMetadata;
 };
 

--- a/packages/web-api/src/types/response/CanvasesCreateResponse.ts
+++ b/packages/web-api/src/types/response/CanvasesCreateResponse.ts
@@ -13,7 +13,9 @@ export type CanvasesCreateResponse = WebAPICallResult & {
   canvas_id?:         string;
   detail?:            string;
   error?:             string;
+  needed?:            string;
   ok?:                boolean;
+  provided?:          string;
   response_metadata?: ResponseMetadata;
 };
 

--- a/packages/web-api/src/types/response/CanvasesDeleteResponse.ts
+++ b/packages/web-api/src/types/response/CanvasesDeleteResponse.ts
@@ -11,7 +11,9 @@
 import { WebAPICallResult } from '../../WebClient';
 export type CanvasesDeleteResponse = WebAPICallResult & {
   error?:             string;
+  needed?:            string;
   ok?:                boolean;
+  provided?:          string;
   response_metadata?: ResponseMetadata;
 };
 

--- a/packages/web-api/src/types/response/CanvasesEditResponse.ts
+++ b/packages/web-api/src/types/response/CanvasesEditResponse.ts
@@ -12,9 +12,12 @@ import { WebAPICallResult } from '../../WebClient';
 export type CanvasesEditResponse = WebAPICallResult & {
   detail?:            string;
   error?:             string;
+  needed?:            string;
   ok?:                boolean;
+  provided?:          string;
   response_metadata?: ResponseMetadata;
 };
 
 export interface ResponseMetadata {
+  messages?: string[];
 }

--- a/packages/web-api/src/types/response/CanvasesSectionsLookupResponse.ts
+++ b/packages/web-api/src/types/response/CanvasesSectionsLookupResponse.ts
@@ -11,12 +11,15 @@
 import { WebAPICallResult } from '../../WebClient';
 export type CanvasesSectionsLookupResponse = WebAPICallResult & {
   error?:             string;
+  needed?:            string;
   ok?:                boolean;
+  provided?:          string;
   response_metadata?: ResponseMetadata;
   sections?:          Section[];
 };
 
 export interface ResponseMetadata {
+  messages?: string[];
 }
 
 export interface Section {

--- a/packages/web-api/src/types/response/ChatPostMessageResponse.ts
+++ b/packages/web-api/src/types/response/ChatPostMessageResponse.ts
@@ -60,12 +60,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -78,6 +80,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -341,7 +350,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -376,6 +385,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -399,6 +409,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -423,6 +435,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -513,6 +526,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -528,6 +547,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -575,14 +692,81 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: MessageBlockMessage;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  EventPayload;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
 }
 
-export interface MessageBlockMessage {
+export interface EventPayload {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    FieldMessage;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
+}
+
+export interface FieldMessage {
   app_id?:              string;
   attachments?:         any[];
   blocks?:              TitleBlockElement[];
@@ -722,6 +906,7 @@ export interface MessageFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -745,6 +930,8 @@ export interface MessageFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -769,6 +956,7 @@ export interface MessageFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
@@ -848,9 +1036,6 @@ export interface MessageFile {
   vtt?:                                     string;
 }
 
-export interface EventPayload {
-}
-
 export interface PurpleIcons {
   emoji?:    string;
   image_36?: string;
@@ -926,6 +1111,34 @@ export interface PurpleRoot {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: FieldMessage;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -968,7 +1181,7 @@ export interface PurpleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         MessageFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/ChatScheduleMessageResponse.ts
+++ b/packages/web-api/src/types/response/ChatScheduleMessageResponse.ts
@@ -23,7 +23,7 @@ export type ChatScheduleMessageResponse = WebAPICallResult & {
 
 export interface Message {
   app_id?:      string;
-  blocks?:      Block[];
+  blocks?:      MessageBlock[];
   bot_id?:      string;
   bot_profile?: BotProfile;
   metadata?:    Metadata;
@@ -34,7 +34,7 @@ export interface Message {
   user?:        string;
 }
 
-export interface Block {
+export interface MessageBlock {
   accessory?:                    Accessory;
   alt_text?:                     string;
   api_decoration_available?:     boolean;
@@ -46,25 +46,25 @@ export interface Block {
   button_label?:                 string;
   call?:                         Call;
   call_id?:                      string;
-  description?:                  Description;
+  description?:                  DescriptionElement;
   developer_trace_id?:           string;
   dispatch_action?:              boolean;
   element?:                      Accessory;
   elements?:                     Accessory[];
   external_id?:                  string;
   fallback?:                     string;
-  fields?:                       Description[];
+  fields?:                       DescriptionElement[];
   file?:                         File;
   file_id?:                      string;
   function_trigger_id?:          string;
-  hint?:                         Description;
+  hint?:                         DescriptionElement;
   image_bytes?:                  number;
   image_height?:                 number;
   image_url?:                    string;
   image_width?:                  number;
   is_animated?:                  boolean;
   is_workflow_app?:              boolean;
-  label?:                        Description;
+  label?:                        DescriptionElement;
   optional?:                     boolean;
   owning_team_id?:               string;
   provider_icon_url?:            string;
@@ -73,9 +73,9 @@ export interface Block {
   share_url?:                    string;
   slack_file?:                   SlackFile;
   source?:                       string;
-  text?:                         Description;
+  text?:                         DescriptionElement;
   thumbnail_url?:                string;
-  title?:                        Description;
+  title?:                        DescriptionElement;
   title_url?:                    string;
   trigger_subtype?:              string;
   trigger_type?:                 string;
@@ -117,11 +117,11 @@ export interface Accessory {
   offset?:                          number;
   option_groups?:                   OptionGroup[];
   options?:                         Option[];
-  placeholder?:                     Description;
+  placeholder?:                     DescriptionElement;
   response_url_enabled?:            boolean;
   slack_file?:                      SlackFile;
   style?:                           string;
-  text?:                            Description;
+  text?:                            DescriptionElement;
   timezone?:                        string;
   type?:                            string;
   url?:                             string;
@@ -130,14 +130,14 @@ export interface Accessory {
 }
 
 export interface Confirm {
-  confirm?: Description;
-  deny?:    Description;
+  confirm?: DescriptionElement;
+  deny?:    DescriptionElement;
   style?:   string;
-  text?:    Description;
-  title?:   Description;
+  text?:    DescriptionElement;
+  title?:   DescriptionElement;
 }
 
-export interface Description {
+export interface DescriptionElement {
   emoji?:    boolean;
   text?:     string;
   type?:     DescriptionType;
@@ -155,7 +155,7 @@ export interface AccessoryElement {
   indent?:   number;
   offset?:   number;
   style?:    string;
-  type?:     string;
+  type?:     FluffyType;
 }
 
 export interface PurpleElement {
@@ -167,7 +167,7 @@ export interface PurpleElement {
   team_id?:      string;
   text?:         string;
   timestamp?:    string;
-  type?:         ElementType;
+  type?:         PurpleType;
   unicode?:      string;
   url?:          string;
   user_id?:      string;
@@ -182,7 +182,7 @@ export interface Style {
   strike?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -195,6 +195,13 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
 export interface Filter {
   exclude_bot_users?:                boolean;
   exclude_external_shared_channels?: boolean;
@@ -202,14 +209,14 @@ export interface Filter {
 }
 
 export interface Option {
-  description?: Description;
-  text?:        Description;
+  description?: DescriptionElement;
+  text?:        DescriptionElement;
   url?:         string;
   value?:       string;
 }
 
 export interface OptionGroup {
-  label?:   Description;
+  label?:   DescriptionElement;
   options?: Option[];
 }
 
@@ -285,33 +292,34 @@ export interface File {
   app_id?:                                  string;
   app_name?:                                string;
   attachments?:                             any[];
-  blocks?:                                  any[];
+  blocks?:                                  TitleBlockElement[];
   bot_id?:                                  string;
   canvas_template_mode?:                    string;
-  cc?:                                      any[];
+  cc?:                                      Cc[];
   channel_actions_count?:                   number;
   channel_actions_ts?:                      string;
-  channels?:                                any[];
+  channels?:                                string[];
   comments_count?:                          number;
   converted_pdf?:                           string;
   created?:                                 number;
   deanimate?:                               string;
   deanimate_gif?:                           string;
   display_as_bot?:                          boolean;
-  dm_mpdm_users_with_file_access?:          any[];
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
   duration_ms?:                             number;
   edit_link?:                               string;
   edit_timestamp?:                          number;
   editable?:                                boolean;
   editor?:                                  string;
-  editors?:                                 any[];
+  editors?:                                 string[];
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
-  from?:                                    any[];
-  groups?:                                  any[];
+  from?:                                    Cc[];
+  groups?:                                  string[];
   has_more?:                                boolean;
   has_more_shares?:                         boolean;
   has_rich_preview?:                        boolean;
@@ -320,7 +328,7 @@ export interface File {
   hls_embed?:                               string;
   id?:                                      string;
   image_exif_rotation?:                     number;
-  ims?:                                     any[];
+  ims?:                                     string[];
   initial_comment?:                         InitialComment;
   is_channel_space?:                        boolean;
   is_external?:                             boolean;
@@ -331,6 +339,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -346,7 +356,7 @@ export interface File {
   original_w?:                              string;
   permalink?:                               string;
   permalink_public?:                        string;
-  pinned_to?:                               any[];
+  pinned_to?:                               string[];
   pjpeg?:                                   string;
   plain_text?:                              string;
   pretty_type?:                             string;
@@ -355,12 +365,13 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
-  reactions?:                               any[];
+  reactions?:                               Reaction[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  EventPayload;
+  shares?:                                  Shares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -420,8 +431,8 @@ export interface File {
   thumb_video_w?:                           number;
   timestamp?:                               number;
   title?:                                   string;
-  title_blocks?:                            any[];
-  to?:                                      any[];
+  title_blocks?:                            TitleBlockElement[];
+  to?:                                      Cc[];
   transcription?:                           Transcription;
   update_notification?:                     number;
   updated?:                                 number;
@@ -432,6 +443,62 @@ export interface File {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
+}
+
+export interface TitleBlockElement {
+  accessory?:                    Accessory;
+  alt_text?:                     string;
+  app_collaborators?:            string[];
+  app_id?:                       string;
+  author_name?:                  string;
+  block_id?:                     string;
+  bot_user_id?:                  string;
+  button_label?:                 string;
+  description?:                  DescriptionElement | string;
+  developer_trace_id?:           string;
+  elements?:                     Accessory[];
+  fallback?:                     string;
+  fields?:                       DescriptionElement[];
+  function_trigger_id?:          string;
+  image_bytes?:                  number;
+  image_height?:                 number;
+  image_url?:                    string;
+  image_width?:                  number;
+  is_animated?:                  boolean;
+  is_workflow_app?:              boolean;
+  owning_team_id?:               string;
+  provider_icon_url?:            string;
+  provider_name?:                string;
+  sales_home_workflow_app_type?: number;
+  share_url?:                    string;
+  slack_file?:                   SlackFile;
+  text?:                         DescriptionElement;
+  thumbnail_url?:                string;
+  title?:                        DescriptionElement | string;
+  title_url?:                    string;
+  trigger_subtype?:              string;
+  trigger_type?:                 string;
+  type?:                         string;
+  url?:                          string;
+  video_url?:                    string;
+  workflow_id?:                  string;
+}
+
+export interface Cc {
+  address?:  string;
+  name?:     string;
+  original?: string;
+}
+
+export interface DmMpdmUsersWithFileAccess {
+  access?:  string;
+  user_id?: string;
+}
+
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
 }
 
 export interface Headers {
@@ -451,10 +518,115 @@ export interface InitialComment {
   user?:      string;
 }
 
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
+}
+
 export interface MediaProgress {
   duration_ms?:   number;
   max_offset_ms?: number;
   offset_ms?:     number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?:  string;
+  url?:   string;
+  users?: string[];
 }
 
 export interface Saved {
@@ -464,7 +636,24 @@ export interface Saved {
   state?:          string;
 }
 
-export interface EventPayload {
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?:  { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?:            string;
+  channel_name?:      string;
+  date_last_shared?:  number;
+  latest_reply?:      string;
+  reply_count?:       number;
+  reply_users?:       string[];
+  reply_users_count?: number;
+  share_user_id?:     string;
+  source?:            string;
+  team_id?:           string;
+  thread_ts?:         string;
+  ts?:                string;
 }
 
 export interface Transcription {
@@ -491,6 +680,9 @@ export interface Icons {
 export interface Metadata {
   event_payload?: EventPayload;
   event_type?:    string;
+}
+
+export interface EventPayload {
 }
 
 export interface Room {

--- a/packages/web-api/src/types/response/ChatUpdateResponse.ts
+++ b/packages/web-api/src/types/response/ChatUpdateResponse.ts
@@ -23,12 +23,12 @@ export type ChatUpdateResponse = WebAPICallResult & {
 
 export interface Message {
   app_id?:         string;
-  blocks?:         Block[];
+  blocks?:         MessageBlock[];
   bot_id?:         string;
   bot_profile?:    BotProfile;
   display_as_bot?: boolean;
   edited?:         Edited;
-  files?:          FileElement[];
+  files?:          File[];
   metadata?:       Metadata;
   room?:           Room;
   team?:           string;
@@ -39,7 +39,7 @@ export interface Message {
   x_files?:        string[];
 }
 
-export interface Block {
+export interface MessageBlock {
   accessory?:                    Accessory;
   alt_text?:                     string;
   api_decoration_available?:     boolean;
@@ -59,7 +59,7 @@ export interface Block {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         BlockFile;
+  file?:                         File;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;
@@ -84,7 +84,7 @@ export interface Block {
   title_url?:                    string;
   trigger_subtype?:              string;
   trigger_type?:                 string;
-  type?:                         string;
+  type?:                         BlockType;
   url?:                          string;
   video_url?:                    string;
   workflow_id?:                  string;
@@ -291,225 +291,13 @@ export interface AppIconUrls {
   image_original?: string;
 }
 
-export interface BlockFile {
+export interface File {
   access?:                                  string;
   alt_txt?:                                 string;
   app_id?:                                  string;
   app_name?:                                string;
   attachments?:                             any[];
-  blocks?:                                  any[];
-  bot_id?:                                  string;
-  canvas_template_mode?:                    string;
-  cc?:                                      any[];
-  channel_actions_count?:                   number;
-  channel_actions_ts?:                      string;
-  channels?:                                any[];
-  comments_count?:                          number;
-  converted_pdf?:                           string;
-  created?:                                 number;
-  deanimate?:                               string;
-  deanimate_gif?:                           string;
-  display_as_bot?:                          boolean;
-  dm_mpdm_users_with_file_access?:          any[];
-  duration_ms?:                             number;
-  edit_link?:                               string;
-  edit_timestamp?:                          number;
-  editable?:                                boolean;
-  editor?:                                  string;
-  editors?:                                 any[];
-  external_id?:                             string;
-  external_type?:                           string;
-  external_url?:                            string;
-  file_access?:                             string;
-  filetype?:                                string;
-  from?:                                    any[];
-  groups?:                                  any[];
-  has_more?:                                boolean;
-  has_more_shares?:                         boolean;
-  has_rich_preview?:                        boolean;
-  headers?:                                 Headers;
-  hls?:                                     string;
-  hls_embed?:                               string;
-  id?:                                      string;
-  image_exif_rotation?:                     number;
-  ims?:                                     any[];
-  initial_comment?:                         InitialComment;
-  is_channel_space?:                        boolean;
-  is_external?:                             boolean;
-  is_public?:                               boolean;
-  is_starred?:                              boolean;
-  last_editor?:                             string;
-  last_read?:                               number;
-  lines?:                                   number;
-  lines_more?:                              number;
-  linked_channel_id?:                       string;
-  media_display_type?:                      string;
-  media_progress?:                          MediaProgress;
-  mimetype?:                                string;
-  mode?:                                    string;
-  mp4?:                                     string;
-  mp4_low?:                                 string;
-  name?:                                    string;
-  non_owner_editable?:                      boolean;
-  num_stars?:                               number;
-  org_or_workspace_access?:                 string;
-  original_attachment_count?:               number;
-  original_h?:                              string;
-  original_w?:                              string;
-  permalink?:                               string;
-  permalink_public?:                        string;
-  pinned_to?:                               any[];
-  pjpeg?:                                   string;
-  plain_text?:                              string;
-  pretty_type?:                             string;
-  preview?:                                 string;
-  preview_highlight?:                       string;
-  preview_is_truncated?:                    boolean;
-  preview_plain_text?:                      string;
-  private_channels_with_file_access_count?: number;
-  public_url_shared?:                       boolean;
-  quip_thread_id?:                          string;
-  reactions?:                               any[];
-  saved?:                                   Saved;
-  sent_to_self?:                            boolean;
-  shares?:                                  EventPayload;
-  show_badge?:                              boolean;
-  simplified_html?:                         string;
-  size?:                                    number;
-  source_team?:                             string;
-  subject?:                                 string;
-  subtype?:                                 string;
-  team_pref_version_history_enabled?:       boolean;
-  teams_shared_with?:                       any[];
-  template_conversion_ts?:                  number;
-  template_description?:                    string;
-  template_icon?:                           string;
-  template_name?:                           string;
-  template_title?:                          string;
-  thumb_1024?:                              string;
-  thumb_1024_gif?:                          string;
-  thumb_1024_h?:                            string;
-  thumb_1024_w?:                            string;
-  thumb_160?:                               string;
-  thumb_160_gif?:                           string;
-  thumb_160_h?:                             string;
-  thumb_160_w?:                             string;
-  thumb_360?:                               string;
-  thumb_360_gif?:                           string;
-  thumb_360_h?:                             string;
-  thumb_360_w?:                             string;
-  thumb_480?:                               string;
-  thumb_480_gif?:                           string;
-  thumb_480_h?:                             string;
-  thumb_480_w?:                             string;
-  thumb_64?:                                string;
-  thumb_64_gif?:                            string;
-  thumb_64_h?:                              string;
-  thumb_64_w?:                              string;
-  thumb_720?:                               string;
-  thumb_720_gif?:                           string;
-  thumb_720_h?:                             string;
-  thumb_720_w?:                             string;
-  thumb_80?:                                string;
-  thumb_800?:                               string;
-  thumb_800_gif?:                           string;
-  thumb_800_h?:                             string;
-  thumb_800_w?:                             string;
-  thumb_80_gif?:                            string;
-  thumb_80_h?:                              string;
-  thumb_80_w?:                              string;
-  thumb_960?:                               string;
-  thumb_960_gif?:                           string;
-  thumb_960_h?:                             string;
-  thumb_960_w?:                             string;
-  thumb_gif?:                               string;
-  thumb_pdf?:                               string;
-  thumb_pdf_h?:                             string;
-  thumb_pdf_w?:                             string;
-  thumb_tiny?:                              string;
-  thumb_video?:                             string;
-  thumb_video_h?:                           number;
-  thumb_video_w?:                           number;
-  timestamp?:                               number;
-  title?:                                   string;
-  title_blocks?:                            any[];
-  to?:                                      any[];
-  transcription?:                           Transcription;
-  update_notification?:                     number;
-  updated?:                                 number;
-  url_private?:                             string;
-  url_private_download?:                    string;
-  url_static_preview?:                      string;
-  user?:                                    string;
-  user_team?:                               string;
-  username?:                                string;
-  vtt?:                                     string;
-}
-
-export interface Headers {
-  date?:        string;
-  in_reply_to?: string;
-  message_id?:  string;
-  reply_to?:    string;
-}
-
-export interface InitialComment {
-  channel?:   string;
-  comment?:   string;
-  created?:   number;
-  id?:        string;
-  is_intro?:  boolean;
-  timestamp?: number;
-  user?:      string;
-}
-
-export interface MediaProgress {
-  duration_ms?:   number;
-  max_offset_ms?: number;
-  offset_ms?:     number;
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?:       number;
-  is_archived?:    boolean;
-  state?:          string;
-}
-
-export interface EventPayload {
-}
-
-export interface Transcription {
-  locale?: string;
-  status?: string;
-}
-
-export interface BotProfile {
-  app_id?:  string;
-  deleted?: boolean;
-  icons?:   Icons;
-  id?:      string;
-  name?:    string;
-  team_id?: string;
-  updated?: number;
-}
-
-export interface Icons {
-  image_36?: string;
-  image_48?: string;
-  image_72?: string;
-}
-
-export interface Edited {
-  ts?:   string;
-  user?: string;
-}
-
-export interface FileElement {
-  access?:                                  string;
-  alt_txt?:                                 string;
-  app_id?:                                  string;
-  app_name?:                                string;
+  blocks?:                                  TitleBlockElement[];
   bot_id?:                                  string;
   canvas_template_mode?:                    string;
   cc?:                                      Cc[];
@@ -532,6 +320,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -555,6 +344,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -579,6 +370,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -644,7 +436,7 @@ export interface FileElement {
   thumb_video_w?:                           number;
   timestamp?:                               number;
   title?:                                   string;
-  title_blocks?:                            TitleBlock[];
+  title_blocks?:                            TitleBlockElement[];
   to?:                                      Cc[];
   transcription?:                           Transcription;
   update_notification?:                     number;
@@ -658,45 +450,7 @@ export interface FileElement {
   vtt?:                                     string;
 }
 
-export interface Cc {
-  address?:  string;
-  name?:     string;
-  original?: string;
-}
-
-export interface DmMpdmUsersWithFileAccess {
-  access?:  string;
-  user_id?: string;
-}
-
-export interface Reaction {
-  count?: number;
-  name?:  string;
-  url?:   string;
-  users?: string[];
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?:  { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?:            string;
-  channel_name?:      string;
-  date_last_shared?:  number;
-  latest_reply?:      string;
-  reply_count?:       number;
-  reply_users?:       string[];
-  reply_users_count?: number;
-  share_user_id?:     string;
-  source?:            string;
-  team_id?:           string;
-  thread_ts?:         string;
-  ts?:                string;
-}
-
-export interface TitleBlock {
+export interface TitleBlockElement {
   accessory?:                    Accessory;
   alt_text?:                     string;
   app_collaborators?:            string[];
@@ -729,15 +483,227 @@ export interface TitleBlock {
   title_url?:                    string;
   trigger_subtype?:              string;
   trigger_type?:                 string;
-  type?:                         string;
+  type?:                         BlockType;
   url?:                          string;
   video_url?:                    string;
   workflow_id?:                  string;
 }
 
+export enum BlockType {
+  Actions = 'actions',
+  Context = 'context',
+  Divider = 'divider',
+  Image = 'image',
+  RichText = 'rich_text',
+  Section = 'section',
+  ShareShortcut = 'share_shortcut',
+  Video = 'video',
+}
+
+export interface Cc {
+  address?:  string;
+  name?:     string;
+  original?: string;
+}
+
+export interface DmMpdmUsersWithFileAccess {
+  access?:  string;
+  user_id?: string;
+}
+
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
+export interface Headers {
+  date?:        string;
+  in_reply_to?: string;
+  message_id?:  string;
+  reply_to?:    string;
+}
+
+export interface InitialComment {
+  channel?:   string;
+  comment?:   string;
+  created?:   number;
+  id?:        string;
+  is_intro?:  boolean;
+  timestamp?: number;
+  user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
+}
+
+export interface MediaProgress {
+  duration_ms?:   number;
+  max_offset_ms?: number;
+  offset_ms?:     number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?:  string;
+  url?:   string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?:       number;
+  is_archived?:    boolean;
+  state?:          string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?:  { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?:            string;
+  channel_name?:      string;
+  date_last_shared?:  number;
+  latest_reply?:      string;
+  reply_count?:       number;
+  reply_users?:       string[];
+  reply_users_count?: number;
+  share_user_id?:     string;
+  source?:            string;
+  team_id?:           string;
+  thread_ts?:         string;
+  ts?:                string;
+}
+
+export interface Transcription {
+  locale?: string;
+  status?: string;
+}
+
+export interface BotProfile {
+  app_id?:  string;
+  deleted?: boolean;
+  icons?:   Icons;
+  id?:      string;
+  name?:    string;
+  team_id?: string;
+  updated?: number;
+}
+
+export interface Icons {
+  image_36?: string;
+  image_48?: string;
+  image_72?: string;
+}
+
+export interface Edited {
+  ts?:   string;
+  user?: string;
+}
+
 export interface Metadata {
   event_payload?: EventPayload;
   event_type?:    string;
+}
+
+export interface EventPayload {
 }
 
 export interface Room {

--- a/packages/web-api/src/types/response/ConversationsCanvasesCreateResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsCanvasesCreateResponse.ts
@@ -13,7 +13,9 @@ export type ConversationsCanvasesCreateResponse = WebAPICallResult & {
   canvas_id?:         string;
   detail?:            string;
   error?:             string;
+  needed?:            string;
   ok?:                boolean;
+  provided?:          string;
   response_metadata?: ResponseMetadata;
 };
 

--- a/packages/web-api/src/types/response/ConversationsHistoryResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsHistoryResponse.ts
@@ -76,12 +76,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -94,6 +96,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -357,7 +366,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -392,6 +401,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -415,6 +425,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -439,6 +451,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -529,6 +542,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -544,6 +563,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -591,14 +708,81 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: MessageBlockMessage;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  EventPayload;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
 }
 
-export interface MessageBlockMessage {
+export interface EventPayload {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    FieldMessage;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
+}
+
+export interface FieldMessage {
   app_id?:              string;
   attachments?:         any[];
   blocks?:              TitleBlockElement[];
@@ -610,7 +794,7 @@ export interface MessageBlockMessage {
   comment?:             Comment;
   display_as_bot?:      boolean;
   edited?:              Edited;
-  file?:                BlockFile;
+  file?:                PurpleFile;
   files?:               any[];
   hidden?:              boolean;
   icons?:               MessageIcons;
@@ -709,7 +893,7 @@ export interface Edited {
   user?: string;
 }
 
-export interface BlockFile {
+export interface PurpleFile {
   access?:                                  string;
   alt_txt?:                                 string;
   app_id?:                                  string;
@@ -738,6 +922,7 @@ export interface BlockFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -761,6 +946,8 @@ export interface BlockFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -785,6 +972,7 @@ export interface BlockFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
@@ -864,9 +1052,6 @@ export interface BlockFile {
   vtt?:                                     string;
 }
 
-export interface EventPayload {
-}
-
 export interface MessageIcons {
   emoji?:    string;
   image_36?: string;
@@ -939,6 +1124,34 @@ export interface PurpleRoot {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: FieldMessage;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -981,7 +1194,7 @@ export interface PurpleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         BlockFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/ConversationsOpenResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsOpenResponse.ts
@@ -38,7 +38,7 @@ export interface Channel {
 
 export interface Latest {
   app_id?:        string;
-  blocks?:        Block[];
+  blocks?:        LatestBlock[];
   bot_id?:        string;
   bot_profile?:   BotProfile;
   client_msg_id?: string;
@@ -50,7 +50,7 @@ export interface Latest {
   user?:          string;
 }
 
-export interface Block {
+export interface LatestBlock {
   accessory?:                    Accessory;
   alt_text?:                     string;
   api_decoration_available?:     boolean;
@@ -62,25 +62,25 @@ export interface Block {
   button_label?:                 string;
   call?:                         Call;
   call_id?:                      string;
-  description?:                  Description;
+  description?:                  DescriptionElement;
   developer_trace_id?:           string;
   dispatch_action?:              boolean;
   element?:                      Accessory;
   elements?:                     Accessory[];
   external_id?:                  string;
   fallback?:                     string;
-  fields?:                       Description[];
+  fields?:                       DescriptionElement[];
   file?:                         File;
   file_id?:                      string;
   function_trigger_id?:          string;
-  hint?:                         Description;
+  hint?:                         DescriptionElement;
   image_bytes?:                  number;
   image_height?:                 number;
   image_url?:                    string;
   image_width?:                  number;
   is_animated?:                  boolean;
   is_workflow_app?:              boolean;
-  label?:                        Description;
+  label?:                        DescriptionElement;
   optional?:                     boolean;
   owning_team_id?:               string;
   provider_icon_url?:            string;
@@ -89,9 +89,9 @@ export interface Block {
   share_url?:                    string;
   slack_file?:                   SlackFile;
   source?:                       string;
-  text?:                         Description;
+  text?:                         DescriptionElement;
   thumbnail_url?:                string;
-  title?:                        Description;
+  title?:                        DescriptionElement;
   title_url?:                    string;
   trigger_subtype?:              string;
   trigger_type?:                 string;
@@ -133,11 +133,11 @@ export interface Accessory {
   offset?:                          number;
   option_groups?:                   OptionGroup[];
   options?:                         Option[];
-  placeholder?:                     Description;
+  placeholder?:                     DescriptionElement;
   response_url_enabled?:            boolean;
   slack_file?:                      SlackFile;
   style?:                           string;
-  text?:                            Description;
+  text?:                            DescriptionElement;
   timezone?:                        string;
   type?:                            string;
   url?:                             string;
@@ -146,14 +146,14 @@ export interface Accessory {
 }
 
 export interface Confirm {
-  confirm?: Description;
-  deny?:    Description;
+  confirm?: DescriptionElement;
+  deny?:    DescriptionElement;
   style?:   string;
-  text?:    Description;
-  title?:   Description;
+  text?:    DescriptionElement;
+  title?:   DescriptionElement;
 }
 
-export interface Description {
+export interface DescriptionElement {
   emoji?:    boolean;
   text?:     string;
   type?:     DescriptionType;
@@ -171,7 +171,7 @@ export interface AccessoryElement {
   indent?:   number;
   offset?:   number;
   style?:    string;
-  type?:     string;
+  type?:     FluffyType;
 }
 
 export interface PurpleElement {
@@ -183,7 +183,7 @@ export interface PurpleElement {
   team_id?:      string;
   text?:         string;
   timestamp?:    string;
-  type?:         ElementType;
+  type?:         PurpleType;
   unicode?:      string;
   url?:          string;
   user_id?:      string;
@@ -198,7 +198,7 @@ export interface Style {
   strike?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -211,6 +211,13 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
 export interface Filter {
   exclude_bot_users?:                boolean;
   exclude_external_shared_channels?: boolean;
@@ -218,14 +225,14 @@ export interface Filter {
 }
 
 export interface Option {
-  description?: Description;
-  text?:        Description;
+  description?: DescriptionElement;
+  text?:        DescriptionElement;
   url?:         string;
   value?:       string;
 }
 
 export interface OptionGroup {
-  label?:   Description;
+  label?:   DescriptionElement;
   options?: Option[];
 }
 
@@ -301,33 +308,34 @@ export interface File {
   app_id?:                                  string;
   app_name?:                                string;
   attachments?:                             any[];
-  blocks?:                                  any[];
+  blocks?:                                  TitleBlockElement[];
   bot_id?:                                  string;
   canvas_template_mode?:                    string;
-  cc?:                                      any[];
+  cc?:                                      Cc[];
   channel_actions_count?:                   number;
   channel_actions_ts?:                      string;
-  channels?:                                any[];
+  channels?:                                string[];
   comments_count?:                          number;
   converted_pdf?:                           string;
   created?:                                 number;
   deanimate?:                               string;
   deanimate_gif?:                           string;
   display_as_bot?:                          boolean;
-  dm_mpdm_users_with_file_access?:          any[];
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
   duration_ms?:                             number;
   edit_link?:                               string;
   edit_timestamp?:                          number;
   editable?:                                boolean;
   editor?:                                  string;
-  editors?:                                 any[];
+  editors?:                                 string[];
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
-  from?:                                    any[];
-  groups?:                                  any[];
+  from?:                                    Cc[];
+  groups?:                                  string[];
   has_more?:                                boolean;
   has_more_shares?:                         boolean;
   has_rich_preview?:                        boolean;
@@ -336,7 +344,7 @@ export interface File {
   hls_embed?:                               string;
   id?:                                      string;
   image_exif_rotation?:                     number;
-  ims?:                                     any[];
+  ims?:                                     string[];
   initial_comment?:                         InitialComment;
   is_channel_space?:                        boolean;
   is_external?:                             boolean;
@@ -347,6 +355,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -362,7 +372,7 @@ export interface File {
   original_w?:                              string;
   permalink?:                               string;
   permalink_public?:                        string;
-  pinned_to?:                               any[];
+  pinned_to?:                               string[];
   pjpeg?:                                   string;
   plain_text?:                              string;
   pretty_type?:                             string;
@@ -371,9 +381,10 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
-  reactions?:                               any[];
+  reactions?:                               Reaction[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
   shares?:                                  Shares;
@@ -436,8 +447,8 @@ export interface File {
   thumb_video_w?:                           number;
   timestamp?:                               number;
   title?:                                   string;
-  title_blocks?:                            any[];
-  to?:                                      any[];
+  title_blocks?:                            TitleBlockElement[];
+  to?:                                      Cc[];
   transcription?:                           Transcription;
   update_notification?:                     number;
   updated?:                                 number;
@@ -448,6 +459,62 @@ export interface File {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
+}
+
+export interface TitleBlockElement {
+  accessory?:                    Accessory;
+  alt_text?:                     string;
+  app_collaborators?:            string[];
+  app_id?:                       string;
+  author_name?:                  string;
+  block_id?:                     string;
+  bot_user_id?:                  string;
+  button_label?:                 string;
+  description?:                  DescriptionElement | string;
+  developer_trace_id?:           string;
+  elements?:                     Accessory[];
+  fallback?:                     string;
+  fields?:                       DescriptionElement[];
+  function_trigger_id?:          string;
+  image_bytes?:                  number;
+  image_height?:                 number;
+  image_url?:                    string;
+  image_width?:                  number;
+  is_animated?:                  boolean;
+  is_workflow_app?:              boolean;
+  owning_team_id?:               string;
+  provider_icon_url?:            string;
+  provider_name?:                string;
+  sales_home_workflow_app_type?: number;
+  share_url?:                    string;
+  slack_file?:                   SlackFile;
+  text?:                         DescriptionElement;
+  thumbnail_url?:                string;
+  title?:                        DescriptionElement | string;
+  title_url?:                    string;
+  trigger_subtype?:              string;
+  trigger_type?:                 string;
+  type?:                         string;
+  url?:                          string;
+  video_url?:                    string;
+  workflow_id?:                  string;
+}
+
+export interface Cc {
+  address?:  string;
+  name?:     string;
+  original?: string;
+}
+
+export interface DmMpdmUsersWithFileAccess {
+  access?:  string;
+  user_id?: string;
+}
+
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
 }
 
 export interface Headers {
@@ -467,10 +534,115 @@ export interface InitialComment {
   user?:      string;
 }
 
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
+}
+
 export interface MediaProgress {
   duration_ms?:   number;
   max_offset_ms?: number;
   offset_ms?:     number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?:  string;
+  url?:   string;
+  users?: string[];
 }
 
 export interface Saved {
@@ -481,6 +653,23 @@ export interface Saved {
 }
 
 export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?:  { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?:            string;
+  channel_name?:      string;
+  date_last_shared?:  number;
+  latest_reply?:      string;
+  reply_count?:       number;
+  reply_users?:       string[];
+  reply_users_count?: number;
+  share_user_id?:     string;
+  source?:            string;
+  team_id?:           string;
+  thread_ts?:         string;
+  ts?:                string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsRepliesResponse.ts
@@ -65,12 +65,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -83,6 +85,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -346,7 +355,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -381,6 +390,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -404,6 +414,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -428,6 +440,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -518,6 +531,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -533,6 +552,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -580,14 +697,81 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: MessageBlockMessage;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  EventPayload;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
 }
 
-export interface MessageBlockMessage {
+export interface EventPayload {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    FieldMessage;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
+}
+
+export interface FieldMessage {
   app_id?:              string;
   attachments?:         any[];
   blocks?:              TitleBlockElement[];
@@ -599,7 +783,7 @@ export interface MessageBlockMessage {
   comment?:             Comment;
   display_as_bot?:      boolean;
   edited?:              Edited;
-  file?:                BlockFile;
+  file?:                PurpleFile;
   files?:               any[];
   hidden?:              boolean;
   icons?:               MessageIcons;
@@ -698,7 +882,7 @@ export interface Edited {
   user?: string;
 }
 
-export interface BlockFile {
+export interface PurpleFile {
   access?:                                  string;
   alt_txt?:                                 string;
   app_id?:                                  string;
@@ -727,6 +911,7 @@ export interface BlockFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -750,6 +935,8 @@ export interface BlockFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -774,6 +961,7 @@ export interface BlockFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
@@ -853,9 +1041,6 @@ export interface BlockFile {
   vtt?:                                     string;
 }
 
-export interface EventPayload {
-}
-
 export interface MessageIcons {
   emoji?:    string;
   image_36?: string;
@@ -928,6 +1113,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: FieldMessage;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -970,7 +1183,7 @@ export interface PurpleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         BlockFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/FilesCompleteUploadExternalResponse.ts
+++ b/packages/web-api/src/types/response/FilesCompleteUploadExternalResponse.ts
@@ -10,11 +10,12 @@
 
 import { WebAPICallResult } from '../../WebClient';
 export type FilesCompleteUploadExternalResponse = WebAPICallResult & {
-  error?:    string;
-  files?:    File[];
-  needed?:   string;
-  ok?:       boolean;
-  provided?: string;
+  error?:             string;
+  files?:             File[];
+  needed?:            string;
+  ok?:                boolean;
+  provided?:          string;
+  response_metadata?: ResponseMetadata;
 };
 
 export interface File {
@@ -91,4 +92,8 @@ export interface Public {
   team_id?:           string;
   thread_ts?:         string;
   ts?:                string;
+}
+
+export interface ResponseMetadata {
+  messages?: string[];
 }

--- a/packages/web-api/src/types/response/FilesRemoteAddResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteAddResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesRemoteInfoResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteInfoResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesRemoteShareResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteShareResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesRemoteUpdateResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteUpdateResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesRevokePublicURLResponse.ts
+++ b/packages/web-api/src/types/response/FilesRevokePublicURLResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesSharedPublicURLResponse.ts
+++ b/packages/web-api/src/types/response/FilesSharedPublicURLResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/FilesUploadResponse.ts
+++ b/packages/web-api/src/types/response/FilesUploadResponse.ts
@@ -44,6 +44,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -67,6 +68,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -91,6 +94,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -181,6 +185,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -196,6 +206,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/PinsListResponse.ts
+++ b/packages/web-api/src/types/response/PinsListResponse.ts
@@ -52,6 +52,7 @@ export interface File {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -75,6 +76,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -99,6 +102,7 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -189,6 +193,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -204,6 +214,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/ReactionsGetResponse.ts
+++ b/packages/web-api/src/types/response/ReactionsGetResponse.ts
@@ -21,7 +21,7 @@ export type ReactionsGetResponse = WebAPICallResult & {
 
 export interface Message {
   app_id?:      string;
-  blocks?:      Block[];
+  blocks?:      MessageBlock[];
   bot_id?:      string;
   bot_profile?: BotProfile;
   permalink?:   string;
@@ -34,7 +34,7 @@ export interface Message {
   user?:        string;
 }
 
-export interface Block {
+export interface MessageBlock {
   accessory?:                    Accessory;
   alt_text?:                     string;
   api_decoration_available?:     boolean;
@@ -46,25 +46,25 @@ export interface Block {
   button_label?:                 string;
   call?:                         Call;
   call_id?:                      string;
-  description?:                  Description;
+  description?:                  DescriptionElement;
   developer_trace_id?:           string;
   dispatch_action?:              boolean;
   element?:                      Accessory;
   elements?:                     Accessory[];
   external_id?:                  string;
   fallback?:                     string;
-  fields?:                       Description[];
+  fields?:                       DescriptionElement[];
   file?:                         File;
   file_id?:                      string;
   function_trigger_id?:          string;
-  hint?:                         Description;
+  hint?:                         DescriptionElement;
   image_bytes?:                  number;
   image_height?:                 number;
   image_url?:                    string;
   image_width?:                  number;
   is_animated?:                  boolean;
   is_workflow_app?:              boolean;
-  label?:                        Description;
+  label?:                        DescriptionElement;
   optional?:                     boolean;
   owning_team_id?:               string;
   provider_icon_url?:            string;
@@ -73,9 +73,9 @@ export interface Block {
   share_url?:                    string;
   slack_file?:                   SlackFile;
   source?:                       string;
-  text?:                         Description;
+  text?:                         DescriptionElement;
   thumbnail_url?:                string;
-  title?:                        Description;
+  title?:                        DescriptionElement;
   title_url?:                    string;
   trigger_subtype?:              string;
   trigger_type?:                 string;
@@ -117,11 +117,11 @@ export interface Accessory {
   offset?:                          number;
   option_groups?:                   OptionGroup[];
   options?:                         Option[];
-  placeholder?:                     Description;
+  placeholder?:                     DescriptionElement;
   response_url_enabled?:            boolean;
   slack_file?:                      SlackFile;
   style?:                           string;
-  text?:                            Description;
+  text?:                            DescriptionElement;
   timezone?:                        string;
   type?:                            string;
   url?:                             string;
@@ -130,14 +130,14 @@ export interface Accessory {
 }
 
 export interface Confirm {
-  confirm?: Description;
-  deny?:    Description;
+  confirm?: DescriptionElement;
+  deny?:    DescriptionElement;
   style?:   string;
-  text?:    Description;
-  title?:   Description;
+  text?:    DescriptionElement;
+  title?:   DescriptionElement;
 }
 
-export interface Description {
+export interface DescriptionElement {
   emoji?:    boolean;
   text?:     string;
   type?:     DescriptionType;
@@ -155,7 +155,7 @@ export interface AccessoryElement {
   indent?:   number;
   offset?:   number;
   style?:    string;
-  type?:     string;
+  type?:     FluffyType;
 }
 
 export interface PurpleElement {
@@ -167,7 +167,7 @@ export interface PurpleElement {
   team_id?:      string;
   text?:         string;
   timestamp?:    string;
-  type?:         ElementType;
+  type?:         PurpleType;
   unicode?:      string;
   url?:          string;
   user_id?:      string;
@@ -182,7 +182,7 @@ export interface Style {
   strike?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -195,6 +195,13 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
 export interface Filter {
   exclude_bot_users?:                boolean;
   exclude_external_shared_channels?: boolean;
@@ -202,14 +209,14 @@ export interface Filter {
 }
 
 export interface Option {
-  description?: Description;
-  text?:        Description;
+  description?: DescriptionElement;
+  text?:        DescriptionElement;
   url?:         string;
   value?:       string;
 }
 
 export interface OptionGroup {
-  label?:   Description;
+  label?:   DescriptionElement;
   options?: Option[];
 }
 
@@ -285,33 +292,34 @@ export interface File {
   app_id?:                                  string;
   app_name?:                                string;
   attachments?:                             any[];
-  blocks?:                                  any[];
+  blocks?:                                  TitleBlockElement[];
   bot_id?:                                  string;
   canvas_template_mode?:                    string;
-  cc?:                                      any[];
+  cc?:                                      Cc[];
   channel_actions_count?:                   number;
   channel_actions_ts?:                      string;
-  channels?:                                any[];
+  channels?:                                string[];
   comments_count?:                          number;
   converted_pdf?:                           string;
   created?:                                 number;
   deanimate?:                               string;
   deanimate_gif?:                           string;
   display_as_bot?:                          boolean;
-  dm_mpdm_users_with_file_access?:          any[];
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
   duration_ms?:                             number;
   edit_link?:                               string;
   edit_timestamp?:                          number;
   editable?:                                boolean;
   editor?:                                  string;
-  editors?:                                 any[];
+  editors?:                                 string[];
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
-  from?:                                    any[];
-  groups?:                                  any[];
+  from?:                                    Cc[];
+  groups?:                                  string[];
   has_more?:                                boolean;
   has_more_shares?:                         boolean;
   has_rich_preview?:                        boolean;
@@ -320,7 +328,7 @@ export interface File {
   hls_embed?:                               string;
   id?:                                      string;
   image_exif_rotation?:                     number;
-  ims?:                                     any[];
+  ims?:                                     string[];
   initial_comment?:                         InitialComment;
   is_channel_space?:                        boolean;
   is_external?:                             boolean;
@@ -331,6 +339,8 @@ export interface File {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -346,7 +356,7 @@ export interface File {
   original_w?:                              string;
   permalink?:                               string;
   permalink_public?:                        string;
-  pinned_to?:                               any[];
+  pinned_to?:                               string[];
   pjpeg?:                                   string;
   plain_text?:                              string;
   pretty_type?:                             string;
@@ -355,12 +365,13 @@ export interface File {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
-  reactions?:                               any[];
+  reactions?:                               Reaction[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  Knocks;
+  shares?:                                  Shares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -420,8 +431,8 @@ export interface File {
   thumb_video_w?:                           number;
   timestamp?:                               number;
   title?:                                   string;
-  title_blocks?:                            any[];
-  to?:                                      any[];
+  title_blocks?:                            TitleBlockElement[];
+  to?:                                      Cc[];
   transcription?:                           Transcription;
   update_notification?:                     number;
   updated?:                                 number;
@@ -432,6 +443,62 @@ export interface File {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
+}
+
+export interface TitleBlockElement {
+  accessory?:                    Accessory;
+  alt_text?:                     string;
+  app_collaborators?:            string[];
+  app_id?:                       string;
+  author_name?:                  string;
+  block_id?:                     string;
+  bot_user_id?:                  string;
+  button_label?:                 string;
+  description?:                  DescriptionElement | string;
+  developer_trace_id?:           string;
+  elements?:                     Accessory[];
+  fallback?:                     string;
+  fields?:                       DescriptionElement[];
+  function_trigger_id?:          string;
+  image_bytes?:                  number;
+  image_height?:                 number;
+  image_url?:                    string;
+  image_width?:                  number;
+  is_animated?:                  boolean;
+  is_workflow_app?:              boolean;
+  owning_team_id?:               string;
+  provider_icon_url?:            string;
+  provider_name?:                string;
+  sales_home_workflow_app_type?: number;
+  share_url?:                    string;
+  slack_file?:                   SlackFile;
+  text?:                         DescriptionElement;
+  thumbnail_url?:                string;
+  title?:                        DescriptionElement | string;
+  title_url?:                    string;
+  trigger_subtype?:              string;
+  trigger_type?:                 string;
+  type?:                         string;
+  url?:                          string;
+  video_url?:                    string;
+  workflow_id?:                  string;
+}
+
+export interface Cc {
+  address?:  string;
+  name?:     string;
+  original?: string;
+}
+
+export interface DmMpdmUsersWithFileAccess {
+  access?:  string;
+  user_id?: string;
+}
+
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
 }
 
 export interface Headers {
@@ -451,10 +518,115 @@ export interface InitialComment {
   user?:      string;
 }
 
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
+}
+
 export interface MediaProgress {
   duration_ms?:   number;
   max_offset_ms?: number;
   offset_ms?:     number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?:  string;
+  url?:   string;
+  users?: string[];
 }
 
 export interface Saved {
@@ -464,7 +636,24 @@ export interface Saved {
   state?:          string;
 }
 
-export interface Knocks {
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?:  { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?:            string;
+  channel_name?:      string;
+  date_last_shared?:  number;
+  latest_reply?:      string;
+  reply_count?:       number;
+  reply_users?:       string[];
+  reply_users_count?: number;
+  share_user_id?:     string;
+  source?:            string;
+  team_id?:           string;
+  thread_ts?:         string;
+  ts?:                string;
 }
 
 export interface Transcription {
@@ -486,12 +675,6 @@ export interface Icons {
   image_36?: string;
   image_48?: string;
   image_72?: string;
-}
-
-export interface Reaction {
-  count?: number;
-  name?:  string;
-  users?: string[];
 }
 
 export interface Room {
@@ -528,4 +711,7 @@ export interface Room {
   was_accepted?:                 boolean;
   was_missed?:                   boolean;
   was_rejected?:                 boolean;
+}
+
+export interface Knocks {
 }

--- a/packages/web-api/src/types/response/ReactionsListResponse.ts
+++ b/packages/web-api/src/types/response/ReactionsListResponse.ts
@@ -77,12 +77,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -95,6 +97,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -358,7 +367,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -393,6 +402,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -416,6 +426,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -440,6 +452,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -530,6 +543,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -545,6 +564,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -592,14 +709,81 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: MessageBlockMessage;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  Knocks;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
 }
 
-export interface MessageBlockMessage {
+export interface Knocks {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    FieldMessage;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
+}
+
+export interface FieldMessage {
   app_id?:              string;
   attachments?:         any[];
   blocks?:              TitleBlockElement[];
@@ -611,7 +795,7 @@ export interface MessageBlockMessage {
   comment?:             Comment;
   display_as_bot?:      boolean;
   edited?:              Edited;
-  file?:                BlockFile;
+  file?:                PurpleFile;
   files?:               any[];
   hidden?:              boolean;
   icons?:               RootIcons;
@@ -710,7 +894,7 @@ export interface Edited {
   user?: string;
 }
 
-export interface BlockFile {
+export interface PurpleFile {
   access?:                                  string;
   alt_txt?:                                 string;
   app_id?:                                  string;
@@ -739,6 +923,7 @@ export interface BlockFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -762,6 +947,8 @@ export interface BlockFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -786,6 +973,7 @@ export interface BlockFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
@@ -865,9 +1053,6 @@ export interface BlockFile {
   vtt?:                                     string;
 }
 
-export interface Knocks {
-}
-
 export interface RootIcons {
   emoji?:    string;
   image_36?: string;
@@ -943,6 +1128,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: FieldMessage;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -985,7 +1198,7 @@ export interface PurpleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         BlockFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/RtmStartResponse.ts
+++ b/packages/web-api/src/types/response/RtmStartResponse.ts
@@ -40,20 +40,30 @@ export type RtmStartResponse = WebAPICallResult & {
 };
 
 export interface Bot {
-  app_id?:          string;
+  app_id?:          Appid;
   deleted?:         boolean;
   icons?:           BotIcons;
-  id?:              string;
+  id?:              Id;
   is_workflow_bot?: boolean;
   name?:            string;
   team_id?:         string;
   updated?:         number;
 }
 
+export enum Appid {
+  A00000000 = 'A00000000',
+  Empty = '',
+}
+
 export interface BotIcons {
   image_36?: string;
   image_48?: string;
   image_72?: string;
+}
+
+export enum Id {
+  B00000000 = 'B00000000',
+  Empty = '',
 }
 
 export interface Channel {
@@ -171,12 +181,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -189,6 +201,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -226,7 +245,7 @@ export interface Action {
   selected_options?: SelectedOptionElement[];
   style?:            string;
   text?:             string;
-  type?:             string;
+  type?:             ActionType;
   url?:              string;
   value?:            string;
 }
@@ -246,6 +265,32 @@ export interface ActionOptionGroup {
 export interface SelectedOptionElement {
   text?:  string;
   value?: string;
+}
+
+export enum ActionType {
+  Button = 'button',
+  ChannelsSelect = 'channels_select',
+  Checkboxes = 'checkboxes',
+  ConversationsSelect = 'conversations_select',
+  Datepicker = 'datepicker',
+  Datetimepicker = 'datetimepicker',
+  ExternalSelect = 'external_select',
+  Image = 'image',
+  MultiChannelsSelect = 'multi_channels_select',
+  MultiConversationsSelect = 'multi_conversations_select',
+  MultiExternalSelect = 'multi_external_select',
+  MultiStaticSelect = 'multi_static_select',
+  MultiUsersSelect = 'multi_users_select',
+  Overflow = 'overflow',
+  RadioButtons = 'radio_buttons',
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+  StaticSelect = 'static_select',
+  Timepicker = 'timepicker',
+  UsersSelect = 'users_select',
+  WorkflowButton = 'workflow_button',
 }
 
 export interface TitleBlockElement {
@@ -325,7 +370,7 @@ export interface Accessory {
   style?:                           string;
   text?:                            DescriptionElement;
   timezone?:                        string;
-  type?:                            string;
+  type?:                            ActionType;
   url?:                             string;
   value?:                           string;
   workflow?:                        Workflow;
@@ -357,7 +402,7 @@ export interface AccessoryElement {
   indent?:   number;
   offset?:   number;
   style?:    string;
-  type?:     FluffyType;
+  type?:     ActionType;
 }
 
 export interface PurpleElement {
@@ -395,13 +440,6 @@ export enum PurpleType {
   Text = 'text',
   User = 'user',
   Usergroup = 'usergroup',
-}
-
-export enum FluffyType {
-  RichTextList = 'rich_text_list',
-  RichTextPreformatted = 'rich_text_preformatted',
-  RichTextQuote = 'rich_text_quote',
-  RichTextSection = 'rich_text_section',
 }
 
 export interface Filter {
@@ -452,7 +490,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -487,6 +525,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -510,6 +549,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -534,6 +575,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -624,6 +666,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -639,6 +687,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -686,11 +832,78 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: Message;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  ListShares;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
+}
+
+export interface ListShares {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    Message;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
 }
 
 export interface Message {
@@ -817,6 +1030,7 @@ export interface MessageFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -840,6 +1054,8 @@ export interface MessageFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -864,12 +1080,13 @@ export interface MessageFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  FluffyShares;
+  shares?:                                  ListShares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -941,9 +1158,6 @@ export interface MessageFile {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
-}
-
-export interface FluffyShares {
 }
 
 export interface MessageIcons {
@@ -1018,6 +1232,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: Message;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -1060,7 +1302,7 @@ export interface LatestBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         MessageFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;
@@ -2015,7 +2257,7 @@ export interface Profile {
   always_active?:              boolean;
   api_app_id?:                 string;
   avatar_hash?:                string;
-  bot_id?:                     string;
+  bot_id?:                     Id;
   display_name?:               string;
   display_name_normalized?:    string;
   email?:                      string;

--- a/packages/web-api/src/types/response/SearchAllResponse.ts
+++ b/packages/web-api/src/types/response/SearchAllResponse.ts
@@ -84,6 +84,7 @@ export interface FilesMatch {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   sent_to_self?:                            boolean;
@@ -151,12 +152,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -169,6 +172,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -451,7 +461,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -486,6 +496,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -509,6 +520,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -533,6 +546,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -628,6 +642,12 @@ export enum LastEditor {
   U00000000 = 'U00000000',
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface FileHeaders {
   date?:        string;
   in_reply_to?: string;
@@ -643,6 +663,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -700,11 +818,78 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: Message;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  ListShares;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
+}
+
+export interface ListShares {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    Message;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
 }
 
 export interface Message {
@@ -847,6 +1032,7 @@ export interface MessageFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -870,6 +1056,8 @@ export interface MessageFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -894,12 +1082,13 @@ export interface MessageFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  FluffyShares;
+  shares?:                                  ListShares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -971,9 +1160,6 @@ export interface MessageFile {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
-}
-
-export interface FluffyShares {
 }
 
 export interface MessageIcons {
@@ -1048,6 +1234,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: Message;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -1098,7 +1312,7 @@ export interface MatchTitleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         MessageFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/SearchFilesResponse.ts
+++ b/packages/web-api/src/types/response/SearchFilesResponse.ts
@@ -40,7 +40,7 @@ export interface Match {
   dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
   edit_link?:                               string;
   editable?:                                boolean;
-  editors?:                                 string[];
+  editors?:                                 LastEditor[];
   editors_count?:                           number;
   external_id?:                             string;
   external_type?:                           string;
@@ -60,7 +60,7 @@ export interface Match {
   is_external?:                             boolean;
   is_public?:                               boolean;
   is_starred?:                              boolean;
-  last_editor?:                             string;
+  last_editor?:                             LastEditor;
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
@@ -82,6 +82,7 @@ export interface Match {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   sent_to_self?:                            boolean;
@@ -127,8 +128,8 @@ export interface Match {
   url_private?:                             string;
   url_private_download?:                    string;
   url_static_preview?:                      string;
-  user?:                                    string;
-  user_team?:                               string;
+  user?:                                    LastEditor;
+  user_team?:                               UserTeam;
   username?:                                string;
 }
 
@@ -149,12 +150,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -167,6 +170,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -430,7 +440,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -465,6 +475,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -488,6 +499,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -512,6 +525,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -599,7 +613,18 @@ export interface Cc {
 
 export interface DmMpdmUsersWithFileAccess {
   access?:  string;
-  user_id?: string;
+  user_id?: LastEditor;
+}
+
+export enum LastEditor {
+  Empty = '',
+  U00000000 = 'U00000000',
+}
+
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
 }
 
 export interface FileHeaders {
@@ -617,6 +642,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -652,11 +775,21 @@ export interface Public {
   reply_count?:       number;
   reply_users?:       string[];
   reply_users_count?: number;
-  share_user_id?:     string;
+  share_user_id?:     LastEditor;
   source?:            string;
-  team_id?:           string;
+  team_id?:           UserTeam;
   thread_ts?:         string;
-  ts?:                string;
+  ts?:                Ts;
+}
+
+export enum UserTeam {
+  Empty = '',
+  T00000000 = 'T00000000',
+}
+
+export enum Ts {
+  Empty = '',
+  The0000000000000000 = '0000000000.000000',
 }
 
 export interface Transcription {
@@ -664,11 +797,78 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: Message;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  ListShares;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
+}
+
+export interface ListShares {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    Message;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
 }
 
 export interface Message {
@@ -811,6 +1011,7 @@ export interface MessageFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -834,6 +1035,8 @@ export interface MessageFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -858,12 +1061,13 @@ export interface MessageFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  FluffyShares;
+  shares?:                                  ListShares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -935,9 +1139,6 @@ export interface MessageFile {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
-}
-
-export interface FluffyShares {
 }
 
 export interface MessageIcons {
@@ -1012,6 +1213,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: Message;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -1062,7 +1291,7 @@ export interface TitleBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         MessageFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/SearchMessagesResponse.ts
+++ b/packages/web-api/src/types/response/SearchMessagesResponse.ts
@@ -62,12 +62,14 @@ export interface Attachment {
   channel_team?:          string;
   color?:                 string;
   fallback?:              string;
-  fields?:                Field[];
+  fields?:                AttachmentField[];
+  file_id?:               string;
   filename?:              string;
   files?:                 FileElement[];
   footer?:                string;
   footer_icon?:           string;
   from_url?:              string;
+  hide_border?:           boolean;
   hide_color?:            boolean;
   id?:                    number;
   image_bytes?:           number;
@@ -80,6 +82,13 @@ export interface Attachment {
   is_msg_unfurl?:         boolean;
   is_reply_unfurl?:       boolean;
   is_thread_root_unfurl?: boolean;
+  list?:                  List;
+  list_record?:           PurpleListRecord;
+  list_record_id?:        string;
+  list_records?:          ListRecordElement[];
+  list_schema?:           Schema[];
+  list_view?:             View;
+  list_view_id?:          string;
   message_blocks?:        MessageBlock[];
   metadata?:              AttachmentMetadata;
   mimetype?:              string;
@@ -362,7 +371,7 @@ export enum BlockType {
   Video = 'video',
 }
 
-export interface Field {
+export interface AttachmentField {
   short?: boolean;
   title?: string;
   value?: string;
@@ -397,6 +406,7 @@ export interface FileElement {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               Favorite[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    Cc[];
@@ -420,6 +430,8 @@ export interface FileElement {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -444,6 +456,7 @@ export interface FileElement {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               Reaction[];
@@ -534,6 +547,12 @@ export interface DmMpdmUsersWithFileAccess {
   user_id?: string;
 }
 
+export interface Favorite {
+  collection_id?:   string;
+  collection_name?: string;
+  position?:        string;
+}
+
 export interface Headers {
   date?:        string;
   in_reply_to?: string;
@@ -549,6 +568,104 @@ export interface InitialComment {
   is_intro?:  boolean;
   timestamp?: number;
   user?:      string;
+}
+
+export interface ListLimits {
+  column_count?:        number;
+  column_count_limit?:  number;
+  over_column_maximum?: boolean;
+  over_row_maximum?:    boolean;
+  over_view_maximum?:   boolean;
+  row_count?:           number;
+  row_count_limit?:     number;
+  view_count?:          number;
+  view_count_limit?:    number;
+}
+
+export interface ListMetadata {
+  creation_source?: CreationSource;
+  description?:     string;
+  icon?:            string;
+  icon_team_id?:    string;
+  icon_url?:        string;
+  integrations?:    string[];
+  is_trial?:        boolean;
+  schema?:          Schema[];
+  views?:           View[];
+}
+
+export interface CreationSource {
+  reference_id?:         string;
+  type?:                 string;
+  workflow_function_id?: string;
+}
+
+export interface Schema {
+  id?:                string;
+  is_primary_column?: boolean;
+  key?:               string;
+  name?:              string;
+  options?:           Options;
+  type?:              string;
+}
+
+export interface Options {
+  canvas_id?:                  string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?:                    Choice[];
+  currency?:                   string;
+  currency_format?:            string;
+  date_format?:                string;
+  default_value?:              string;
+  default_value_typed?:        DefaultValueTyped;
+  emoji?:                      string;
+  emoji_team_id?:              string;
+  for_assignment?:             boolean;
+  format?:                     string;
+  linked_to?:                  string[];
+  mark_as_done_when_checked?:  boolean;
+  max?:                        number;
+  notify_users?:               boolean;
+  precision?:                  number;
+  rounding?:                   string;
+  show_member_name?:           boolean;
+  time_format?:                string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?:   string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?:           Column[];
+  created_by?:        string;
+  date_created?:      number;
+  id?:                string;
+  is_all_items_view?: boolean;
+  is_locked?:         boolean;
+  name?:              string;
+  position?:          string;
+  stick_column_left?: boolean;
+  type?:              string;
+}
+
+export interface Column {
+  id?:       string;
+  key?:      string;
+  position?: string;
+  visible?:  boolean;
+  width?:    number;
 }
 
 export interface MediaProgress {
@@ -596,11 +713,78 @@ export interface Transcription {
   status?: string;
 }
 
-export interface MessageBlock {
-  channel?: string;
-  message?: Message;
-  team?:    string;
-  ts?:      string;
+export interface List {
+  channels?:                                string[];
+  comments_count?:                          number;
+  created?:                                 number;
+  display_as_bot?:                          boolean;
+  dm_mpdm_users_with_file_access?:          DmMpdmUsersWithFileAccess[];
+  editable?:                                boolean;
+  external_type?:                           string;
+  file_access?:                             string;
+  filetype?:                                string;
+  groups?:                                  string[];
+  has_more_shares?:                         boolean;
+  has_rich_preview?:                        boolean;
+  id?:                                      string;
+  ims?:                                     string[];
+  is_external?:                             boolean;
+  is_public?:                               boolean;
+  last_editor?:                             string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
+  mimetype?:                                string;
+  mode?:                                    string;
+  name?:                                    string;
+  permalink?:                               string;
+  permalink_public?:                        string;
+  pretty_type?:                             string;
+  private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
+  public_url_shared?:                       boolean;
+  shares?:                                  ListShares;
+  size?:                                    number;
+  timestamp?:                               number;
+  title?:                                   string;
+  updated?:                                 number;
+  url_private?:                             string;
+  url_private_download?:                    string;
+  user?:                                    string;
+  user_team?:                               string;
+  username?:                                string;
+}
+
+export interface ListShares {
+}
+
+export interface PurpleListRecord {
+  record?: Record;
+  schema?: Schema[];
+}
+
+export interface Record {
+  fields?:    RecordField[];
+  record_id?: string;
+}
+
+export interface RecordField {
+  attachment?: any[];
+  channel?:    any[];
+  checkbox?:   boolean;
+  column_id?:  string;
+  date?:       any[];
+  email?:      any[];
+  key?:        string;
+  message?:    Message;
+  number?:     any[];
+  phone?:      any[];
+  rating?:     any[];
+  rich_text?:  any[];
+  select?:     any[];
+  text?:       string;
+  timestamp?:  any[];
+  user?:       any[];
+  value?:      string;
 }
 
 export interface Message {
@@ -743,6 +927,7 @@ export interface MessageFile {
   external_id?:                             string;
   external_type?:                           string;
   external_url?:                            string;
+  favorites?:                               any[];
   file_access?:                             string;
   filetype?:                                string;
   from?:                                    any[];
@@ -766,6 +951,8 @@ export interface MessageFile {
   lines?:                                   number;
   lines_more?:                              number;
   linked_channel_id?:                       string;
+  list_limits?:                             ListLimits;
+  list_metadata?:                           ListMetadata;
   media_display_type?:                      string;
   media_progress?:                          MediaProgress;
   mimetype?:                                string;
@@ -790,12 +977,13 @@ export interface MessageFile {
   preview_is_truncated?:                    boolean;
   preview_plain_text?:                      string;
   private_channels_with_file_access_count?: number;
+  private_file_with_access_count?:          number;
   public_url_shared?:                       boolean;
   quip_thread_id?:                          string;
   reactions?:                               any[];
   saved?:                                   Saved;
   sent_to_self?:                            boolean;
-  shares?:                                  FluffyShares;
+  shares?:                                  ListShares;
   show_badge?:                              boolean;
   simplified_html?:                         string;
   size?:                                    number;
@@ -867,9 +1055,6 @@ export interface MessageFile {
   user_team?:                               string;
   username?:                                string;
   vtt?:                                     string;
-}
-
-export interface FluffyShares {
 }
 
 export interface MessageIcons {
@@ -944,6 +1129,34 @@ export interface Root {
   username?:          string;
 }
 
+export interface ListRecordElement {
+  created_by?:        string;
+  date_created?:      number;
+  fields?:            RecordField[];
+  id?:                string;
+  is_subscribed?:     boolean;
+  list_id?:           string;
+  platform_refs?:     PlatformRefs;
+  position?:          string;
+  saved?:             Saved;
+  thread_ts?:         string;
+  updated_by?:        string;
+  updated_timestamp?: string;
+}
+
+export interface PlatformRefs {
+  bot_created_by?: string;
+  bot_deleted_by?: string;
+  bot_updated_by?: string;
+}
+
+export interface MessageBlock {
+  channel?: string;
+  message?: Message;
+  team?:    string;
+  ts?:      string;
+}
+
 export interface AttachmentMetadata {
   extension?:   string;
   format?:      string;
@@ -986,7 +1199,7 @@ export interface MatchBlock {
   external_id?:                  string;
   fallback?:                     string;
   fields?:                       DescriptionElement[];
-  file?:                         MessageFile;
+  file?:                         FileElement;
   file_id?:                      string;
   function_trigger_id?:          string;
   hint?:                         DescriptionElement;

--- a/packages/web-api/src/types/response/UsersConversationsResponse.ts
+++ b/packages/web-api/src/types/response/UsersConversationsResponse.ts
@@ -64,6 +64,7 @@ export interface Properties {
   canvas?:                Canvas;
   huddles_restricted?:    boolean;
   posting_restricted_to?: PostingRestrictedTo;
+  threads_restricted_to?: ThreadsRestrictedTo;
 }
 
 export interface Canvas {
@@ -75,6 +76,10 @@ export interface Canvas {
 export interface PostingRestrictedTo {
   type?: string[];
   user?: string[];
+}
+
+export interface ThreadsRestrictedTo {
+  type?: string[];
 }
 
 export interface Purpose {

--- a/packages/web-api/src/types/response/UsersDiscoverableContactsLookupResponse.ts
+++ b/packages/web-api/src/types/response/UsersDiscoverableContactsLookupResponse.ts
@@ -9,15 +9,19 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 
 import { WebAPICallResult } from '../../WebClient';
-export type CanvasesAccessSetResponse = WebAPICallResult & {
-  error?:                        string;
-  failed_to_update_channel_ids?: string[];
-  failed_to_update_user_ids?:    string[];
-  needed?:                       string;
-  ok?:                           boolean;
-  provided?:                     string;
-  response_metadata?:            ResponseMetadata;
+export type UsersDiscoverableContactsLookupResponse = WebAPICallResult & {
+  error?:             string;
+  needed?:            string;
+  ok?:                boolean;
+  provided?:          string;
+  response_metadata?: ResponseMetadata;
+  user?:              User;
 };
 
 export interface ResponseMetadata {
+  messages?: string[];
+}
+
+export interface User {
+  is_discoverable?: boolean;
 }

--- a/packages/web-api/src/types/response/index.ts
+++ b/packages/web-api/src/types/response/index.ts
@@ -279,6 +279,7 @@ export { UsergroupsUsersListResponse } from './UsergroupsUsersListResponse';
 export { UsergroupsUsersUpdateResponse } from './UsergroupsUsersUpdateResponse';
 export { UsersConversationsResponse } from './UsersConversationsResponse';
 export { UsersDeletePhotoResponse } from './UsersDeletePhotoResponse';
+export { UsersDiscoverableContactsLookupResponse } from './UsersDiscoverableContactsLookupResponse';
 export { UsersGetPresenceResponse } from './UsersGetPresenceResponse';
 export { UsersIdentityResponse } from './UsersIdentityResponse';
 export { UsersInfoResponse } from './UsersInfoResponse';


### PR DESCRIPTION
- add missing `response_metadata` fields to many response types
- add new `favorites` field
- add new list-related fields
- more specifically type many responses related to chat.* methods