### PR TITLE
chore: tweak response types generation script

### DIFF
--- a/scripts/code_generator.rb
+++ b/scripts/code_generator.rb
@@ -24,7 +24,7 @@ class TsWriter
 
 
   def write(root_class_name, json_path, typedef_filepath, input_json)
-    cmd = "npx quicktype --just-types --alphabetize-properties --all-properties-optional --acronym-style original -t #{root_class_name} -l ts"
+    cmd = "npx quicktype --just-types --prefer-const-values --alphabetize-properties --all-properties-optional --acronym-style original -t #{root_class_name} -l ts"
     puts "Generating #{root_class_name} from #{json_path}"
     Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
       stdin.write(input_json)

--- a/scripts/generate-web-api-types.sh
+++ b/scripts/generate-web-api-types.sh
@@ -3,18 +3,20 @@
 script_dir=`dirname $0`
 tmp_dir=${script_dir}/../tmp
 
-rm -rf ${tmp_dir}
-mkdir ${tmp_dir}
-cd ${tmp_dir}
+mkdir -p ${tmp_dir}
+pushd ${tmp_dir}
 
 # Use the latest revision of the java-slack-sdk git repo
-git clone https://github.com/slackapi/java-slack-sdk.git
-
-cd -
-cd ${script_dir}
+test -d java-slack-sdk || git clone https://github.com/slackapi/java-slack-sdk.git
+pushd java-slack-sdk
+git pull origin main
+popd
+popd
+pushd ${script_dir}
 
 # Download quicktype for generating code
 npm i
 
 # This Ruby script runs quicktype internally and do some additional modification to the generated files
 ruby ./code_generator.rb
+popd


### PR DESCRIPTION
- dont reclone java-slack-sdk every time
- pass `--prefer-const-values` to not generate `enum`s in place of string values; this should prevent creating enums like `['', 'U000000']` based off of sample .json files from java-slack-sdk
