### PR TITLE
ci: include node version 22 in the testing matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           files: packages/${{ matrix.package }}/coverage/lcov.info
       - name: Upload code coverage
-        if: matrix.node-version == '20.x' && steps.check_coverage.outputs.files_exists == 'true'
+        if: matrix.node-version == '22.x' && steps.check_coverage.outputs.files_exists == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,36 +25,36 @@ jobs:
           - web-api
           - webhook
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Get Development Dependencies
-      run: npm i
-    - name: Build and Run Tests in Each Package
-      working-directory: packages/${{ matrix.package }}
-      run: |
-        npm install || npm list
-        # depending on which package we are testing, also npm link up other dependent packages
-        case "$PWD" in
-          */webhook) pushd ../types && npm i && popd && npm link ../types;;
-          */web-api) pushd ../types && npm i && popd && npm link ../types && pushd ../logger && npm i && popd && npm link ../logger;;
-          */oauth) pushd ../logger && npm i && popd && npm link ../logger && pushd ../web-api && npm i && popd && npm link ../web-api;;
-          */socket-mode) pushd ../logger && npm i && popd && npm link ../logger && pushd ../web-api && npm i && popd && npm link ../web-api;;
-          *) ;; # default
-        esac
-        npm test
-    - name: Check for coverage report existence
-      id: check_coverage
-      uses: andstor/file-existence-action@v3
-      with:
-        files: packages/${{ matrix.package }}/coverage/lcov.info
-    - name: Upload code coverage
-      if: matrix.node-version == '20.x' && steps.check_coverage.outputs.files_exists == 'true'
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        directory: packages/${{ matrix.package }}/coverage
-        flags: ${{ matrix.package }}
-        verbose: true
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get Development Dependencies
+        run: npm i
+      - name: Build and Run Tests in Each Package
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          npm install || npm list
+          # depending on which package we are testing, also npm link up other dependent packages
+          case "$PWD" in
+            */webhook) pushd ../types && npm i && popd && npm link ../types;;
+            */web-api) pushd ../types && npm i && popd && npm link ../types && pushd ../logger && npm i && popd && npm link ../logger;;
+            */oauth) pushd ../logger && npm i && popd && npm link ../logger && pushd ../web-api && npm i && popd && npm link ../web-api;;
+            */socket-mode) pushd ../logger && npm i && popd && npm link ../logger && pushd ../web-api && npm i && popd && npm link ../web-api;;
+            *) ;; # default
+          esac
+          npm test
+      - name: Check for coverage report existence
+        id: check_coverage
+        uses: andstor/file-existence-action@v3
+        with:
+          files: packages/${{ matrix.package }}/coverage/lcov.info
+      - name: Upload code coverage
+        if: matrix.node-version == '20.x' && steps.check_coverage.outputs.files_exists == 'true'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: packages/${{ matrix.package }}/coverage
+          flags: ${{ matrix.package }}
+          verbose: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         package:
           - cli-hooks
           - cli-test

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,9 +25,9 @@ jobs:
           - web-api
           - webhook
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get Development Dependencies


### PR DESCRIPTION
###  Summary

This PR adds node version 22 to the testing matrix and bumps versions of action jobs using a deprecated node version. This is a 🚀 moment.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
