### PR TITLE
socket-mode(fix): redact ephemeral tokens and secrets from debug logs

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

This PR replaces values that should be redacted in debug logs - such as the ephemeral `bot_access_token` used in custom functions and `interactor.secret` - with `[[REDACTED]]`.

### Preview

Example output differences are found towards the end:

```diff
- [DEBUG]  socket-mode:SocketModeClient:0 Received a message on the WebSocket: {"envelope_id":"15726246-7de2-491a-95ed-09ba986b1c6b","payload":{"type":"block_actions","team":{"id":"T038J6TH5PF","domain":"sandbox"},"enterprise":null,"user":{"id":"U03SV4BFTJP","name":"me","team_id":"T038J6TH5PF"},"channel":{"id":"D079CP6N3GW","name":"directmessage"},"message":{"user":"U0794R4RBLP","type":"message","ts":"1719282819.865949","bot_id":"B07A85ZNJMN","app_id":"A079CP1699U","text":"Placeholder text","team":"T038J6TH5PF","blocks":[{"type":"section","block_id":"I9kjf","text":{"type":"mrkdwn","text":"Placeholder text","verbatim":false},"accessory":{"type":"button","action_id":"sample_button","text":{"type":"plain_text","text":"Complete function","emoji":true}}}]},"container":{"type":"message","message_ts":"1719282819.865949","channel_id":"D079CP6N3GW","is_ephemeral":false},"actions":[{"block_id":"I9kjf","action_id":"sample_button","type":"button","text":{"type":"plain_text","text":"Complete function","emoji":true},"action_ts":"1719282823.103643"}],"api_app_id":"A079CP1699U","state":{"values":{}},"bot_access_token":"xwfp-example-001","function_data":{"execution_id":"Fx079KPY1T6X","function":{"callback_id":"sample_function"},"inputs":{"user_id":"U03SV4BFTJP"}},"interactivity":{"interactor":{"secret":"someothervalue","id":"U03SV4BFTJP"},"interactivity_pointer":"7323025435029.3290231583797.b4a081dcb5a60882b1eea4d00e4dbc28"}},"type":"interactive","accepts_response_payload":false}
+ [DEBUG]  socket-mode:SocketModeClient:0 Received a message on the WebSocket: {"envelope_id":"15726246-7de2-491a-95ed-09ba986b1c6b","payload":{"type":"block_actions","team":{"id":"T038J6TH5PF","domain":"sandbox"},"enterprise":null,"user":{"id":"U03SV4BFTJP","name":"me","team_id":"T038J6TH5PF"},"channel":{"id":"D079CP6N3GW","name":"directmessage"},"message":{"user":"U0794R4RBLP","type":"message","ts":"1719282819.865949","bot_id":"B07A85ZNJMN","app_id":"A079CP1699U","text":"Placeholder text","team":"T038J6TH5PF","blocks":[{"type":"section","block_id":"I9kjf","text":{"type":"mrkdwn","text":"Placeholder text","verbatim":false},"accessory":{"type":"button","action_id":"sample_button","text":{"type":"plain_text","text":"Complete function","emoji":true}}}]},"container":{"type":"message","message_ts":"1719282819.865949","channel_id":"D079CP6N3GW","is_ephemeral":false},"actions":[{"block_id":"I9kjf","action_id":"sample_button","type":"button","text":{"type":"plain_text","text":"Complete function","emoji":true},"action_ts":"1719282823.103643"}],"api_app_id":"A079CP1699U","state":{"values":{}},"bot_access_token":"[[REDACTED]]","function_data":{"execution_id":"Fx079KPY1T6X","function":{"callback_id":"sample_function"},"inputs":{"user_id":"U03SV4BFTJP"}},"interactivity":{"interactor":{"secret":"[[REDACTED]]","id":"U03SV4BFTJP"},"interactivity_pointer":"7323025435029.3290231583797.b4a081dcb5a60882b1eea4d00e4dbc28"}},"type":"interactive","accepts_response_payload":false}
```

### Reviewers

The changes from this branch can be tested with a new app:

```sh
$ npm install
$ npm run build  # Build this branch
$ cd ~/bolt-js
$ npm install ~/path/to/node-slack-sdk/packages/socket-mode
$ npm ls
├── @slack/socket-mode@1.3.6 -> ./../node-slack-sdk/packages/socket-mode
$ npm run build  # Build bolt
$ cd
$ slack create example --template slack-samples/bolt-js-custom-function-template
$ cd example
$ npm install ~/path/to/bolt-js
$ npm ls
├── @slack/bolt@3.17.1-customFunctionBeta.0 -> ./../../tools/bolt-js
$ slack run
```

Then add the included "Sample function" to a workflow and inspect logs for `[[REDACTED]]` values!

### Notes

- Similar changes are applied to both `socket-mode@latest` on `main` and the `socket-mode@1.3.x` branch to backport for Bolt JS.
- This PR also includes a patch version bump for a follow up release!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).