### PR TITLE
cli-hooks(fix): remove environment variable requirements from the start hook

### DIFF
--- a/packages/cli-hooks/src/start.js
+++ b/packages/cli-hooks/src/start.js
@@ -19,8 +19,6 @@ if (fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
  * @param {string} cwd - The current working directory of the project.
  */
 export default function start(cwd) {
-  validateEnvironment();
-
   const customPath = process.env.SLACK_CLI_CUSTOM_FILE_PATH;
   const pkgJSONMain = getPackageJSONMain(cwd);
   const pkgJSONDefault = 'app.js';
@@ -51,22 +49,5 @@ function getPackageJSONMain(cwd) {
     return main;
   } catch {
     return undefined;
-  }
-}
-
-/**
- * Confirms environment variables are prepared by the CLI.
- */
-function validateEnvironment() {
-  const missingTokenError = `Missing the {type} token needed to start the app with Socket Mode.
-Hints: Setting the {token} environment variable is required.
-Check: Confirm that you are using the latest version of the Slack CLI.`;
-  if (!process.env.SLACK_CLI_XOXB) {
-    const missingBotTokenError = missingTokenError.replace('{type}', 'bot').replace('{token}', 'SLACK_CLI_XOXB');
-    throw new Error(missingBotTokenError);
-  }
-  if (!process.env.SLACK_CLI_XAPP) {
-    const missingAppTokenError = missingTokenError.replace('{type}', 'app').replace('{token}', 'SLACK_CLI_XAPP');
-    throw new Error(missingAppTokenError);
   }
 }

--- a/packages/cli-hooks/src/start.spec.js
+++ b/packages/cli-hooks/src/start.spec.js
@@ -126,47 +126,4 @@ describe('start implementation', async () => {
       });
     });
   });
-
-  describe('without valid tokens', async () => {
-    beforeEach(() => {
-      sinon.stub(console, 'log');
-      delete process.env.SLACK_CLI_XOXB;
-      delete process.env.SLACK_CLI_XAPP;
-    });
-    afterEach(() => {
-      sinon.restore();
-      delete process.env.SLACK_CLI_XOXB;
-      delete process.env.SLACK_CLI_XAPP;
-    });
-
-    it('should error without a bot token', async () => {
-      try {
-        process.env.SLACK_CLI_XAPP = 'xapp-example';
-        start('./');
-      } catch (err) {
-        if (err instanceof Error) {
-          assert(err.message.includes('Missing the bot token needed to start the app with Socket Mode.'));
-          assert(err.message.includes('Hints: Setting the SLACK_CLI_XOXB environment variable is required.'));
-          assert(err.message.includes('Check: Confirm that you are using the latest version of the Slack CLI.'));
-          return;
-        }
-      }
-      assert(false);
-    });
-
-    it('should error without an app token', async () => {
-      try {
-        process.env.SLACK_CLI_XOXB = 'xoxb-example';
-        start('./');
-      } catch (err) {
-        if (err instanceof Error) {
-          assert(err.message.includes('Missing the app token needed to start the app with Socket Mode.'));
-          assert(err.message.includes('Hints: Setting the SLACK_CLI_XAPP environment variable is required.'));
-          assert(err.message.includes('Check: Confirm that you are using the latest version of the Slack CLI.'));
-          return;
-        }
-      }
-      assert(false);
-    });
-  });
 });


### PR DESCRIPTION
###  Summary

This PR removes validation of environment variables from the `start` hook since it's not always true that these tokens are required to run an app. For instance, an app token isn't needed when running using HTTP Request URLs!

Similar assertions were removed and don't exist in `slackapi/python-slack-hooks`: https://github.com/slackapi/python-slack-hooks/pull/27

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
