### PR TITLE
test (web-api): lint the `test/` directory, too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-slack-sdk",
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-plugin-jsdoc": "^30.6.1"
+    "eslint": "^8",
+    "eslint-plugin-jsdoc": "^48"
   }
 }

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -36,7 +36,7 @@
     "prepare": "npm run build",
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist ./coverage",
-    "lint": "eslint --fix --ext .ts src",
+    "lint": "eslint --fix --ext .ts src test",
     "mocha": "mocha --config .mocharc.json src/*.spec.js",
     "test": "npm run lint && npm run test:types && npm run test:integration && npm run test:unit",
     "test:integration": "npm run build && node test/integration/commonjs-project/index.js && node test/integration/esm-project/index.mjs",

--- a/packages/web-api/test/types/methods/admin.analytics.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.analytics.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.apps.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.apps.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.auth.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.auth.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.barriers.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.barriers.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.conversations.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.conversations.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');
@@ -157,7 +158,7 @@ expectAssignable<Parameters<typeof web.admin.conversations.disconnectShared>>([{
 // -- happy path
 expectAssignable<Parameters<typeof web.admin.conversations.ekm.listOriginalConnectedChannelInfo>>([{
 }]); // all optional args
-expectAssignable<Parameters<typeof web.admin.conversations.ekm.listOriginalConnectedChannelInfo>>([]); // all optional args
+expectAssignable<Parameters<typeof web.admin.conversations.ekm.listOriginalConnectedChannelInfo>>([]); // all optnl args
 
 // admin.conversations.getConversationPrefs
 // -- sad path

--- a/packages/web-api/test/types/methods/admin.emoji.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.emoji.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.functions.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.functions.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.inviteRequests.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.inviteRequests.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.roles.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.roles.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.teams.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.teams.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.usergroups.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.usergroups.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.users.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.users.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/admin.workflows.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.workflows.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/api.test-d.ts
+++ b/packages/web-api/test/types/methods/api.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/apps.test-d.ts
+++ b/packages/web-api/test/types/methods/apps.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/auth.test-d.ts
+++ b/packages/web-api/test/types/methods/auth.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/bookmarks.test-d.ts
+++ b/packages/web-api/test/types/methods/bookmarks.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/bots.test-d.ts
+++ b/packages/web-api/test/types/methods/bots.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/calls.test-d.ts
+++ b/packages/web-api/test/types/methods/calls.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/canvas.test-d.ts
+++ b/packages/web-api/test/types/methods/canvas.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/chat.test-d.ts
+++ b/packages/web-api/test/types/methods/chat.test-d.ts
@@ -1,4 +1,5 @@
-import { expectError, expectAssignable } from 'tsd';
+import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/dialog.test-d.ts
+++ b/packages/web-api/test/types/methods/dialog.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/dnd.test-d.ts
+++ b/packages/web-api/test/types/methods/dnd.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/emoji.test-d.ts
+++ b/packages/web-api/test/types/methods/emoji.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/files.test-d.ts
+++ b/packages/web-api/test/types/methods/files.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/functions.test-d.ts
+++ b/packages/web-api/test/types/methods/functions.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/migration.test-d.ts
+++ b/packages/web-api/test/types/methods/migration.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/oauth.test-d.ts
+++ b/packages/web-api/test/types/methods/oauth.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/openid.test-d.ts
+++ b/packages/web-api/test/types/methods/openid.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/pins.test-d.ts
+++ b/packages/web-api/test/types/methods/pins.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/reactions.test-d.ts
+++ b/packages/web-api/test/types/methods/reactions.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/reminders.test-d.ts
+++ b/packages/web-api/test/types/methods/reminders.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/rtm.test-d.ts
+++ b/packages/web-api/test/types/methods/rtm.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/search.test-d.ts
+++ b/packages/web-api/test/types/methods/search.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/tooling.test-d.ts
+++ b/packages/web-api/test/types/methods/tooling.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/usergroups.test-d.ts
+++ b/packages/web-api/test/types/methods/usergroups.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/users.test-d.ts
+++ b/packages/web-api/test/types/methods/users.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/methods/views.test-d.ts
+++ b/packages/web-api/test/types/methods/views.test-d.ts
@@ -1,4 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');

--- a/packages/web-api/test/types/webclient-no-token.test-d.ts
+++ b/packages/web-api/test/types/webclient-no-token.test-d.ts
@@ -1,4 +1,5 @@
 import { expectType } from 'tsd';
+
 import { WebClient } from '../..';
 import { OauthAccessResponse } from '../../src/types/response/OauthAccessResponse';
 

--- a/packages/web-api/test/types/webclient-paginate-types.test-d.ts
+++ b/packages/web-api/test/types/webclient-paginate-types.test-d.ts
@@ -1,7 +1,8 @@
 /// <reference lib="esnext.asynciterable" />
 
-import { expectType, expectError } from 'tsd';
-import { WebClient, WebAPICallResult } from '../../';
+import { expectError, expectType } from 'tsd';
+
+import { WebAPICallResult, WebClient } from '../..';
 
 const web = new WebClient();
 
@@ -23,7 +24,9 @@ expectType<Promise<number>>(web.paginate('conversations.list', {}, () => false, 
 // expectError(web.paginate('conversations.list', {}, undefined, () => 5));
 
 // Ensure that it works in a for-await-of loop.
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 async () => {
+  // eslint-disable-next-line no-restricted-syntax
   for await (const page of web.paginate('conversations.list')) {
     expectType<WebAPICallResult>(page);
   }
@@ -54,5 +57,5 @@ expectType<Promise<Dummy>>(web.paginate(
     expectType<number>(pageNumber);
 
     return d;
-  }
+  },
 ));


### PR DESCRIPTION
Hmm, wonder why the linter fails in CI. Can't repro locally 🤔 