### PR TITLE
cli-test: Update for Windows e2e tests

### DIFF
--- a/packages/cli-test/src/cli/commands/platform.ts
+++ b/packages/cli-test/src/cli/commands/platform.ts
@@ -203,6 +203,13 @@ export default {
     return new Promise((resolve, reject) => {
       // kill the shell process
       shell.kill(proc).then(() => {
+
+        // Due to the complexity of gracefully shutting down processes on Windows / lack of interrupt signal support,
+        // we don't wait for the SLACK_TRACE_PLATFORM_RUN_STOP trace on Windows
+        if (process.platform === "win32") {
+          resolve();
+        }
+
         if (teamName) {
           // TODO: this is messed up. does not match to parameter name at all - team name has nothing to do with this.
           // Check if local app was deleted automatically, if --cleanup was passed to `runStart`

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -203,6 +203,9 @@ export const shell = {
   },
   assembleShellEnv: function assembleShellEnv(): Record<string, string | undefined> {
     const spawnedEnv = { ...process.env };
+    if (process.platform === "win32"){
+      spawnedEnv.PATH = process.env.PATH;
+    }
     // Always enable test trace output
     spawnedEnv.SLACK_TEST_TRACE = 'true';
     // Skip prompts for AAA request and directly send a request


### PR DESCRIPTION
###  Summary

Windows e2e tests can be seen running successfully in CCI consuming these changes: https://app.circleci.com/pipelines/github/slackapi/slack-cli/6390/workflows/31d009e1-6a81-46d2-bec6-c7ace7268fe0/jobs/15343 (failing 'copy artifacts' steps unrelated)

Sanity checked that the Unix e2e tests still pass here: https://app.circleci.com/pipelines/github/slackapi/platform-devxp-test/395/workflows/9cedbc0e-db05-4bf3-bad9-a188d28583c8/jobs/625?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

### Requirements 

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
