### PR TITLE
ci: lock to npm 10.7 when running on node 22

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,12 +24,18 @@ jobs:
           - types
           - web-api
           - webhook
+        include:
+          - node-version: 22.x
+          # npm 10.8, which comes w/ node 22, seems to cause issues when running npm i
+            npm: 10.7.0
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - if: ${{ matrix.npm }}
+        run: npm install -g npm@${{ matrix.npm }}
       - name: Get Development Dependencies
         run: npm i
       - name: Build and Run Tests in Each Package

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,18 +16,23 @@ jobs:
         node-version: [22.x]
         package:
           - logger
+        include:
+          - node-version: 22.x
+            npm: 10.7.0
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - if: ${{ matrix.npm }}
+        run: npm install -g npm@${{ matrix.npm }}
+      - run: npm --version
       - name: Get Development Dependencies
         run: npm i
       - name: Build and Run Tests in Each Package
         working-directory: packages/${{ matrix.package }}
         run: |
-          npm --version
           npm install
           # depending on which package we are testing, also npm link up other dependent packages
           case "$PWD" in

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,35 +13,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
         package:
-          - cli-hooks
-          - cli-test
           - logger
-          - oauth
-          - rtm-api
-          - socket-mode
-          - types
-          - web-api
-          - webhook
-        include:
-          - node-version: 22.x
-          # npm 10.8, which comes w/ node 22, seems to cause issues when running npm i
-            npm: 10.7.0
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - if: ${{ matrix.npm }}
-        run: npm install -g npm@${{ matrix.npm }}
       - name: Get Development Dependencies
         run: npm i
       - name: Build and Run Tests in Each Package
         working-directory: packages/${{ matrix.package }}
         run: |
-          npm install || npm list
+          npm --version
+          npm install
           # depending on which package we are testing, also npm link up other dependent packages
           case "$PWD" in
             */webhook) pushd ../types && npm i && popd && npm link ../types;;

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,20 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x]
+        node-version: [22.4.x]
         package:
           - logger
-        include:
-          - node-version: 22.x
-            npm: 10.6.0
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - if: ${{ matrix.npm }}
-        run: npm install -g npm@${{ matrix.npm }}
       - run: npm --version
       - name: Get Development Dependencies
         run: npm i

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,9 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.4.x]
+        node-version: [18.x, 20.x, 22.4.x]
         package:
+          - cli-hooks
+          - cli-test
           - logger
+          - oauth
+          - rtm-api
+          - socket-mode
+          - types
+          - web-api
+          - webhook
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
           - logger
         include:
           - node-version: 22.x
-            npm: 10.7.0
+            npm: 10.6.0
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-slack-sdk",
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-plugin-jsdoc": "^30.6.1"
+    "eslint": "^8.47.0",
+    "eslint-plugin-jsdoc": "^46.5.0"
   }
 }


### PR DESCRIPTION
Seems like some recent problem w/ npm 10.8 causes `npm i` to fail when CI runs on node 22. See this run: https://github.com/slackapi/node-slack-sdk/actions/runs/9994381477/job/27624030553?pr=1843

This relates to some interaction between npm and node 22.5, see https://github.com/npm/cli/issues/7657