### PR TITLE
fix: improve type for upload file v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-slack-sdk",
   "devDependencies": {
-    "eslint": "^8.9.0",
+    "eslint": "^7.32.0",
     "eslint-plugin-jsdoc": "^30.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-slack-sdk",
   "devDependencies": {
-    "eslint": "^7.32.0",
+    "eslint": "^8.9.0",
     "eslint-plugin-jsdoc": "^30.6.1"
   }
 }

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -128,7 +128,7 @@ export interface FileUploadBinaryContents {
 // File upload contents can be provided using either `content` or `file` arguments - and one of these is required.
 type FileUploadContents = FileUploadStringContents | FileUploadBinaryContents;
 
-type FileUpload = FileUploadContents & FileDestinationArgumentChannels & FileType & {
+type FileUpload = FileUploadContents & (FileDestinationArgumentChannels | FileDestinationArgument) & FileType & {
   /** @description Name of the file. */
   filename?: string;
   /** @description The message text introducing the file in specified channel(s). */
@@ -144,6 +144,8 @@ export type FileUploadV2 = FileUpload & {
   alt_text?: string;
   /** @description Channel ID where the file will be shared. If not specified the file will be private. */
   channel_id?: string;
+  /** @deprecated use channel_id instead */
+  channels?: string;
   /** @description Syntax type of the snippet being uploaded. E.g. `python`. */
   snippet_type?: string;
 };

--- a/packages/web-api/test/types/methods/files.test-d.ts
+++ b/packages/web-api/test/types/methods/files.test-d.ts
@@ -124,7 +124,16 @@ expectAssignable<Parameters<typeof web.files.uploadV2>>([{
   content: 'text',
 }]);
 expectAssignable<Parameters<typeof web.files.uploadV2>>([{
+  channel_id: 'C1234', // optionally share to one or more channels
+  content: 'text',
+}]);
+expectAssignable<Parameters<typeof web.files.uploadV2>>([{
   channels: 'C1234',
+  thread_ts: '12345.67', // or even to a specific thread
+  content: 'text',
+}]);
+expectAssignable<Parameters<typeof web.files.uploadV2>>([{
+  channel_id: 'C1234',
   thread_ts: '12345.67', // or even to a specific thread
   content: 'text',
 }]);


### PR DESCRIPTION
###  Summary

This PR aims to fix #1846 by adding additional typing and related tests

### Testing
1. Pull this branch
2. `cd packages/web-api`
3. `npm build`
4. In a project with the following `app.ts`
```ts
import { WebClient } from '@slack/web-api';

const client = new WebClient('mytoken');

(async () => {
  client.filesUploadV2({
    channel_id: 'C123',
    thread_ts: '173.029',
    content: 'test',
    filename: 'slack.json',
    title: 'test',
  });
})();
```
5. with `npm install ~/path/to/node-slack-sdk/packages/web-api`  the above should not create any typescript errors or warnings
6. change `channel_id` -> `channels`, you should see the following warning when running the app
```txt
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
