### PR TITLE
Publish `@slack/cli-hooks@1.1.1`

### DIFF
--- a/packages/cli-hooks/package.json
+++ b/packages/cli-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/cli-hooks",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node implementation of the contract between the Slack CLI and Bolt for JavaScript",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

This PR gives the changes on `main` an official version for `@slack/cli-hooks`.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
