### PR TITLE
feat (cli-test): expose arbitrary apihost flag to underlying SlackCLIProcess class

### DIFF
--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -49,6 +49,16 @@ describe('SlackCLIProcess class', () => {
         sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--apihost qa.slack.com');
         spawnProcessSpy.resetHistory();
       });
+      it('should map apihost option to provided host', async () => {
+        let cmd = new SlackCLIProcess('help', { apihost: 'dev123.slack.com' });
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--apihost dev123.slack.com');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help');
+        await cmd.execAsync();
+        sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--apihost dev123.slack.com');
+        spawnProcessSpy.resetHistory();
+      });
       it('should default to passing --skip-update but allow overriding that', async () => {
         let cmd = new SlackCLIProcess('help');
         await cmd.execAsync();

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -2,18 +2,22 @@ import { shell } from './shell';
 
 import type { ShellProcess } from '../utils/types';
 import type { SpawnOptionsWithoutStdio } from 'node:child_process';
-/*
- * some parameters used in the 'shell' calls that are CLI-specific and probably should not exist there:
-  * @param skipUpdate skip auto update notification
-  */
 
 export interface SlackCLIGlobalOptions {
   /**
+   * @description The API host the command should interact with, full domain name. (`--apihost qa1234.slack.com`)
+   * Takes precendence over `qa` and `dev` options.
+   * @example `qa1234.slack.com` or `dev2345.slack.com`
+   */
+  apihost?: string;
+  /**
    * @description Whether the command should interact with dev.slack (`--slackdev`)
+   * `qa` and `apihost` will both supersede this option.
    */
   dev?: boolean;
   /**
    * @description Whether the command should interact with qa.slack (`--apihost qa.slack.com`)
+   * Takes precendence over `dev` option but is superseded by `apihost`.
    */
   qa?: boolean;
   /**
@@ -88,11 +92,11 @@ export class SlackCLIProcess {
     let cmd = `${process.env.SLACK_CLI_PATH}`;
     if (this.globalOptions) {
       const opts = this.globalOptions;
-      // TODO: how to expose arbitrary apihost better?
-      if (opts.qa) {
+      if (opts.apihost) {
+        cmd += ` --apihost ${opts.apihost}`;
+      } else if (opts.qa) {
         cmd += ' --apihost qa.slack.com';
-      }
-      if (opts.dev) {
+      } else if (opts.dev) {
         cmd += ' --slackdev';
       }
       if (opts.skipUpdate || opts.skipUpdate === undefined) {


### PR DESCRIPTION
Inching towards 1.0 release.

Incremental step to refactoring the command options, which will be a third PR I will work on shortly.