### PR TITLE
fix (web-api): tweak type of `reply_broadcast` to be wider

### DIFF
--- a/packages/web-api/src/types/request/chat.ts
+++ b/packages/web-api/src/types/request/chat.ts
@@ -88,7 +88,7 @@ interface WithinThreadReply extends Partial<ThreadTS> {
 }
 interface BroadcastedThreadReply extends ThreadTS {
   /** @description Used in conjunction with `thread_ts`, when set to `true` will broadcast the reply to the channel. */
-  reply_broadcast: true;
+  reply_broadcast: boolean;
 }
 // For APIs supporting `reply_broadcast`, there are two options: either a broadcasted threaded reply,
 // or not broadcasted. Broadcasted replies are necessarily threaded, so `thread_ts` becomes required.

--- a/packages/web-api/test/types/methods/chat.test-d.ts
+++ b/packages/web-api/test/types/methods/chat.test-d.ts
@@ -1,4 +1,5 @@
-import { expectError, expectAssignable } from 'tsd';
+import { expectAssignable, expectError } from 'tsd';
+
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');
@@ -284,6 +285,24 @@ expectAssignable<Parameters<typeof web.chat.postMessage>>([{
   thread_ts: '1234.56',
   reply_broadcast: true, // can send a threaded message and broadcast it, too
 }]);
+expectAssignable<Parameters<typeof web.chat.postMessage>>([{
+  channel: 'C1234',
+  blocks: [],
+  thread_ts: '1234.56',
+  reply_broadcast: false, // can send a threaded message and explicitly not broadcast it
+}]);
+// adding a test for when `reply_broadcast` specific boolean value is not known ahead of time
+// https://github.com/slackapi/node-slack-sdk/issues/1859
+function wideBooleanTest(b: boolean) {
+  expectAssignable<Parameters<typeof web.chat.postMessage>>([{
+    channel: 'C1234',
+    blocks: [],
+    thread_ts: '1234.56',
+    reply_broadcast: b, // can reply_broadcast be parameterized?
+  }]);
+}
+wideBooleanTest(true);
+wideBooleanTest(false);
 
 // chat.scheduleMessage
 // -- sad path


### PR DESCRIPTION
...to allow for wider `boolean` usage with it. fixes #1859
