### PR TITLE
Docs: fix incorrect link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -182,7 +182,7 @@ const config = {
               },
               {
                 label: 'JavaScript',
-                to: 'https://slack.dev/node-slack-sdk',
+                to: 'https://slack.dev/bolt-js',
                 target: '_self',
               },
               {


### PR DESCRIPTION
###  Summary

I used the `bolt-js` config as a template and was overzealous on replacing "bolt-js" instances with "node-slack-sdk". The link to the bolt-js pages should _probably_ be the link to the bolt-js pages. 

### Requirements 

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
