### PR TITLE
cli-test: tackle TODOs, revamp arguments and function signatures, expose all CLI options

### DIFF
--- a/packages/cli-test/package.json
+++ b/packages/cli-test/package.json
@@ -25,7 +25,7 @@
     "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist ./coverage",
     "prepare": "npm run build",
-    "mocha": "cross-env SLACK_CLI_PATH=/doesnt/matter mocha --config .mocharc.json src/*.spec.ts src/**/*.spec.ts",
+    "mocha": "cross-env SLACK_CLI_PATH=/doesnt/matter mocha --config .mocharc.json src/*.spec.ts src/**/*.spec.ts src/**/**/*.spec.ts",
     "test": "npm run lint && npm run build && c8 npm run mocha"
   },
   "dependencies": {

--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -76,7 +76,7 @@ describe('SlackCLIProcess class', () => {
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--skip-update');
       });
-      it('should default to `--app deployed` but allow overriding that via the `instance` parameter', async () => {
+      it('should default to `--app deployed` but allow overriding that via the `app` parameter', async () => {
         let cmd = new SlackCLIProcess('help');
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--app deployed');

--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -81,7 +81,7 @@ describe('SlackCLIProcess class', () => {
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--app deployed');
         spawnProcessSpy.resetHistory();
-        cmd = new SlackCLIProcess('help', { instance: 'local' });
+        cmd = new SlackCLIProcess('help', { app: 'local' });
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--app local');
       });

--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -76,6 +76,38 @@ describe('SlackCLIProcess class', () => {
         await cmd.execAsync();
         sandbox.assert.calledWithMatch(spawnProcessSpy, '--skip-update');
       });
+      it('should default to `--app deployed` but allow overriding that via the `instance` parameter', async () => {
+        let cmd = new SlackCLIProcess('help');
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--app deployed');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help', { instance: 'local' });
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--app local');
+      });
+      it('should default to `--force` but allow overriding that via the `force` parameter', async () => {
+        let cmd = new SlackCLIProcess('help');
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--force');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help', { force: true });
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--force');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help', { force: false });
+        await cmd.execAsync();
+        sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--force');
+      });
+      it('should map token option to `--token`', async () => {
+        let cmd = new SlackCLIProcess('help', { token: 'xoxb-1234' });
+        await cmd.execAsync();
+        sandbox.assert.calledWithMatch(spawnProcessSpy, '--token xoxb-1234');
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess('help');
+        await cmd.execAsync();
+        sandbox.assert.neverCalledWithMatch(spawnProcessSpy, '--token xoxb-1234');
+        spawnProcessSpy.resetHistory();
+      });
     });
     describe('command options', () => {
       it('should pass command-level key/value options to command in the form `--<key> value`', async () => {

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -31,7 +31,11 @@ export interface SlackCLIGlobalOptions {
    * @description Whether the CLI should skip updating (`--skip-update`). Defaults to `true`.
    */
   skipUpdate?: boolean;
-  /** @description Workspace or organization name or ID to scope command to. */
+  /**
+   * @description The ID of your team. If you are using a Standard Slack plan, this is your workspace ID.
+   * If you are using an Enterprise Grid plan, this is the organization ID, even if your app is only granted to a
+   * subset of workspaces within the org.
+   */
   team?: string;
   /** @description Access token to use when making Slack API calls. */
   token?: string;

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -18,7 +18,8 @@ export interface SlackCLIGlobalOptions {
   /** @description Ignore warnings and continue executing command. Defaults to `true`. */
   force?: boolean;
   /**
-   * @description Application instance to target. Can be `local`, `deployed` an app ID string Defaults to `deployed`.
+   * @description Application instance to target. Can be `local`, `deployed` or an app ID string.
+   * Defaults to `deployed`.
    */
   instance?: string;
   /**
@@ -38,7 +39,7 @@ export interface SlackCLIGlobalOptions {
 
 export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost'>;
 
-export type SlackCLICommandOptions = Record<string, string | boolean | undefined>;
+export type SlackCLICommandOptions = Record<string, string | boolean | number | undefined>;
 
 export class SlackCLIProcess {
   /**

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -1,6 +1,6 @@
 import { shell } from './shell';
 
-import type { ShellProcess } from '../utils/types';
+import type { ShellProcess } from '../types/shell';
 import type { SpawnOptionsWithoutStdio } from 'node:child_process';
 
 export interface SlackCLIGlobalOptions {

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -21,7 +21,7 @@ export interface SlackCLIGlobalOptions {
    * @description Application instance to target. Can be `local`, `deployed` or an app ID string.
    * Defaults to `deployed`.
    */
-  instance?: string;
+  instance?: 'local' | 'deployed' | string;
   /**
    * @description Whether the command should interact with qa.slack (`--apihost qa.slack.com`)
    * Takes precendence over `dev` option but is superseded by `apihost`.

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -30,6 +30,8 @@ export interface SlackCLIGlobalOptions {
   team?: string;
 }
 
+export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost'>;
+
 export type SlackCLICommandOptions = Record<string, string | boolean | undefined>;
 
 export class SlackCLIProcess {

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -21,7 +21,7 @@ export interface SlackCLIGlobalOptions {
    * @description Application instance to target. Can be `local`, `deployed` or an app ID string.
    * Defaults to `deployed`.
    */
-  instance?: 'local' | 'deployed' | string;
+  app?: 'local' | 'deployed' | string;
   /**
    * @description Whether the command should interact with qa.slack (`--apihost qa.slack.com`)
    * Takes precendence over `dev` option but is superseded by `apihost`.
@@ -118,8 +118,8 @@ export class SlackCLIProcess {
         cmd += ` --team ${opts.team}`;
       }
       // App instance; defaults to `deployed`
-      if (opts.instance) {
-        cmd += ` --app ${opts.instance}`;
+      if (opts.app) {
+        cmd += ` --app ${opts.app}`;
       } else {
         cmd += ' --app deployed';
       }

--- a/packages/cli-test/src/cli/commands/app.spec.ts
+++ b/packages/cli-test/src/cli/commands/app.spec.ts
@@ -1,0 +1,57 @@
+import sinon from 'sinon';
+
+import app from './app';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('app commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('delete method', () => {
+    it('should invoke `app delete` and default to deployed apps and force=true', async () => {
+      await app.delete({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--force'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--app deployed'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('app delete'));
+    });
+    it('should invoke with `--app local` if app=local', async () => {
+      await app.delete({ appPath: '/some/path', app: 'local' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--app local'));
+    });
+    it('should invoke with `--force` if force=true', async () => {
+      await app.delete({ appPath: '/some/path', force: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--force'));
+    });
+    it('should invoke without `--force` if force=false', async () => {
+      await app.delete({ appPath: '/some/path', force: false });
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--force'));
+    });
+  });
+  describe('install method', () => {
+    it('should invoke a CLI process with `app install`', async () => {
+      await app.install({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('app install'));
+    });
+  });
+  describe('list method', () => {
+    it('should invoke a CLI process with `app list`', async () => {
+      await app.list({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('app list'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/app.spec.ts
+++ b/packages/cli-test/src/cli/commands/app.spec.ts
@@ -23,15 +23,10 @@ describe('app commands', () => {
   });
 
   describe('delete method', () => {
-    it('should invoke `app delete` and default to deployed apps and force=true', async () => {
+    it('should invoke `app delete` and default force=true', async () => {
       await app.delete({ appPath: '/some/path' });
       sandbox.assert.calledWith(spawnSpy, sinon.match('--force'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--app deployed'));
       sandbox.assert.calledWith(spawnSpy, sinon.match('app delete'));
-    });
-    it('should invoke with `--app local` if app=local', async () => {
-      await app.delete({ appPath: '/some/path', app: 'local' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--app local'));
     });
     it('should invoke with `--force` if force=true', async () => {
       await app.delete({ appPath: '/some/path', force: true });

--- a/packages/cli-test/src/cli/commands/app.ts
+++ b/packages/cli-test/src/cli/commands/app.ts
@@ -1,54 +1,48 @@
-import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
+import { SlackCLIProcess } from '../cli-process';
 
 import type { ProjectCommandArguments } from '../../types/commands/common_arguments';
 
+/**
+ * `slack app delete`
+ * @param args command arguments
+ * @returns command output
+ */
+export const del = async function appDelete(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('app delete', args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack app install`
+ * @param args command arguments
+ * @returns command output
+ */
+export const install = async function workspaceInstall(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('app install', args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack app list`
+ * @param appPath path to app
+ * @returns command output
+ */
+export const list = async function appList(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('app list', args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
 export default {
-  /**
-   * `slack app delete`
-   * @param args command arguments
-   * @returns command output
-   */
-  delete: async function appDelete(args: ProjectCommandArguments & {
-  /** @description `--force`; ignores warnings and executes app deletion. Defaults to `true`. */
-    force?: boolean;
-    /** @description `--app [deployed|local]`; deletes either the deployed or local app. Defaults to `deployed`. */
-    app?: 'deployed' | 'local';
-  }): Promise<string> {
-    const appEnvironment = args.app ? args.app : 'deployed';
-    const cmdOpts: SlackCLICommandOptions = {
-      '--app': appEnvironment,
-    };
-    if (typeof args.force === 'undefined' || args.force) {
-      cmdOpts['--force'] = true;
-    }
-    const cmd = new SlackCLIProcess('app delete', args, cmdOpts);
-    const proc = await cmd.execAsync({
-      cwd: args.appPath,
-    });
-    return proc.output;
-  },
-  /**
-   * `slack app install`
-   * @param args command arguments
-   * @returns command output
-   */
-  install: async function workspaceInstall(args: ProjectCommandArguments): Promise<string> {
-    const cmd = new SlackCLIProcess('app install', args);
-    const proc = await cmd.execAsync({
-      cwd: args.appPath,
-    });
-    return proc.output;
-  },
-  /**
-   * `slack app list`
-   * @param appPath path to app
-   * @returns command output
-   */
-  list: async function appList(args: ProjectCommandArguments): Promise<string> {
-    const cmd = new SlackCLIProcess('app list', args);
-    const proc = await cmd.execAsync({
-      cwd: args.appPath,
-    });
-    return proc.output;
-  },
+  delete: del,
+  install,
+  list,
 };

--- a/packages/cli-test/src/cli/commands/app.ts
+++ b/packages/cli-test/src/cli/commands/app.ts
@@ -4,7 +4,6 @@ import type { ProjectCommandArguments } from '../../types/commands/common_argume
 
 /**
  * `slack app delete`
- * @param args command arguments
  * @returns command output
  */
 export const del = async function appDelete(args: ProjectCommandArguments): Promise<string> {
@@ -17,7 +16,6 @@ export const del = async function appDelete(args: ProjectCommandArguments): Prom
 
 /**
  * `slack app install`
- * @param args command arguments
  * @returns command output
  */
 export const install = async function workspaceInstall(args: ProjectCommandArguments): Promise<string> {
@@ -30,7 +28,6 @@ export const install = async function workspaceInstall(args: ProjectCommandArgum
 
 /**
  * `slack app list`
- * @param appPath path to app
  * @returns command output
  */
 export const list = async function appList(args: ProjectCommandArguments): Promise<string> {

--- a/packages/cli-test/src/cli/commands/app.ts
+++ b/packages/cli-test/src/cli/commands/app.ts
@@ -1,66 +1,54 @@
-import { SlackCLIProcess } from '../cli-process';
+import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
 
-/**
- * `slack app delete`
- * @param appPath path to app
- * @param teamFlag team domain for the function's app
- * @returns command output
- */
-export const del = async function appDelete(
-  appPath: string,
-  teamFlag: string,
-  options?: { isLocalApp?: boolean, qa?: boolean },
-): Promise<string> {
-  // TODO: breaking change, separate params vs single-param-object, probably should reflect global vs command CLI flags
-  const appEnvironment = options?.isLocalApp ? 'local' : 'deployed';
-  const cmd = new SlackCLIProcess('app delete --force', { team: teamFlag, qa: options?.qa }, {
-    '--app': appEnvironment,
-  });
-  const proc = await cmd.execAsync({
-    cwd: appPath,
-  });
-  return proc.output;
-};
+import type { ProjectCommandArguments } from '../../types/commands/common_arguments';
 
-/**
- * `slack app install`
- * @param appPath path to app
- * @param teamFlag team domain where the app will be installed
- * @returns command output
- */
-export const install = async function workspaceInstall(
-  appPath: string,
-  teamFlag: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: breaking change, separate params vs single-param-object, probably should reflect global vs command CLI flags
-  const cmd = new SlackCLIProcess('app install', { team: teamFlag, qa: options?.qa });
-  const proc = await cmd.execAsync({
-    cwd: appPath,
-  });
-  return proc.output;
-};
-
-/**
- * `slack app list`
- * @param appPath path to app
- * @returns command output
- */
-export const list = async function appList(
-  appPath: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess('app list', options);
-  const proc = await cmd.execAsync({
-    cwd: appPath,
-  });
-  return proc.output;
-};
-
-// TODO: (breaking change): rename properties of this default export to match actual command names
 export default {
-  workspaceDelete: del,
-  workspaceInstall: install,
-  workspaceList: list,
+  /**
+   * `slack app delete`
+   * @param args command arguments
+   * @returns command output
+   */
+  delete: async function appDelete(args: ProjectCommandArguments & {
+  /** @description `--force`; ignores warnings and executes app deletion. Defaults to `true`. */
+    force?: boolean;
+    /** @description `--app [deployed|local]`; deletes either the deployed or local app. Defaults to `deployed`. */
+    app?: 'deployed' | 'local';
+  }): Promise<string> {
+    const appEnvironment = args.app ? args.app : 'deployed';
+    const cmdOpts: SlackCLICommandOptions = {
+      '--app': appEnvironment,
+    };
+    if (typeof args.force === 'undefined' || args.force) {
+      cmdOpts['--force'] = true;
+    }
+    const cmd = new SlackCLIProcess('app delete', args, cmdOpts);
+    const proc = await cmd.execAsync({
+      cwd: args.appPath,
+    });
+    return proc.output;
+  },
+  /**
+   * `slack app install`
+   * @param args command arguments
+   * @returns command output
+   */
+  install: async function workspaceInstall(args: ProjectCommandArguments): Promise<string> {
+    const cmd = new SlackCLIProcess('app install', args);
+    const proc = await cmd.execAsync({
+      cwd: args.appPath,
+    });
+    return proc.output;
+  },
+  /**
+   * `slack app list`
+   * @param appPath path to app
+   * @returns command output
+   */
+  list: async function appList(args: ProjectCommandArguments): Promise<string> {
+    const cmd = new SlackCLIProcess('app list', args);
+    const proc = await cmd.execAsync({
+      cwd: args.appPath,
+    });
+    return proc.output;
+  },
 };

--- a/packages/cli-test/src/cli/commands/auth.spec.ts
+++ b/packages/cli-test/src/cli/commands/auth.spec.ts
@@ -1,0 +1,69 @@
+import sinon from 'sinon';
+
+import auth from './auth';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('auth commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('loginNoPrompt method', () => {
+    it('should invoke `login --no-prompt`', async () => {
+      spawnSpy.returns({
+        command: 'something',
+        finished: true,
+        output: '/slackauthticket 123456',
+        process: mockProcess(),
+      });
+      const resp = await auth.loginNoPrompt();
+      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
+      sandbox.assert.match(resp.authTicket, '123456');
+      sandbox.assert.match(resp.authTicketSlashCommand, '/slackauthticket 123456');
+    });
+  });
+  describe('loginChallengeExchange method', () => {
+    it('should invoke `login --no-prompt --challenge --ticket`', async () => {
+      await auth.loginChallengeExchange({
+        authTicket: '123456',
+        challenge: 'batman',
+      });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--challenge batman'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--ticket 123456'));
+    });
+  });
+  describe('logout method', () => {
+    it('should invoke a CLI process with `logout`', async () => {
+      await auth.logout();
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+    });
+    it('should invoke a CLI process with `logout --team` if both `team` and `all` are specified', async () => {
+      await auth.logout({ team: 'T1234', all: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--team T1234'));
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--all'));
+    });
+    it('should invoke a CLI process with `logout --all` if `all` specified', async () => {
+      await auth.logout({ all: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--all'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/auth.ts
+++ b/packages/cli-test/src/cli/commands/auth.ts
@@ -1,6 +1,6 @@
 import { SlackCLICommandOptions, SlackCLIGlobalOptions, SlackCLIProcess } from '../cli-process';
 
-import type { ShellProcess } from '../../utils/types';
+import type { ShellProcess } from '../../types/shell';
 
 export default {
   /**

--- a/packages/cli-test/src/cli/commands/auth.ts
+++ b/packages/cli-test/src/cli/commands/auth.ts
@@ -1,28 +1,35 @@
-import { SlackCLICommandOptions, SlackCLIGlobalOptions, SlackCLIProcess } from '../cli-process';
+import {
+  SlackCLICommandOptions,
+  SlackCLIGlobalOptions,
+  SlackCLIHostTargetOptions,
+  SlackCLIProcess,
+} from '../cli-process';
 
 import type { ShellProcess } from '../../types/shell';
 
 export default {
   /**
-   *  `slack login --no-prompt`
+   *  `slack login --no-prompt`; initiates a CLI login flow. The `authTicketSlashCommand` returned should be entered
+   *  into the Slack client, and the challenge code retrieved and fed into the `loginChallengeExchange` method to
+   *  complete the CLI login flow.
    */
-  loginNoPrompt: async function loginNoPrompt(options?: { qa?: boolean }): Promise<{
+  loginNoPrompt: async function loginNoPrompt(args?: SlackCLIHostTargetOptions): Promise<{
+    /** @description Command output */
+    output: ShellProcess['output'];
     /**
-     * Command output
-     */
-    shellOutput: ShellProcess['output'];
-    /**
-     * Slash command with auth ticket, e.g. '/slackauthticket MTMxNjgxMDUtYTYwOC00NzRhLWE3M2YtMjVmZTQyMjc1MDg4'
+     * @description Slash command that a Slack client user must enter into the message composer in order to initiate
+     * login flow.
+     * @example `/slackauthticket MTMxNjgxMDUtYTYwOC00NzRhLWE3M2YtMjVmZTQyMjc1MDg4`
      */
     authTicketSlashCommand: string;
     /**
      * An auth ticket is a A UUID sequence granted by Slack to a CLI auth requestor.
      * That ticket must then be submitted via slash command by a user logged in to Slack and permissions accepted to be
-     * granted a token for use.
+     * granted a token for use. This `authTicket` is included in the `authTicketSlashCommand`.
      */
     authTicket: string;
   }> {
-    const cmd = new SlackCLIProcess('login', options, {
+    const cmd = new SlackCLIProcess('login', args, {
       '--no-prompt': true,
     });
     const proc = await cmd.execAsync();
@@ -32,31 +39,28 @@ export default {
     const authTicket = authTicketSlashCommand.split(' ')[1];
 
     return {
-      shellOutput: proc.output,
+      output: proc.output,
       authTicketSlashCommand,
       authTicket,
     };
   },
 
-  // TODO: (breaking change) inconsistent use of object-as-params vs. separate parameters
   /**
    * `slack login --no-prompt --challenge --ticket`
-   * @param challenge challenge string from UI
    * @param authTicket authTicket string from loginNoPrompt
    * @param options
    * @returns
    */
-  loginChallengeExchange: async function loginChallengeExchange(
+  loginChallengeExchange: async function loginChallengeExchange(args: SlackCLIHostTargetOptions & {
+    /** @description Challenge string extracted from the Slack client UI after submitting the auth slash command. */
     challenge: string,
+    /** @description The `authTicket` output from `loginNoPrompt`; required to complete the login flow. */
     authTicket: string,
-    options?: {
-      qa?: boolean;
-    },
-  ): Promise<string> {
-    const cmd = new SlackCLIProcess('login', options, {
+  }): Promise<string> {
+    const cmd = new SlackCLIProcess('login', args, {
       '--no-prompt': true,
-      '--challenge': challenge,
-      '--ticket': authTicket,
+      '--challenge': args.challenge,
+      '--ticket': args.authTicket,
     });
     const proc = await cmd.execAsync();
     return proc.output;
@@ -66,24 +70,19 @@ export default {
    * `slack logout`
    * @returns command output
    */
-  logout: async function logout(options?: {
-    // TODO: (breaking change) the two flags here are mutually exclusive; model better using an `|` of types
-    /** team domain to logout from */
-    teamFlag?: string;
-    /** perform the logout for all authentications */
-    allWorkspaces?: boolean;
-    qa?: boolean;
-  }): Promise<string> {
-    // TODO: (breaking change) inconsistent use of object-as-params vs. separate parameters
+  logout: async function logout(args?: Omit<SlackCLIGlobalOptions, 'team'> & (Pick<SlackCLIGlobalOptions, 'team'> | {
+    /**
+     * @description Perform the logout for all authentications.
+     * The `team` argument takes precendence over this argument.
+     */
+    all?: boolean;
+  })): Promise<string> {
     // Create the command with workspaces to logout of
-    const globalOpts: SlackCLIGlobalOptions = { qa: options?.qa };
     const cmdOpts: SlackCLICommandOptions = {};
-    if (options?.teamFlag) {
-      globalOpts.team = options.teamFlag;
-    } else if (options?.allWorkspaces) {
+    if (args && 'all' in args && !('team' in args) && args.all) {
       cmdOpts['--all'] = true;
     }
-    const cmd = new SlackCLIProcess('logout', globalOpts, cmdOpts);
+    const cmd = new SlackCLIProcess('logout', args, cmdOpts);
     const proc = await cmd.execAsync();
     return proc.output;
   },

--- a/packages/cli-test/src/cli/commands/collaborator.spec.ts
+++ b/packages/cli-test/src/cli/commands/collaborator.spec.ts
@@ -1,0 +1,69 @@
+import sinon from 'sinon';
+
+import auth from './auth';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('auth commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('loginNoPrompt method', () => {
+    it('should invoke `login --no-prompt`', async () => {
+      spawnSpy.returns({
+        command: 'something',
+        finished: true,
+        output: '/slackauthticket 123456',
+        process: mockProcess(),
+      });
+      const resp = await auth.loginNoPrompt();
+      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
+      sandbox.assert.match(resp.authTicket, '123456');
+      sandbox.assert.match(resp.authTicketSlashCommand, '/slackauthticket 123456');
+    });
+  });
+  describe('loginChallengeExchange method', () => {
+    it('should invoke `login --no-prompt --challenge --ticket`', async () => {
+      await auth.loginChallengeExchange({
+        authTicket: '123456',
+        challenge: 'batman',
+      });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--challenge batman'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--ticket 123456'));
+    });
+  });
+  describe('logout method', () => {
+    it('should invoke a CLI process with `logout`', async () => {
+      await auth.logout();
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+    });
+    it('should invoke a CLI process with `logout --team` if both `team` and `all` are specified', async () => {
+      await auth.logout({ team: 'T1234', all: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--team T1234'));
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--all'));
+    });
+    it('should invoke a CLI process with `logout --all` if `all` specified', async () => {
+      await auth.logout({ all: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--all'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/collaborator.spec.ts
+++ b/packages/cli-test/src/cli/commands/collaborator.spec.ts
@@ -1,10 +1,10 @@
 import sinon from 'sinon';
 
-import auth from './auth';
+import collaborator from './collaborator';
 import { mockProcess } from '../../utils/test';
 import { shell } from '../shell';
 
-describe('auth commands', () => {
+describe('collaborator commands', () => {
   const sandbox = sinon.createSandbox();
   let spawnSpy: sinon.SinonStub;
 
@@ -22,48 +22,22 @@ describe('auth commands', () => {
     sandbox.restore();
   });
 
-  describe('loginNoPrompt method', () => {
-    it('should invoke `login --no-prompt`', async () => {
-      spawnSpy.returns({
-        command: 'something',
-        finished: true,
-        output: '/slackauthticket 123456',
-        process: mockProcess(),
-      });
-      const resp = await auth.loginNoPrompt();
-      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
-      sandbox.assert.match(resp.authTicket, '123456');
-      sandbox.assert.match(resp.authTicketSlashCommand, '/slackauthticket 123456');
+  describe('add method', () => {
+    it('should invoke `collaborators add <email>`', async () => {
+      await collaborator.add({ appPath: '/some/path', collaboratorEmail: 'you@me.com' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('collaborators add you@me.com'));
     });
   });
-  describe('loginChallengeExchange method', () => {
-    it('should invoke `login --no-prompt --challenge --ticket`', async () => {
-      await auth.loginChallengeExchange({
-        authTicket: '123456',
-        challenge: 'batman',
-      });
-      sandbox.assert.calledWith(spawnSpy, sinon.match('login'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--no-prompt'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--challenge batman'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--ticket 123456'));
+  describe('list method', () => {
+    it('should invoke `collaborators list`', async () => {
+      await collaborator.list({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('collaborators list'));
     });
   });
-  describe('logout method', () => {
-    it('should invoke a CLI process with `logout`', async () => {
-      await auth.logout();
-      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
-    });
-    it('should invoke a CLI process with `logout --team` if both `team` and `all` are specified', async () => {
-      await auth.logout({ team: 'T1234', all: true });
-      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--team T1234'));
-      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--all'));
-    });
-    it('should invoke a CLI process with `logout --all` if `all` specified', async () => {
-      await auth.logout({ all: true });
-      sandbox.assert.calledWith(spawnSpy, sinon.match('logout'));
-      sandbox.assert.calledWith(spawnSpy, sinon.match('--all'));
+  describe('remove method', () => {
+    it('should invoke `collaborators remove <email>`', async () => {
+      await collaborator.remove({ appPath: '/some/path', collaboratorEmail: 'you@me.com' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('collaborators remove you@me.com'));
     });
   });
 });

--- a/packages/cli-test/src/cli/commands/collaborator.ts
+++ b/packages/cli-test/src/cli/commands/collaborator.ts
@@ -1,14 +1,16 @@
 import { ProjectCommandArguments } from '../../types/commands/common_arguments';
 import { SlackCLIProcess } from '../cli-process';
 
+export interface CollaboratorEmail {
+  /** @description email of the collaborator */
+  collaboratorEmail: string,
+}
+
 /**
  * `slack collaborators add`
  * @returns command output
  */
-export const add = async function collaboratorsAdd(args: ProjectCommandArguments & {
-  /** @description email of the user to be added as a collaborator */
-  collaboratorEmail: string,
-}): Promise<string> {
+export const add = async function collaboratorsAdd(args: ProjectCommandArguments & CollaboratorEmail): Promise<string> {
   const cmd = new SlackCLIProcess(`collaborators add ${args.collaboratorEmail}`, args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
@@ -18,47 +20,33 @@ export const add = async function collaboratorsAdd(args: ProjectCommandArguments
 
 /**
  * `slack collaborators list`
- * @param appPath path to app
- * @param teamFlag team domain to list collaborators for
  * @returns command output
  */
-export const list = async function collaboratorsList(
-  appPath: string,
-  teamFlag: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess('collaborators list', { team: teamFlag, qa: options?.qa });
+export const list = async function collaboratorsList(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('collaborators list', args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
 /**
  * `slack collaborators remove`
- * @param appPath path to app
- * @param teamFlag team domain to remove collaborators from
  * @param collaboratorEmail email of the user to be removed as a collaborator
  * @returns command output
  */
 export const remove = async function collaboratorsRemove(
-  appPath: string,
-  teamFlag: string,
-  collaboratorEmail: string,
-  options?: { qa?: boolean },
+  args: ProjectCommandArguments & CollaboratorEmail,
 ): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess(`collaborators remove ${collaboratorEmail}`, { team: teamFlag, qa: options?.qa });
+  const cmd = new SlackCLIProcess(`collaborators remove ${args.collaboratorEmail}`, args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
-// TODO: (breaking change): rename properties of this default export to match actual command names
 export default {
-  collaboratorsAdd: add,
-  collaboratorsList: list,
-  collaboratorsRemove: remove,
+  add,
+  list,
+  remove,
 };

--- a/packages/cli-test/src/cli/commands/collaborator.ts
+++ b/packages/cli-test/src/cli/commands/collaborator.ts
@@ -1,22 +1,17 @@
+import { ProjectCommandArguments } from '../../types/commands/common_arguments';
 import { SlackCLIProcess } from '../cli-process';
 
 /**
  * `slack collaborators add`
- * @param appPath path to app
- * @param teamFlag team domain to add collaborators to
- * @param collaboratorEmail email of the user to be added as a collaborator
  * @returns command output
  */
-export const add = async function collaboratorsAdd(
-  appPath: string,
-  teamFlag: string,
+export const add = async function collaboratorsAdd(args: ProjectCommandArguments & {
+  /** @description email of the user to be added as a collaborator */
   collaboratorEmail: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess(`collaborators add ${collaboratorEmail}`, { team: teamFlag, qa: options?.qa });
+}): Promise<string> {
+  const cmd = new SlackCLIProcess(`collaborators add ${args.collaboratorEmail}`, args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };

--- a/packages/cli-test/src/cli/commands/create.spec.ts
+++ b/packages/cli-test/src/cli/commands/create.spec.ts
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+
+import { create } from './create';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('create', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('method', () => {
+    it('should invoke `create <appPath>`', async () => {
+      await create({ appPath: 'myApp' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('create myApp'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/create.spec.ts
+++ b/packages/cli-test/src/cli/commands/create.spec.ts
@@ -27,5 +27,16 @@ describe('create', () => {
       await create({ appPath: 'myApp' });
       sandbox.assert.calledWith(spawnSpy, sinon.match('create myApp'));
     });
+    it('should invoke `create <appPath> --template` if template specified', async () => {
+      await create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('create myApp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--template slack-samples/deno-hello-world'));
+    });
+    it('should invoke `create <appPath> --template --branch` if both template and branch specified', async () => {
+      await create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world', branch: 'feat-functions' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('create myApp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--template slack-samples/deno-hello-world'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--branch feat-functions'));
+    });
   });
 });

--- a/packages/cli-test/src/cli/commands/create.ts
+++ b/packages/cli-test/src/cli/commands/create.ts
@@ -1,56 +1,14 @@
-import { SpawnOptionsWithoutStdio } from 'node:child_process';
-
-import { SlackCLICommandOptions, SlackCLIGlobalOptions, SlackCLIProcess } from '../cli-process';
+import { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import { SlackCLIProcess } from '../cli-process';
 
 /**
  * `slack create`
- * @param opts generic command options to pass to `create`
  * @returns command output
  */
-export const create = async function create(
-  appName?: string, // TODO: bad arg name. it should be app path, because this is effectively how it is used
-  globalOpts?: SlackCLIGlobalOptions,
-  commandOpts?: SlackCLICommandOptions,
-  shellOpts?: SpawnOptionsWithoutStdio,
-): Promise<string> {
-  // TODO: single object param vs separate params (breaking change)
-  let cmdStr = 'create';
-  if (appName) {
-    cmdStr += ` ${appName}`;
-  }
-  const cmd = new SlackCLIProcess(cmdStr, globalOpts, commandOpts);
-  const proc = await cmd.execAsync(shellOpts);
+export const create = async function create(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess(`create ${args.appPath}`, args);
+  const proc = await cmd.execAsync();
   return proc.output;
 };
 
-// TODO: (breaking change) remove this method
-/**
- * `slack create` using a template
- * Creates an app from a specified template string.
- * @param templateString template string (ex: `slack-samples/deno-hello-world`)
- * @param appName desired app name
- * @param branchName the branch to clone (default: `main`)
- * @returns command output
- */
-export const createAppFromTemplate = async function createAppFromTemplate({
-  templateString,
-  appName = '',
-  branchName = 'main',
-  shellOpts = {},
-}: {
-  templateString: string;
-  appName?: string; // TODO: bad arg name. it should be app path, because this is effectively how it is used
-  branchName?: string;
-  shellOpts?: SpawnOptionsWithoutStdio;
-}): Promise<string> {
-  return create(appName, {}, {
-    '--template': templateString,
-    '--branch': branchName,
-  }, shellOpts);
-};
-
-// TODO: (breaking change): rename properties of this default export to match actual command names
-export default {
-  createAppFromTemplate,
-  createApp: create,
-};
+export default create;

--- a/packages/cli-test/src/cli/commands/create.ts
+++ b/packages/cli-test/src/cli/commands/create.ts
@@ -1,12 +1,26 @@
 import { ProjectCommandArguments } from '../../types/commands/common_arguments';
-import { SlackCLIProcess } from '../cli-process';
+import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
 
 /**
  * `slack create`
  * @returns command output
  */
-export const create = async function create(args: ProjectCommandArguments): Promise<string> {
-  const cmd = new SlackCLIProcess(`create ${args.appPath}`, args);
+export const create = async function create(
+  args: ProjectCommandArguments & {
+    /** @description URL to an app template to use when creating app. */
+    template?: string;
+    /** @description Branch to use from the provided `template`. */
+    branch?: string;
+  },
+): Promise<string> {
+  const cmdOpts: SlackCLICommandOptions = {};
+  if ('template' in args) {
+    cmdOpts['--template'] = args.template;
+    if ('branch' in args) {
+      cmdOpts['--branch'] = args.branch;
+    }
+  }
+  const cmd = new SlackCLIProcess(`create ${args.appPath}`, args, cmdOpts);
   const proc = await cmd.execAsync();
   return proc.output;
 };

--- a/packages/cli-test/src/cli/commands/env.spec.ts
+++ b/packages/cli-test/src/cli/commands/env.spec.ts
@@ -1,0 +1,43 @@
+import sinon from 'sinon';
+
+import env from './env';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('env commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('add method', () => {
+    it('should invoke `env add <key> <value>`', async () => {
+      await env.add({ appPath: '/some/path', secretKey: 'key', secretValue: 'value' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('env add key value'));
+    });
+  });
+  describe('list method', () => {
+    it('should invoke `env list`', async () => {
+      await env.list({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('env list'));
+    });
+  });
+  describe('remove method', () => {
+    it('should invoke `env remove <key>`', async () => {
+      await env.remove({ appPath: '/some/path', secretKey: 'key' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('env remove key'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/env.ts
+++ b/packages/cli-test/src/cli/commands/env.ts
@@ -1,71 +1,51 @@
+import { ProjectCommandArguments } from '../../types/commands/common_arguments';
 import { SlackCLIProcess } from '../cli-process';
+
+export interface EnvCommandArguments {
+  /** @description Environment variable key */
+  secretKey: string;
+  /** @description Environment variable value */
+  secretValue: string;
+}
 
 /**
  * `slack env add`
- * @param appPath path to app
- * @param teamFlag team domain to add env var to
- * @param secretKey environment variable key
- * @param secretValue environment variable value
  * @returns command output
  */
-export const add = async function envAdd(
-  appPath: string,
-  teamFlag: string,
-  secretKey: string,
-  secretValue: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess(`env add ${secretKey} ${secretValue}`, { team: teamFlag, qa: options?.qa });
+export const add = async function envAdd(args: ProjectCommandArguments & EnvCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess(`env add ${args.secretKey} ${args.secretValue}`, args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
 /**
  * `slack env list`
- * @param appPath path to app
- * @param teamFlag team domain to list env vars for
  * @returns command output
  */
-export const list = async function envList(
-  appPath: string,
-  teamFlag: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess('env list', { team: teamFlag, qa: options?.qa });
+export const list = async function envList(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('env list', args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
 /**
  * `slack env remove`
- * @param appPath path to app
- * @param teamFlag team domain to remove env var from
- * @param secretKey environment variable key
  * @returns command output
  */
-export const remove = async function envRemove(
-  appPath: string,
-  teamFlag: string,
-  secretKey: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: (breaking change) separate parameters vs single-param-object
-  const cmd = new SlackCLIProcess(`env remove ${secretKey}`, { team: teamFlag, qa: options?.qa });
+export const remove = async function envRemove(args: ProjectCommandArguments & Pick<EnvCommandArguments, 'secretKey'>): Promise<string> {
+  const cmd = new SlackCLIProcess(`env remove ${args.secretKey}`, args);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
-// TODO: (breaking change): rename properties of this default export to match actual command names
 export default {
-  envAdd: add,
-  envList: list,
-  envRemove: remove,
+  add,
+  list,
+  remove,
 };

--- a/packages/cli-test/src/cli/commands/external-auth.spec.ts
+++ b/packages/cli-test/src/cli/commands/external-auth.spec.ts
@@ -1,0 +1,66 @@
+import sinon from 'sinon';
+
+import extAuth from './external-auth';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('external-auth commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('add method', () => {
+    it('should invoke `external-auth add --provider`', async () => {
+      await extAuth.add({ appPath: '/some/path', provider: 'bigcorp' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth add --provider bigcorp'));
+    });
+  });
+  describe('addSecret method', () => {
+    it('should invoke `external-auth add-secret --provider --secret`', async () => {
+      await extAuth.addSecret({ appPath: '/some/path', provider: 'bigcorp', secret: 'shh' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth add-secret'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--provider bigcorp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--secret shh'));
+    });
+  });
+  describe('remove method', () => {
+    it('should invoke `external-auth remove --provider`', async () => {
+      await extAuth.remove({ appPath: '/some/path', provider: 'bigcorp' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth remove --provider bigcorp'));
+    });
+    it('should invoke `external-auth remove --provider --all` if `all: true` specified', async () => {
+      await extAuth.remove({ appPath: '/some/path', provider: 'bigcorp', all: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth remove --provider bigcorp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--all'));
+    });
+  });
+  describe('select-auth method', () => {
+    it('should invoke `external-auth select-auth --provider`', async () => {
+      await extAuth.selectAuth({ appPath: '/some/path', provider: 'bigcorp' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth select-auth --provider bigcorp'));
+    });
+    it('should invoke `external-auth select-auth --provider --external-account` if `externalAccount` specified', async () => {
+      await extAuth.selectAuth({ appPath: '/some/path', provider: 'bigcorp', externalAccount: 'me@me.com' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth select-auth --provider bigcorp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--external-account me@me.com'));
+    });
+    it('should invoke `external-auth select-auth --provider --workflow` if `workflow` specified', async () => {
+      await extAuth.selectAuth({ appPath: '/some/path', provider: 'bigcorp', workflow: '#/workflow/1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('external-auth select-auth --provider bigcorp'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--workflow #/workflow/1234'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/function.spec.ts
+++ b/packages/cli-test/src/cli/commands/function.spec.ts
@@ -1,0 +1,58 @@
+import sinon from 'sinon';
+
+import func from './function';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('function commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('access method', () => {
+    it('should invoke `function access --info` if info=true', async () => {
+      await func.access({ appPath: '/some/path', info: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('function access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--info'));
+    });
+    it('should invoke `function access --name --app-collaborators` if `name` and `appCollaborators` specified', async () => {
+      await func.access({ appPath: '/some/path', name: 'best', appCollaborators: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('function access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--name best'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--app-collaborators'));
+    });
+    it('should invoke `function access --name --everyone` if `name` and `everyone` specified', async () => {
+      await func.access({ appPath: '/some/path', name: 'best', everyone: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('function access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--name best'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--everyone'));
+    });
+    it('should invoke `function access --name --grant --users` if `name`, `grant` and `users` specified', async () => {
+      await func.access({ appPath: '/some/path', name: 'best', grant: true, users: ['U1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('function access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--name best'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--grant'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--users U1234'));
+    });
+    it('should invoke `function access --name --revoke --users` if `name`, `revoke` and `users` specified', async () => {
+      await func.access({ appPath: '/some/path', name: 'best', revoke: true, users: ['U1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('function access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--name best'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--revoke'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--users U1234'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/function.ts
+++ b/packages/cli-test/src/cli/commands/function.ts
@@ -1,4 +1,9 @@
-import { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import {
+  GroupAccessChangeArguments,
+  InfoArgument,
+  ProjectCommandArguments,
+  UserAccessChangeArguments,
+} from '../../types/commands/common_arguments';
 import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
 
 type AccessChangeArguments = {
@@ -6,35 +11,6 @@ type AccessChangeArguments = {
   name: string;
   info?: boolean;
 } & (GroupAccessChangeArguments | UserAccessChangeArguments);
-
-type GroupAccessChangeArguments = GrantAppCollaboratorsArgument | GrantEveryoneArgument;
-
-export interface GrantAppCollaboratorsArgument {
-  /** @description Grant access for function specified by `name` to app collaborators. */
-  appCollaborators: true;
-}
-export interface GrantEveryoneArgument {
-  /** @description Grant access for function specified by `name` to everyone. */
-  everyone: true;
-}
-export interface GrantArgument {
-  /** @description Grant access for function specified by `name` to users specified by `users`. */
-  grant: true;
-}
-export interface RevokeArgument {
-  /** @description Revoke access for function specified by `name` to users specified by `users`. */
-  revoke: true;
-}
-
-type UserAccessChangeArguments = {
-  /** @description Array of users to grant or revoke access to. */
-  users: [string, ...string[]];
-} & (RevokeArgument | GrantArgument);
-
-export interface InfoArgument {
-  /** @description Whether to show access information for a function. Supercedes all other arguments. */
-  info: true;
-}
 
 type FunctionAccessArguments = AccessChangeArguments | InfoArgument;
 
@@ -46,7 +22,7 @@ export const access = async function functionAccess(
   args: ProjectCommandArguments & FunctionAccessArguments,
 ): Promise<string> {
   const cmdOpts: SlackCLICommandOptions = {};
-  if (typeof args.info !== 'undefined' || ('info' in args && args.info)) {
+  if ('info' in args && args.info) {
     cmdOpts['--info'] = true;
   } else {
     cmdOpts['--name'] = args.name;

--- a/packages/cli-test/src/cli/commands/function.ts
+++ b/packages/cli-test/src/cli/commands/function.ts
@@ -1,31 +1,79 @@
-import { SlackCLIProcess } from '../cli-process';
+import { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
 
-// TODO: the "flag" param throughout here should be done in a better way.
-// Perhaps expose the SlackCommandOptions type directly?
+type AccessChangeArguments = {
+  /** @description `callback_id` of function being targeted. */
+  name: string;
+  info?: boolean;
+} & (GroupAccessChangeArguments | UserAccessChangeArguments);
+
+type GroupAccessChangeArguments = GrantAppCollaboratorsArgument | GrantEveryoneArgument;
+
+export interface GrantAppCollaboratorsArgument {
+  /** @description Grant access for function specified by `name` to app collaborators. */
+  appCollaborators: true;
+}
+export interface GrantEveryoneArgument {
+  /** @description Grant access for function specified by `name` to everyone. */
+  everyone: true;
+}
+export interface GrantArgument {
+  /** @description Grant access for function specified by `name` to users specified by `users`. */
+  grant: true;
+}
+export interface RevokeArgument {
+  /** @description Revoke access for function specified by `name` to users specified by `users`. */
+  revoke: true;
+}
+
+type UserAccessChangeArguments = {
+  /** @description Array of users to grant or revoke access to. */
+  users: [string, ...string[]];
+} & (RevokeArgument | GrantArgument);
+
+export interface InfoArgument {
+  /** @description Whether to show access information for a function. Supercedes all other arguments. */
+  info: true;
+}
+
+type FunctionAccessArguments = AccessChangeArguments | InfoArgument;
 
 /**
  * `slack function access`
- * @param appPath path to app
- * @param teamFlag team domain for the function's app
- * @param flags specification of function distribution, i.e. --name greeting_function --app-collaborators
  * @returns command output
  */
 export const access = async function functionAccess(
-  appPath: string,
-  teamFlag: string,
-  flags: string,
-  options?: { qa?: boolean },
+  args: ProjectCommandArguments & FunctionAccessArguments,
 ): Promise<string> {
-  // TODO: breaking change, separate params vs single-param-object
-  const cmd = new SlackCLIProcess(`function access ${flags}`, { team: teamFlag, qa: options?.qa });
+  const cmdOpts: SlackCLICommandOptions = {};
+  if (typeof args.info !== 'undefined' || ('info' in args && args.info)) {
+    cmdOpts['--info'] = true;
+  } else {
+    cmdOpts['--name'] = args.name;
+    if ('appCollaborators' in args && args.appCollaborators) {
+      cmdOpts['--app-collaborators'] = true;
+    } else if ('everyone' in args && args.everyone) {
+      cmdOpts['--everyone'] = true;
+    } else if ('users' in args) {
+      cmdOpts['--users'] = args.users.join(',');
+      if ('grant' in args && args.grant) {
+        cmdOpts['--grant'] = true;
+      } else if ('revoke' in args && args.revoke) {
+        cmdOpts['--revoke'] = true;
+      } else {
+        throw new Error('When granting or revoking function access to users, you must specify one of `grant` or `revoke` as `true`.');
+      }
+    } else {
+      throw new Error('When setting function access, you must specify a target for whom to give access to.');
+    }
+  }
+  const cmd = new SlackCLIProcess('function access', args, cmdOpts);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
-// TODO: (breaking change): rename properties of this default export to match actual command names
 export default {
-  functionDistribute: access, // TODO: brekaing change remove this, is now called 'function access'
-  functionAccess: access,
+  access,
 };

--- a/packages/cli-test/src/cli/commands/manifest.spec.ts
+++ b/packages/cli-test/src/cli/commands/manifest.spec.ts
@@ -1,0 +1,43 @@
+import sinon from 'sinon';
+
+import manifest from './manifest';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('manifest commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('info method', () => {
+    it('should invoke `manifest info` and default `--source project`', async () => {
+      await manifest.info({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('manifest info'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--source project'));
+    });
+    it('should invoke `manifest info --source remote` source=remote specified', async () => {
+      await manifest.info({ appPath: '/some/path', source: 'remote' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('manifest info'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--source remote'));
+    });
+  });
+  describe('validate method', () => {
+    it('should invoke `manifest validate`', async () => {
+      await manifest.validate({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('manifest validate'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/manifest.ts
+++ b/packages/cli-test/src/cli/commands/manifest.ts
@@ -1,23 +1,39 @@
-import { SlackCLIProcess } from '../cli-process';
+import { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
 
 /**
- * `slack manifest validate`
- * @param appPath path to app
+ * `slack manifest info`
  * @returns command output
  */
-export const validate = async function manifestValidate(
-  appPath: string,
-  options?: { qa?: boolean },
-): Promise<string> {
-  // TODO: breaking change, separate params vs single-param-object
-  const cmd = new SlackCLIProcess('manifest validate', options);
+export const info = async function manifestInfo(args: ProjectCommandArguments & {
+  /**
+   * @description Whether to retrieve manifest from the local `project`, or `remote` from Slack. Defaults to `project`.
+   */
+  source?: 'project' | 'remote';
+}): Promise<string> {
+  const cmdOpts: SlackCLICommandOptions = {
+    '--source': args.source || 'project',
+  };
+  const cmd = new SlackCLIProcess('manifest info', args, cmdOpts);
   const proc = await cmd.execAsync({
-    cwd: appPath,
+    cwd: args.appPath,
   });
   return proc.output;
 };
 
-// TODO: (breaking change): rename properties of this default export to match actual command names
+/**
+ * `slack manifest validate`
+ * @returns command output
+ */
+export const validate = async function manifestValidate(args: ProjectCommandArguments): Promise<string> {
+  const cmd = new SlackCLIProcess('manifest validate', args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
 export default {
-  manifestValidate: validate,
+  info,
+  validate,
 };

--- a/packages/cli-test/src/cli/commands/platform.spec.ts
+++ b/packages/cli-test/src/cli/commands/platform.spec.ts
@@ -1,0 +1,115 @@
+import assert from 'assert';
+
+import sinon from 'sinon';
+
+import platform from './platform';
+import { ShellProcess } from '../../types/shell';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('platform commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+  let waitForOutputSpy: sinon.SinonStub;
+  let fakeProcess: ShellProcess;
+
+  beforeEach(() => {
+    fakeProcess = {
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process: mockProcess(),
+    };
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns(fakeProcess);
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+    waitForOutputSpy = sandbox.stub(shell, 'waitForOutput').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('activity method', () => {
+    it('should invoke `activity`', async () => {
+      await platform.activity({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('activity'));
+    });
+    it('should invoke `activity` with specified `source`', async () => {
+      await platform.activity({ appPath: '/some/path', source: 'slack' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('activity'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--source slack'));
+    });
+  });
+  describe('activityTailStart method', () => {
+    it('should invoke `activity --tail`', async () => {
+      await platform.activityTailStart({ appPath: '/some/path', stringToWaitFor: 'poop' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('activity'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--tail'));
+    });
+  });
+  describe('activityTailStop method', () => {
+    it('should reject if waitForOutput rejects', async () => {
+      waitForOutputSpy.rejects();
+      await assert.rejects(platform.activityTailStop({ stringToWaitFor: 'poop', proc: fakeProcess }));
+    });
+    it('should reject if shell.kill rejects', async () => {
+      sandbox.stub(shell, 'kill').rejects();
+      await assert.rejects(platform.activityTailStop({ stringToWaitFor: 'poop', proc: fakeProcess }));
+    });
+    it('should resolve if waitForOutput and shell.kill resolve', async () => {
+      sandbox.stub(shell, 'kill').resolves();
+      await platform.activityTailStop({ stringToWaitFor: 'poop', proc: fakeProcess });
+      assert.ok(true);
+    });
+  });
+  describe('deploy method', () => {
+    it('should invoke `deploy` with --hide-triggers by default', async () => {
+      await platform.deploy({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('deploy'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--hide-triggers'));
+    });
+    it('should invoke `deploy` without --hide-triggers if hideTriggers=false', async () => {
+      await platform.deploy({ appPath: '/some/path', hideTriggers: false });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('deploy'));
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--hide-triggers'));
+    });
+  });
+  describe('runStart method', () => {
+    it('should invoke `run` with --cleanup and --hide-triggers by default', async () => {
+      await platform.runStart({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('run'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--cleanup'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--hide-triggers'));
+    });
+    it('should invoke `run` without --hide-triggers if hideTriggers=false', async () => {
+      await platform.runStart({ appPath: '/some/path', hideTriggers: false });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('run'));
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--hide-triggers'));
+    });
+    it('should invoke `run` without --cleanup if cleanup=false', async () => {
+      await platform.runStart({ appPath: '/some/path', cleanup: false });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('run'));
+      sandbox.assert.neverCalledWith(spawnSpy, sinon.match('--cleanup'));
+    });
+  });
+  describe('runStop method', () => {
+    it('should reject if shell.kill rejects', async () => {
+      sandbox.stub(shell, 'kill').rejects();
+      await assert.rejects(platform.runStop({ proc: fakeProcess }));
+    });
+    it('should reject if waitForShutdown=true and waitForOutput rejects', async () => {
+      sandbox.stub(shell, 'kill').resolves();
+      waitForOutputSpy.rejects();
+      await assert.rejects(platform.runStop({ proc: fakeProcess, waitForShutdown: true }));
+    });
+    it('should resolve immediately if waitForShutdown=false and shell.kill resolve', async () => {
+      sandbox.stub(shell, 'kill').resolves();
+      await platform.runStop({ proc: fakeProcess, waitForShutdown: false });
+      assert.ok(true);
+    });
+    it('should resolve if waitForShutdown=true and both shell.kill and shell.waitForOutput resolve', async () => {
+      sandbox.stub(shell, 'kill').resolves();
+      await platform.runStop({ proc: fakeProcess, waitForShutdown: true });
+      assert.ok(true);
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/platform.ts
+++ b/packages/cli-test/src/cli/commands/platform.ts
@@ -103,6 +103,7 @@ export const runStart = async function runStart(
   args: ProjectCommandArguments & RunDeployArguments,
 ): Promise<ShellProcess> {
   const cmd = new SlackCLIProcess('run', args, {
+    '--app': 'local',
     '--cleanup': typeof args.cleanup !== 'undefined' ? args.cleanup : true,
     '--hide-triggers': typeof args.hideTriggers !== 'undefined' ? args.hideTriggers : true,
     '--org-workspace-grant': args.orgWorkspaceGrantFlag,

--- a/packages/cli-test/src/cli/commands/platform.ts
+++ b/packages/cli-test/src/cli/commands/platform.ts
@@ -1,4 +1,4 @@
-import { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import { ProjectCommandArguments, WorkspaceGrantArgument } from '../../types/commands/common_arguments';
 import { SlackTracerId } from '../../utils/constants';
 import logger from '../../utils/logger';
 import { SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
@@ -16,14 +16,9 @@ export interface ProcessArgument {
   proc: ShellProcess;
 }
 
-export interface RunDeployArguments {
+export interface RunDeployArguments extends WorkspaceGrantArgument {
   /** @description Hides output and prompts related to triggers. Defaults to `true`. */
   hideTriggers?: boolean;
-  /**
-   * @description Org workspace ID, or the string `all` to request access to all workspaces in the org,
-   * to request grant access to in AAA scenarios
-   */
-  orgWorkspaceGrantFlag?: string;
   /** @description Delete the app after `run` process finishes. Defaults to `true`. */
   cleanup?: boolean;
 }

--- a/packages/cli-test/src/cli/commands/platform.ts
+++ b/packages/cli-test/src/cli/commands/platform.ts
@@ -3,7 +3,7 @@ import logger from '../../utils/logger';
 import { SlackCLIProcess } from '../cli-process';
 import { shell } from '../shell';
 
-import type { ShellProcess } from '../../utils/types';
+import type { ShellProcess } from '../../types/shell';
 
 // TODO: the options for these methods could be DRYed up
 

--- a/packages/cli-test/src/cli/commands/platform.ts
+++ b/packages/cli-test/src/cli/commands/platform.ts
@@ -123,7 +123,10 @@ export const runStart = async function runStart(
  * @param teamName to check that app was deleted from that team
  */
 export const runStop = async function runStop(args: ProcessArgument & {
-  /** @description Should wait for the `run` process to spin down before exiting this function. */
+  /**
+   * @description Should wait for the `run` process to spin down before exiting this function.
+   * On Windows, this property is always set to `true`. Defaults to `false`.
+   */
   waitForShutdown?: boolean;
 }): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/packages/cli-test/src/cli/commands/trigger.spec.ts
+++ b/packages/cli-test/src/cli/commands/trigger.spec.ts
@@ -1,0 +1,171 @@
+import sinon from 'sinon';
+
+import trigger from './trigger';
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+
+describe('trigger commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('access method', () => {
+    it('should invoke `trigger access --info` if info=true', async () => {
+      await trigger.access({ appPath: '/some/path', info: true, triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--info'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger access --app-collaborators` if `appCollaborators` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', appCollaborators: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--app-collaborators'));
+    });
+    it('should invoke `trigger access --everyone` if `everyone` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', everyone: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--everyone'));
+    });
+    it('should invoke `trigger access --grant --users` if `grant` and `users` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', grant: true, users: ['U1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--grant'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--users U1234'));
+    });
+    it('should invoke `trigger access --revoke --users` if `revoke` and `users` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', revoke: true, users: ['U1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--revoke'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--users U1234'));
+    });
+    it('should invoke `trigger access --grant --channels` if `grant` and `channels` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', grant: true, channels: ['C1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--grant'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--channels C1234'));
+    });
+    it('should invoke `trigger access --revoke --channels` if `revoke` and `channels` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', revoke: true, channels: ['C1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--revoke'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--channels C1234'));
+    });
+    it('should invoke `trigger access --grant --organizations` if `grant` and `organizations` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', grant: true, organizations: ['E1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--grant'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--organizations E1234'));
+    });
+    it('should invoke `trigger access --revoke --organizations` if `revoke` and `organizations` specified', async () => {
+      await trigger.access({ appPath: '/some/path', triggerId: 'T1234', revoke: true, organizations: ['E1234'] });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger access'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--revoke'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--organizations E1234'));
+    });
+  });
+  describe('create method', () => {
+    it('should invoke `trigger create --trigger-def` if triggerDef specified', async () => {
+      await trigger.create({ appPath: '/some/path', triggerDef: 'some/file.json' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger create'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-def some/file.json'));
+    });
+    it('should invoke `trigger create --workflow --title` if workflow specified', async () => {
+      await trigger.create({ appPath: '/some/path', workflow: 'some#/callback_id', title: 'Title' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger create'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--title Title'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--workflow some#/callback_id'));
+    });
+    it('should invoke `trigger create --description` if description specified', async () => {
+      await trigger.create({ appPath: '/some/path', workflow: 'some#/callback_id', title: 'Title', description: 'test' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger create'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--description test'));
+    });
+    it('should invoke `trigger create --interactivity` if interactivity specified', async () => {
+      await trigger.create({ appPath: '/some/path', workflow: 'some#/callback_id', title: 'Title', interactivity: true, interactivityName: 'test' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger create'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--interactivity'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--interactivity-name test'));
+    });
+  });
+  describe('delete method', () => {
+    it('should invoke `trigger delete --trigger-id`', async () => {
+      await trigger.delete({ appPath: '/some/path', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger delete'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+  });
+  describe('info method', () => {
+    it('should invoke `trigger info --trigger-id`', async () => {
+      await trigger.info({ appPath: '/some/path', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger info'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+  });
+  describe('list method', () => {
+    it('should invoke `trigger list`', async () => {
+      await trigger.list({ appPath: '/some/path' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger list'));
+    });
+    it('should invoke `trigger list --limit` if limit specified', async () => {
+      await trigger.list({ appPath: '/some/path', limit: 10 });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger list'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--limit 10'));
+    });
+    it('should invoke `trigger list --type` if type specified', async () => {
+      await trigger.list({ appPath: '/some/path', type: 'event' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger list'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--type event'));
+    });
+  });
+  describe('update method', () => {
+    it('should invoke `trigger update --trigger-def` if triggerDef specified', async () => {
+      await trigger.update({ appPath: '/some/path', triggerDef: 'some/file.json', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-def some/file.json'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger update --workflow` if workflow specified', async () => {
+      await trigger.update({ appPath: '/some/path', workflow: 'some#/callback_id', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--workflow some#/callback_id'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger update --title` if title specified', async () => {
+      await trigger.update({ appPath: '/some/path', title: 'something', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--title something'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger update --description` if description specified', async () => {
+      await trigger.update({ appPath: '/some/path', description: 'test', triggerId: 'T1234' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--description test'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger update --interactivity` if interactivity specified', async () => {
+      await trigger.update({ appPath: '/some/path', triggerId: 'T1234', interactivity: true });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--interactivity'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+    it('should invoke `trigger update --interactivity-name` if interactivityName specified', async () => {
+      await trigger.update({ appPath: '/some/path', triggerId: 'T1234', interactivityName: 'poop' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match('trigger update'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--interactivity-name poop'));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('--trigger-id T1234'));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/index.spec.ts
+++ b/packages/cli-test/src/cli/index.spec.ts
@@ -10,7 +10,7 @@ describe('cli module', () => {
   let deleteSpy: sinon.SinonStub;
 
   beforeEach(() => {
-    logoutSpy = sandbox.stub(SlackCLI, 'logout').resolves();
+    logoutSpy = sandbox.stub(SlackCLI.auth, 'logout').resolves();
     warnSpy = sandbox.stub(logger, 'warn');
     sandbox.stub(SlackCLI.app, 'list').resolves('This thing has so many apps you would not believe');
     deleteSpy = sandbox.stub(SlackCLI.app, 'delete').resolves();

--- a/packages/cli-test/src/cli/index.spec.ts
+++ b/packages/cli-test/src/cli/index.spec.ts
@@ -20,22 +20,22 @@ describe('cli module', () => {
   });
 
   describe('stopSession method', () => {
-    it('should invoke logout', async () => {
-      await SlackCLI.stopSession({ appTeamID: 'T123' });
+    it('should invoke logout if `shouldLogOut` is truthy', async () => {
+      await SlackCLI.stopSession({ team: 'T123', shouldLogOut: true });
       sandbox.assert.called(logoutSpy);
     });
     it('should warn if logout failed', async () => {
       logoutSpy.rejects('boomsies');
-      await SlackCLI.stopSession({ appTeamID: 'T123' });
+      await SlackCLI.stopSession({ team: 'T123', shouldLogOut: true });
       sandbox.assert.calledWithMatch(warnSpy, 'boomsies');
     });
     it('should attempt to delete app if appPath is provided', async () => {
-      await SlackCLI.stopSession({ appTeamID: 'T123', appPath: '/some/path' });
+      await SlackCLI.stopSession({ team: 'T123', appPath: '/some/path' });
       sandbox.assert.called(deleteSpy);
     });
     it('should warn if app deletion fails', async () => {
       deleteSpy.rejects('explosions');
-      await SlackCLI.stopSession({ appTeamID: 'T123', appPath: '/some/path' });
+      await SlackCLI.stopSession({ team: 'T123', appPath: '/some/path' });
       sandbox.assert.calledWithMatch(warnSpy, 'explosions');
     });
   });

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -17,15 +17,8 @@ import logger from '../utils/logger';
  * Set of functions to spawn and interact with Slack Platform CLI processes and commands
  */
 export const SlackCLI = {
-  ...appCommands,
-  app: {
-    delete: appCommands.workspaceDelete,
-    install: appCommands.workspaceInstall,
-    list: appCommands.workspaceList,
-  },
-  ...authCommands,
+  app: appCommands,
   auth: authCommands,
-  ...collaboratorCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
   collaborators: {
     add: collaboratorCommands.collaboratorsAdd,
     list: collaboratorCommands.collaboratorsList,
@@ -84,12 +77,12 @@ export const SlackCLI = {
     // TODO: perhaps appPath does not exist, should guard against that.
     if (appPath) {
       // List instances of app installation if app path provided
-      const installedAppsOutput = await SlackCLI.app.list(appPath, { qa });
+      const installedAppsOutput = await SlackCLI.app.list({ appPath, qa });
       // If app is installed
       if (!installedAppsOutput.includes('This project has no apps')) {
         // Soft app delete
         try {
-          await SlackCLI.app.delete(appPath, appTeamID, { isLocalApp, qa });
+          await SlackCLI.app.delete({ appPath, team: appTeamID, qa, app: isLocalApp ? 'local' : 'deployed' });
         } catch (error) {
           logger.warn(`stopSession could not delete app gracefully, continuing. Error: ${error}`);
         }
@@ -104,7 +97,7 @@ export const SlackCLI = {
 
     if (shouldLogOut) {
       try {
-        await SlackCLI.logout({ teamFlag: appTeamID, qa });
+        await SlackCLI.auth.logout({ team: appTeamID, qa });
       } catch (error) {
         // TODO: maybe should error instead? this seems pretty bad
         logger.warn(`Could not logout gracefully. Error: ${error}`);

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import appCommands from './commands/app';
-import authCommands from './commands/auth';
-import collaboratorCommands from './commands/collaborator';
+import app from './commands/app';
+import auth from './commands/auth';
+import collaborator from './commands/collaborator';
 import createCommands from './commands/create';
 import envCommands from './commands/env';
 import externalAuthCommands from './commands/external-auth';
@@ -17,13 +17,9 @@ import logger from '../utils/logger';
  * Set of functions to spawn and interact with Slack Platform CLI processes and commands
  */
 export const SlackCLI = {
-  app: appCommands,
-  auth: authCommands,
-  collaborators: {
-    add: collaboratorCommands.collaboratorsAdd,
-    list: collaboratorCommands.collaboratorsList,
-    remove: collaboratorCommands.collaboratorsRemove,
-  },
+  app,
+  auth,
+  collaborator,
   ...createCommands,
   ...envCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
   env: {

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -1,16 +1,17 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import app from './commands/app';
 import auth from './commands/auth';
 import collaborator from './commands/collaborator';
-import createCommands from './commands/create';
-import envCommands from './commands/env';
-import externalAuthCommands from './commands/external-auth';
-import functionCommands from './commands/function';
-import manifestCommands from './commands/manifest';
+import { create } from './commands/create';
+import env from './commands/env';
+import externalAuth from './commands/external-auth';
+import func from './commands/function';
+import manifest from './commands/manifest';
 import platformCommands from './commands/platform';
 import triggerCommands from './commands/trigger';
+import { ProjectCommandArguments } from '../types/commands/common_arguments';
 import logger from '../utils/logger';
 
 /**
@@ -20,22 +21,11 @@ export const SlackCLI = {
   app,
   auth,
   collaborator,
-  ...createCommands,
-  ...envCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
-  env: {
-    add: envCommands.envAdd,
-    list: envCommands.envList,
-    remove: envCommands.envRemove,
-  },
-  ...externalAuthCommands,
-  ...functionCommands,
-  function: {
-    access: functionCommands.functionAccess,
-  },
-  ...manifestCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
-  manifest: {
-    validate: manifestCommands.manifestValidate,
-  },
+  create,
+  env,
+  externalAuth,
+  function: func,
+  manifest,
   ...platformCommands,
   platform: platformCommands,
   ...triggerCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
@@ -52,50 +42,40 @@ export const SlackCLI = {
    * Delete app and Log out of current team session
    * @param options
    */
-  stopSession: async function stopSession({
-    appPath,
-    appTeamID,
-    shouldLogOut = true,
-    isLocalApp,
-    qa,
-  }: {
-    // TODO: (breaking change) model these types better, if appPath isn't provided then appTeamId
-    // and isLocalApp are not needed either
-    /** Path to app. If not provided, will not interact with any app */
-    appPath?: string;
-    /** Team domain or ID where app is installed */
-    appTeamID: string;
+  stopSession: async function stopSession(args: Partial<ProjectCommandArguments> & {
     /** Should the CLI log out of its session with the team specified by `appTeamID`. Defaults to `true` */
     shouldLogOut?: boolean;
-    isLocalApp?: boolean;
-    qa?: boolean;
   }): Promise<void> {
-    // TODO: perhaps appPath does not exist, should guard against that.
-    if (appPath) {
+    if (args.appPath) {
       // List instances of app installation if app path provided
-      const installedAppsOutput = await SlackCLI.app.list({ appPath, qa });
+      const installedAppsOutput = await SlackCLI.app.list({
+        ...args,
+        appPath: args.appPath!, // very dumb https://github.com/microsoft/TypeScript/issues/42384#issuecomment-872906445
+      });
       // If app is installed
       if (!installedAppsOutput.includes('This project has no apps')) {
         // Soft app delete
         try {
-          await SlackCLI.app.delete({ appPath, team: appTeamID, qa, app: isLocalApp ? 'local' : 'deployed' });
+          await SlackCLI.app.delete({
+            ...args,
+            appPath: args.appPath!, // same crap https://github.com/microsoft/TypeScript/issues/42384#issuecomment-872906445
+          });
         } catch (error) {
           logger.warn(`stopSession could not delete app gracefully, continuing. Error: ${error}`);
         }
 
         // Delete app.json file. Needed for retries. Otherwise asks for collaborator, if old file is present
-        fs.rmSync(path.join(appPath, '.slack'), {
+        fs.rmSync(path.join(args.appPath, '.slack'), {
           force: true,
           recursive: true,
         });
       }
     }
 
-    if (shouldLogOut) {
+    if (args.shouldLogOut) {
       try {
-        await SlackCLI.auth.logout({ team: appTeamID, qa });
+        await SlackCLI.auth.logout(args);
       } catch (error) {
-        // TODO: maybe should error instead? this seems pretty bad
         logger.warn(`Could not logout gracefully. Error: ${error}`);
       }
     }

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -9,8 +9,8 @@ import env from './commands/env';
 import externalAuth from './commands/external-auth';
 import func from './commands/function';
 import manifest from './commands/manifest';
-import platformCommands from './commands/platform';
-import triggerCommands from './commands/trigger';
+import platform from './commands/platform';
+import trigger from './commands/trigger';
 import { ProjectCommandArguments } from '../types/commands/common_arguments';
 import logger from '../utils/logger';
 
@@ -26,17 +26,8 @@ export const SlackCLI = {
   externalAuth,
   function: func,
   manifest,
-  ...platformCommands,
-  platform: platformCommands,
-  ...triggerCommands, // TODO: (breaking change) remove, mimic same 'namespacing' as the actual CLI
-  trigger: {
-    access: triggerCommands.triggerAccess,
-    create: triggerCommands.triggerCreate,
-    delete: triggerCommands.triggerDelete,
-    info: triggerCommands.triggerInfo,
-    list: triggerCommands.triggerList,
-    update: triggerCommands.triggerUpdate,
-  },
+  platform,
+  trigger,
 
   /**
    * Delete app and Log out of current team session

--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -1,11 +1,10 @@
 import child from 'child_process';
-import EventEmitter from 'events';
-import stream from 'stream';
 
 import { assert } from 'chai';
 import sinon from 'sinon';
 
 import { shell } from './shell';
+import { mockProcess } from '../utils/test';
 
 import type { ShellProcess } from '../types/shell';
 
@@ -17,10 +16,7 @@ describe('shell module', () => {
   let runOutput: child.SpawnSyncReturns<Buffer>;
 
   beforeEach(() => {
-    spawnProcess = new EventEmitter() as child.ChildProcessWithoutNullStreams;
-    spawnProcess.stdout = new EventEmitter() as stream.Readable;
-    spawnProcess.stderr = new EventEmitter() as stream.Readable;
-    spawnProcess.stdin = new stream.Writable();
+    spawnProcess = mockProcess();
     spawnSpy = sandbox.stub(child, 'spawn').returns(spawnProcess);
     runOutput = { pid: 1337, output: [], stdout: Buffer.from([]), stderr: Buffer.from([]), status: 0, signal: null };
     runSpy = sandbox.stub(child, 'spawnSync').returns(runOutput);

--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 
 import { shell } from './shell';
 
-import type { ShellProcess } from '../utils/types';
+import type { ShellProcess } from '../types/shell';
 
 describe('shell module', () => {
   const sandbox = sinon.createSandbox();

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -5,7 +5,7 @@ import treekill from 'tree-kill';
 import { timeouts } from '../utils/constants';
 import logger from '../utils/logger';
 
-import type { ShellProcess } from '../utils/types';
+import type { ShellProcess } from '../types/shell';
 
 export const shell = {
   /**

--- a/packages/cli-test/src/types/commands/common_arguments.ts
+++ b/packages/cli-test/src/types/commands/common_arguments.ts
@@ -7,3 +7,62 @@ export interface ProjectCommandArguments extends SlackCLIGlobalOptions {
    */
   appPath: string;
 }
+
+export interface WorkspaceGrantArgument {
+  /**
+   * @description Org workspace ID, or the string `all` to request access to all workspaces in the org,
+   * to request grant access to in AAA scenarios
+   */
+  orgWorkspaceGrantFlag?: string;
+}
+
+// Various access-modification arguments (applies to `function access` and `trigger access` calls.
+/**
+ * @description Single-shot grant-to-group access change arguments.
+ * @example `appCollaborators: true`, or `everyone: true`
+ */
+export type GroupAccessChangeArguments = GrantAppCollaboratorsArgument | GrantEveryoneArgument;
+
+interface GrantAppCollaboratorsArgument {
+  /** @description Grant access for function specified by `name` to app collaborators. */
+  appCollaborators: true;
+}
+interface GrantEveryoneArgument {
+  /** @description Grant access for function specified by `name` to everyone. */
+  everyone: true;
+}
+interface GrantArgument {
+  /** @description Grant access for function specified by `name` to users specified by `users`. */
+  grant: true;
+}
+interface RevokeArgument {
+  /** @description Revoke access for function specified by `name` to users specified by `users`. */
+  revoke: true;
+}
+
+/**
+ * @description Grant/revoke user access arguments.
+ */
+export type UserAccessChangeArguments = {
+  /** @description Array of user IDs to grant or revoke access to. */
+  users: [string, ...string[]];
+} & (RevokeArgument | GrantArgument);
+/**
+ * @description Grant/revoke user access arguments.
+ */
+export type ChannelAccessChangeArguments = {
+  /** @description Array of channel IDs to grant or revoke access to. */
+  channels: [string, ...string[]];
+} & (RevokeArgument | GrantArgument);
+/**
+ * @description Grant/revoke organization access arguments.
+ */
+export type OrganizationAccessChangeArguments = {
+  /** @description Array of organization IDs to grant or revoke access to. */
+  organizations: [string, ...string[]];
+} & (RevokeArgument | GrantArgument);
+
+export interface InfoArgument {
+  /** @description Whether to show access information. Supercedes all other arguments. */
+  info: true;
+}

--- a/packages/cli-test/src/types/commands/common_arguments.ts
+++ b/packages/cli-test/src/types/commands/common_arguments.ts
@@ -1,0 +1,9 @@
+import type { SlackCLIGlobalOptions } from '../../cli/cli-process';
+
+export interface ProjectCommandArguments extends SlackCLIGlobalOptions {
+  /**
+   * @description Path to the Slack CLI-generated application to run the command in.
+   * Sets the `cwd` on the shell process executing the CLI.
+   */
+  appPath: string;
+}

--- a/packages/cli-test/src/types/shell.ts
+++ b/packages/cli-test/src/types/shell.ts
@@ -1,14 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 
-export const SlackProduct = {
-  FREE: 'FREE',
-  PRO: 'PRO',
-  BUSINESS_PLUS: 'PLUS',
-  ENTERPRISE: 'ENTERPRISE',
-  ENTERPRISE_SANDBOX: 'ENTERPRISE_SANDBOX',
-  ENTERPRISE_SELECT: 'ENTERPRISE_SELECT',
-};
-
 export interface ShellProcess {
   /**
    * Child process object

--- a/packages/cli-test/src/utils/test.ts
+++ b/packages/cli-test/src/utils/test.ts
@@ -1,0 +1,11 @@
+import child from 'child_process';
+import EventEmitter from 'events';
+import stream from 'stream';
+
+export function mockProcess(): child.ChildProcessWithoutNullStreams {
+  const spawnProcess = new EventEmitter() as child.ChildProcessWithoutNullStreams;
+  spawnProcess.stdout = new EventEmitter() as stream.Readable;
+  spawnProcess.stderr = new EventEmitter() as stream.Readable;
+  spawnProcess.stdin = new stream.Writable();
+  return spawnProcess;
+}


### PR DESCRIPTION
This PR changes all the function signatures to to be consistent. It also factors out types for arguments where possible, and exhaustively types individual properties representing each CLI command's different options.

Unit test coverage was added for the commands, bringing the module coverage up close to 100%.

# Review Guidance

In depth reviewing of all the `src/cli/commands` files is likely not needed (unless you want to see the detailed changes). Commands were changed in relatively uniform ways:

- All commands now accept a single object argument, almost all of which extend from `ProjectCommandArguments`, which itself is just `SlackCLIGlobalOptions` + an `appPath` argument that points to the location of the app project on the filesystem.
- Individual command methods delegate most of the work to the `SlackCLIProcess` class (`src/cli/cli-process.ts`). This class manages assembling the CLI invocation command string and parses global options.
  - Most command methods chiefly deal in parsing command-specific arguments into command-specific CLI flags.

However, please look at the `src/cli/cli-process.ts` file - do the global option names make sense? I left a comment in this file about the naming of the `instance` property, which maps to `--app` on the CLI - I wonder if it should just be named the same as the flag, but `app` is such a vague property name that I decided to change it to `instance`.