### PR TITLE
chore: try latest version of node 22 for CI, fixes codecov

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.4.x]
+        node-version: [18.x, 20.x, 22.x]
         package:
           - cli-hooks
           - cli-test


### PR DESCRIPTION
We had to lock to node 22.4.x due to an issue in 22.5, but since then 22.5.1 and 22.6 have been released.

The change to lock to 22.4.x also broke codecov reporting, since the node version in the matrix and the codecov upload step coverage report existence check didn't match 😬 

Let's see how this does!