### PR TITLE
web-api(fix): allow typed token overrides in supported methods

### DIFF
--- a/packages/web-api/src/types/request/admin/apps.ts
+++ b/packages/web-api/src/types/request/admin/apps.ts
@@ -59,7 +59,7 @@ export type AdminAppsApprovedListArguments = Partial<TeamOrEnterpriseID> & Token
 & Certified;
 
 // https://api.slack.com/methods/admin.apps.clearResolution
-export type AdminAppsClearResolutionArguments = AppID & TeamOrEnterpriseID;
+export type AdminAppsClearResolutionArguments = AppID & TeamOrEnterpriseID & TokenOverridable;
 
 // https://api.slack.com/methods/admin.apps.config.lookup
 export interface AdminAppsConfigLookupArguments extends TokenOverridable {
@@ -95,4 +95,4 @@ export type AdminAppsRestrictedListArguments = TeamOrEnterpriseID & Certified & 
 & CursorPaginationEnabled;
 
 // https://api.slack.com/methods/admin.apps.uninstall
-export type AdminAppsUninstallArguments = AppID & TeamOrEnterpriseID;
+export type AdminAppsUninstallArguments = AppID & TeamOrEnterpriseID & TokenOverridable;

--- a/packages/web-api/src/types/request/apps.ts
+++ b/packages/web-api/src/types/request/apps.ts
@@ -34,4 +34,4 @@ export interface AppsManifestValidateArguments extends Partial<AppID>, TokenOver
 }
 
 // https://api.slack.com/methods/apps.uninstall
-export interface AppsUninstallArguments extends Pick<OAuthCredentials, 'client_id' | 'client_secret'> {}
+export interface AppsUninstallArguments extends Pick<OAuthCredentials, 'client_id' | 'client_secret'>, TokenOverridable {}

--- a/packages/web-api/test/types/methods/admin.apps.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.apps.test-d.ts
@@ -91,6 +91,16 @@ expectAssignable<Parameters<typeof web.admin.apps.clearResolution>>([{
   team_id: 'T1234',
 }]);
 expectAssignable<Parameters<typeof web.admin.apps.clearResolution>>([{
+  token: 'xoxp-example',
+  app_id: 'A1234',
+  team_id: 'T1234',
+}]);
+expectAssignable<Parameters<typeof web.admin.apps.clearResolution>>([{
+  app_id: 'A1234',
+  enterprise_id: 'E1234',
+}]);
+expectAssignable<Parameters<typeof web.admin.apps.clearResolution>>([{
+  token: 'xoxp-example',
   app_id: 'A1234',
   enterprise_id: 'E1234',
 }]);
@@ -239,6 +249,16 @@ expectAssignable<Parameters<typeof web.admin.apps.uninstall>>([{
   team_id: 'T1234',
 }]);
 expectAssignable<Parameters<typeof web.admin.apps.uninstall>>([{
+  token: 'xoxp-example',
+  app_id: 'A1234',
+  team_id: 'T1234',
+}]);
+expectAssignable<Parameters<typeof web.admin.apps.uninstall>>([{
+  app_id: 'A1234',
+  enterprise_id: 'E1234',
+}]);
+expectAssignable<Parameters<typeof web.admin.apps.uninstall>>([{
+  token: 'xoxp-example',
   app_id: 'A1234',
   enterprise_id: 'E1234',
 }]);

--- a/packages/web-api/test/types/methods/apps.test-d.ts
+++ b/packages/web-api/test/types/methods/apps.test-d.ts
@@ -101,3 +101,8 @@ expectAssignable<Parameters<typeof web.apps.uninstall>>([{
   client_id: '1234.56',
   client_secret: 'ABC123',
 }]);
+expectAssignable<Parameters<typeof web.apps.uninstall>>([{
+  token: 'xoxb-example',
+  client_id: '1234.56',
+  client_secret: 'ABC123',
+}]);


### PR DESCRIPTION
### Summary

Fixes #1871 and allows token overrides with a few other methods to match the documented arguments:

- admins.apps.clearResolution
- admin.apps.uninstall
- apps.uninstall

### Reviewers

Confirm this builds without errors in a TypeScript application:

```ts
client.apps.uninstall({
  token: 'xoxb-example',
  client_id: 'example',
  client_secret: '123',
});
```

```sh
$ npx tsc
```

### Notes

⚠️ Please let me know if these weren't included on purpose! It raised some suspicion that both `uninstall` methods didn't include `token` but I believe it's alright to include as an argument.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
