### PR TITLE
socket-mode(build): use a minimum version of web-api@7.3.4

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.0.1",
+    "@slack/web-api": "^7",
     "@types/node": ">=18",
     "@types/ws": "^8",
     "eventemitter3": "^5",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7",
+    "@slack/web-api": "^7.3.4",
     "@types/node": ">=18",
     "@types/ws": "^8",
     "eventemitter3": "^5",


### PR DESCRIPTION
###  Summary

This PR uses the latest version of `@slack/web-api@7` to support the most recent releases without worries of bumping the minor and patch numbers or confusion with past numbers.

### Notes

Noticed this pattern in a casual inspection of [the `@slack/oauth` packages](https://github.com/slackapi/node-slack-sdk/blob/7c2cfdcb50c09bdb07f26deb12c773ee70cfbb17/packages/oauth/package.json#L42-L43) and am thinking it's good to use here too!

Had to dig a bit to confirm this, but running `npm update` in projects using `@slack/socket-mode` should bump `@slack/web-api` to the latest `7.b.c` or whatever's specified otherwise. [Docs on how dependencies update are here](https://docs.npmjs.com/cli/v7/commands/npm-update?v=true#subdependencies) 📚 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
