### PR TITLE
webhook(chore): bump axios to 1.7.4 to address CVE-2024-39338

### DIFF
--- a/packages/interactive-messages/package.json
+++ b/packages/interactive-messages/package.json
@@ -58,7 +58,7 @@
     "@types/lodash.isregexp": "^4.0.6",
     "@types/lodash.isstring": "^4.0.6",
     "@types/node": ">=12.0.0",
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "debug": "^3.1.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isplainobject": "^4.0.6",

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
-    "axios": "^1.6.3"
+    "axios": "^1.7.4"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.38.0",


### PR DESCRIPTION
### Summary

This PR bumps `axios` to 1.7.4 to address CVE-2024-39338 following #1874 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
