### PR TITLE
web-api@6(chore): bump axios to 1.7.4 to address CVE-2024-39338

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -50,7 +50,7 @@
     "@slack/types": "^2.11.0",
     "@types/is-stream": "^1.1.0",
     "@types/node": ">=12.0.0",
-    "axios": "^1.6.5",
+    "axios": "^1.7.4",
     "eventemitter3": "^3.1.0",
     "form-data": "^2.5.0",
     "is-electron": "2.2.2",


### PR DESCRIPTION
###  Summary

This PR backports the axios bump to 1.7.4 to address https://github.com/advisories/GHSA-8hc4-vh64-cxmj following https://github.com/slackapi/node-slack-sdk/issues/1874

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
