### PR TITLE
web-api@6(chore): release @slack/web-api@6.12.1

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
###  Summary

This PR tags `@slack/web-api@6.12.1` with the latest changes on `web-api-6.x` 🚀 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
