### PR TITLE
socket-mode@1(chore): bump @slack/web-api to ^6.12.1 to address CVE-2024-39338

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/web-api": "^6.11.2",
+    "@slack/web-api": "^6.12.1",
     "@types/node": ">=12.0.0",
     "@types/ws": "^7.4.7",
     "eventemitter3": "^5",


### PR DESCRIPTION
### Summary

This PR backports a [`@slack/web-api@^6.12.1` bump](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.12.1) to `@slack/socket-mode@1.3.x` to address CVE-2024-39338.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
