### PR TITLE
socket-mode(chore): release @slack/socket-mode@1.3.6

### DIFF
--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
### Summary

This PR tags the `@slack/socket-mode@1.3.6` release to backport security fixes in [`@slack/web-api@6.12.1`](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.12.1).

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
