### PR TITLE
oauth(build): use a minimum version of @slack/web-api@6.12.1

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/web-api": "^6.11.2",
+    "@slack/web-api": "^6.12.1",
     "@types/jsonwebtoken": "^8.3.7",
     "@types/node": ">=12",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
### Summary

This PR backports a [`@slack/web-api@^6.12.1` bump](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.12.1) to `@slack/oauth@2.x` to address CVE-2024-39338.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
