### PR TITLE
oauth(build): use a minimum version of @slack/web-api@7.3.4

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7",
+    "@slack/web-api": "^7.3.4",
     "@types/jsonwebtoken": "^9",
     "@types/node": ">=18",
     "jsonwebtoken": "^9",


### PR DESCRIPTION
### Summary

This PR sets the minimum version of `@slack/web-api` to `7.3.4` to address [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj). Follows #1878.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
