### PR TITLE
web-api(docs): include updated required packages in the oidc example

### DIFF
--- a/examples/openid-connect/package.json
+++ b/examples/openid-connect/package.json
@@ -11,7 +11,8 @@
   "repository": "slackapi/node-slack-sdk",
   "dependencies": {
     "@koa/router": "^10.1.0",
-    "jsonwebtoken": "^8.5.1",
+    "@slack/web-api": "^7.3.4",
+    "jsonwebtoken": "^9.0.2",
     "koa": "^2.13.1",
     "uuid": "^8.3.2"
   }


### PR DESCRIPTION
### Summary

This PR includes the `@slack/web-api` package in the OIDC example for use in API calls. Also here is a bump to `jsonwebtoken@9.0.2` to address a security issue.

### Reviewers

Tested this to confirm it works with the [included README steps](https://github.com/slackapi/node-slack-sdk/tree/main/examples/openid-connect#openid-connect-example) - I recommend experiencing OIDC authentication.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
