### PR TITLE
cli-test(feat): expose timeout argument for activity tail and run start/stop methods

### DIFF
--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -89,7 +89,9 @@ export class SlackCLIProcess {
   ): Promise<ShellProcess> {
     const cmd = this.assembleShellInvocation();
     const proc = shell.spawnProcess(cmd, shellOpts);
-    await shell.waitForOutput(output, proc);
+    await shell.waitForOutput(output, proc, {
+      timeout: shellOpts?.timeout,
+    });
     return proc;
   }
 

--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -26,43 +26,7 @@ describe('shell module', () => {
     sandbox.restore();
   });
 
-  describe('spawnProcess method', () => {
-    it('should invoke `assembleShellEnv` and pass as child_process.spawn `env` parameter', () => {
-      const fakeEnv = { HEY: 'yo' };
-      const assembleSpy = sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-      const fakeCmd = 'echo "hi"';
-      shell.spawnProcess(fakeCmd);
-      sandbox.assert.calledOnce(assembleSpy);
-      sandbox.assert.calledWithMatch(spawnSpy, fakeCmd, sinon.match({ shell: true, env: fakeEnv }));
-    });
-    it('should raise bubble error details up', () => {
-      spawnSpy.throws(new Error('this is bat country'));
-      assert.throw(() => {
-        shell.spawnProcess('about to explode');
-      }, /this is bat country/);
-    });
-  });
-
-  describe('runCommandSync method', () => {
-    it('should invoke `assembleShellEnv` and pass as child_process.spawnSync `env` parameter', () => {
-      const fakeEnv = { HEY: 'yo' };
-      const assembleSpy = sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-      const fakeCmd = 'echo "hi"';
-      shell.runCommandSync(fakeCmd);
-      sandbox.assert.calledOnce(assembleSpy);
-      sandbox.assert.calledWithMatch(runSpy, fakeCmd, sinon.match({ shell: true, env: fakeEnv }));
-    });
-    it('should raise bubble error details up', () => {
-      runSpy.throws(new Error('this is bat country'));
-      assert.throw(() => {
-        shell.runCommandSync('about to explode');
-      }, /this is bat country/);
-    });
-  });
-
   describe('checkIfFinished method', () => {
-    beforeEach(() => {
-    });
     it('should resolve if underlying process raises a `close` event', (done) => {
       const proc: ShellProcess = {
         process: spawnProcess,
@@ -87,6 +51,66 @@ describe('shell module', () => {
         done();
       });
       spawnProcess.emit('error', new Error('boom'));
+    });
+  });
+
+  describe('runCommandSync method', () => {
+    it('should invoke `assembleShellEnv` and pass as child_process.spawnSync `env` parameter', () => {
+      const fakeEnv = { HEY: 'yo' };
+      const assembleSpy = sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
+      const fakeCmd = 'echo "hi"';
+      shell.runCommandSync(fakeCmd);
+      sandbox.assert.calledOnce(assembleSpy);
+      sandbox.assert.calledWithMatch(runSpy, fakeCmd, sinon.match({ shell: true, env: fakeEnv }));
+    });
+    it('should raise bubble error details up', () => {
+      runSpy.throws(new Error('this is bat country'));
+      assert.throw(() => {
+        shell.runCommandSync('about to explode');
+      }, /this is bat country/);
+    });
+  });
+
+  describe('spawnProcess method', () => {
+    it('should invoke `assembleShellEnv` and pass as child_process.spawn `env` parameter', () => {
+      const fakeEnv = { HEY: 'yo' };
+      const assembleSpy = sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
+      const fakeCmd = 'echo "hi"';
+      shell.spawnProcess(fakeCmd);
+      sandbox.assert.calledOnce(assembleSpy);
+      sandbox.assert.calledWithMatch(spawnSpy, fakeCmd, sinon.match({ shell: true, env: fakeEnv }));
+    });
+    it('should raise bubble error details up', () => {
+      spawnSpy.throws(new Error('this is bat country'));
+      assert.throw(() => {
+        shell.spawnProcess('about to explode');
+      }, /this is bat country/);
+    });
+  });
+
+  describe('waitForOutput method', () => {
+    it('should use provided timeout parameter', (done) => {
+      const proc: ShellProcess = {
+        process: spawnProcess,
+        output: '',
+        finished: true,
+        command: 'echo "hi"',
+      };
+      shell.waitForOutput('heyo', proc, { timeout: 500 }).then(() => {
+        assert.fail('expected rejection, but got resolution');
+      }, (err) => {
+        assert.include(err.message, 'timed out');
+        done();
+      });
+    });
+    it('should resolve if process includes expected output', async () => {
+      const proc: ShellProcess = {
+        process: spawnProcess,
+        output: 'batman',
+        finished: true,
+        command: 'echo "hi"',
+      };
+      await shell.waitForOutput('bat', proc);
     });
   });
 });

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -173,15 +173,22 @@ export const shell = {
   waitForOutput: async function waitForOutput(
     expString: string,
     proc: ShellProcess,
+    opts?: {
+      /** @description How long to wait for expected output in milliseconds. Defaults to 10 seconds. */
+      timeout?: number;
+    },
   ): Promise<void> {
     const delay = 1000;
+    const timeout = opts?.timeout || timeouts.waitingAction;
     let waitedFor = 0;
     let timedOut = false;
     while (!proc.output.includes(expString)) {
+      console.log('OUTPUT', proc.output);
+      console.log('EXPECTED', expString);
       // eslint-disable-next-line no-await-in-loop
       await this.sleep(delay);
       waitedFor += delay;
-      if (waitedFor > timeouts.waitingAction) {
+      if (waitedFor > timeout) {
         timedOut = true;
         break;
       }

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -183,8 +183,6 @@ export const shell = {
     let waitedFor = 0;
     let timedOut = false;
     while (!proc.output.includes(expString)) {
-      console.log('OUTPUT', proc.output);
-      console.log('EXPECTED', expString);
       // eslint-disable-next-line no-await-in-loop
       await this.sleep(delay);
       waitedFor += delay;


### PR DESCRIPTION
Problematic to not be able to customize the timeout of `run` or `activity --tail`, as the default 10 second timeout can be difficult to manage.