### PR TITLE
logger(docs): include an example setup with some configurations

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -26,10 +26,41 @@ mimics the default node `console` API with three additions:
 - `setLevel(LogLevel)`: sets the `LogLevel` of the logger.
 - `setName(string)`: sets a prefix to display in logs. Useful if you have multiple loggers active.
 
+### Example
+
+This short snippet shows various `Logger` levels and customized labels:
+
+```javascript
+const { ConsoleLogger, LogLevel } = require("@slack/logger");
+
+const logger = new ConsoleLogger();
+
+logger.error("a problem happened");
+logger.warn("might need attention");
+logger.info("take note of this");
+logger.debug("or dig into details");
+
+logger.setName("HAL");
+logger.setLevel(LogLevel.DEBUG);
+
+logger.info("what an observation");
+logger.debug("i am so interested");
+```
+
+When run, messages that match the following values are logged:
+
+```txt
+[ERROR]   a problem happened
+[WARN]   might need attention
+[INFO]   take note of this
+[INFO]  HAL what an observation
+[DEBUG]  HAL i am so interested
+```
+
 ## Getting Help
 
 If you get stuck, we're here to help. The following are the best ways to get assistance working through your issue:
 
-  * [Issue Tracker](http://github.com/slackapi/node-slack-sdk/issues) for questions, feature requests, bug reports and
-    general discussion related to this package. Try searching before you create a new issue.
-  * [Email us](mailto:developers@slack.com) in Slack developer support: `developers@slack.com`
+- [Issue Tracker](http://github.com/slackapi/node-slack-sdk/issues) for questions, feature requests, bug reports and
+  general discussion related to this package. Try searching before you create a new issue.
+- [Email us](mailto:developers@slack.com) in Slack developer support: `developers@slack.com`


### PR DESCRIPTION
### Summary

This PR adds an example to the `@slack/logger` package to showcase a few options 🙏 🌳  

### Preview

[README.md](https://github.com/zimeg/node-slack-sdk/blob/logger-docs-example-snippet/packages/logger/README.md)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
