### PR TITLE
doc: fix typo in web-api.md

### DIFF
--- a/docs/content/packages/web-api.md
+++ b/docs/content/packages/web-api.md
@@ -434,7 +434,7 @@ being able to reach `api.slack.com` and an error in the response from Slack abou
 something that can be resolved with a retry, so it was retried. The invalid token error means that the call isn't going
 to succeed until your app does something differently, so it stops attempting retries.
 
-You might not think 10 reties in 30 minutes is a good policy for your app. No problem, you can set the `retryConfig` to
+You might not think 10 retries in 30 minutes is a good policy for your app. No problem, you can set the `retryConfig` to
 one that works better for you. The `retryPolicies` export contains a few well known options, and you can always write
 your own.
 


### PR DESCRIPTION
### Summary

The following sentence:

> You might not think 10 **reties** in 30 minutes...

Should read:

> You might not think 10 **retries** in 30 minutes...

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
