### PR TITLE
chore: dependabot ignore & grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,14 @@ updates:
       - "/packages/types"
       - "/packages/web-api"
       - "/packages/web-api/test/integration-tests/**"
+    groups:
+      devDependencies:
+        dependency-type: "development"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@typescript-eslint/parser"
+      - dependency-name: "@typescript-eslint/eslint-plugin"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directories:
@@ -24,6 +30,8 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+      slack:
+        patterns:
           - "@slack/*"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Summary

This PR configures dependabot to group dev dependencies and ignores eslint updates

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
