### PR TITLE
`MessageEvent` incorrectly references the Node global MessageEvent type. #2020

### DIFF
--- a/packages/types/src/events/index.ts
+++ b/packages/types/src/events/index.ts
@@ -85,7 +85,6 @@ import type {
 import type { TokensRevokedEvent } from './token';
 import type { UserChangeEvent, UserHuddleChangedEvent, UserProfileChangedEvent, UserStatusChangedEvent } from './user';
 
-export type MessageEvent = AllMessageEvents;
 export * from './app';
 export * from './call';
 export * from './channel';

--- a/packages/types/src/events/message.ts
+++ b/packages/types/src/events/message.ts
@@ -24,6 +24,8 @@ export type AllMessageEvents =
   // | ReminderAddEvent // TODO: missing
   | ThreadBroadcastMessageEvent;
 
+export type MessageEvent = AllMessageEvents;
+
 export interface GenericMessageEvent {
   type: 'message';
   subtype: undefined;


### PR DESCRIPTION
### Summary

This pull request resolves #2020 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
