### PR TITLE
types(test): add a test to not mix up built-in node `MessageEvent` type

### DIFF
--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -49,7 +49,7 @@ export interface Confirm {
  * @description Defines a dialog that adds a confirmation step to interactive elements.
  * @see {@link https://api.slack.com/reference/block-kit/composition-objects#confirm Confirmation dialog object reference}.
  */
-export interface ConfirmationDialog extends Confirm { }
+export interface ConfirmationDialog extends Confirm {}
 
 /**
  * @description Defines when a {@link PlainTextElement} will return a {@link https://api.slack.com/reference/interaction-payloads/block-actions `block_actions` interaction payload}.

--- a/packages/types/src/block-kit/extensions.ts
+++ b/packages/types/src/block-kit/extensions.ts
@@ -15,7 +15,7 @@ export interface Action {
   action_id?: string;
 }
 
-export interface Actionable extends Action { }
+export interface Actionable extends Action {}
 
 export interface Confirmable {
   /**

--- a/packages/types/test/events/message.test-d.ts
+++ b/packages/types/test/events/message.test-d.ts
@@ -1,0 +1,25 @@
+import { expectAssignable } from 'tsd';
+import type { GenericMessageEvent, MessageDeletedEvent, MessageEvent } from '../../src/index';
+
+const anyMessageEvent: GenericMessageEvent = {
+  type: 'message',
+  subtype: undefined,
+  channel_type: 'channel',
+  channel: 'C1234',
+  event_ts: '1234.56',
+  user: 'U1234',
+  ts: '1234.56',
+};
+// don't confuse `MessageEvent` with the built-in node Message event (https://github.com/slackapi/node-slack-sdk/issues/2020)
+const messageDeletedEvent: MessageDeletedEvent = {
+  type: 'message',
+  subtype: 'message_deleted',
+  event_ts: '1234.56',
+  hidden: true,
+  channel: 'C12345',
+  channel_type: 'channel',
+  ts: '1234.56',
+  deleted_ts: '1234.56',
+  previous_message: anyMessageEvent,
+};
+expectAssignable<MessageEvent>(messageDeletedEvent.previous_message);

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -16,9 +16,7 @@
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-      "*": [
-        "./types/*"
-      ]
+      "*": ["./types/*"]
     },
     "esModuleInterop": true
     // Not using this setting because its only used to require the package.json file, and that would change the
@@ -26,12 +24,8 @@
     // to use import instead of require(), but its not worth the tradeoff of restructuring the build (for now).
     // "resolveJsonModule": true,
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/**/*.spec.*"
-  ],
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.*"],
   "jsdoc": {
     "out": "support/jsdoc",
     "access": "public"


### PR DESCRIPTION
because we also have an identically-named Slack `MessageEvent` type. This is a test that relates to #2020 and augments #2021.

I've confirmed that this test fails without the fix from #2021 