### PR TITLE
oauth(docs): replace hardcoded state secrets with process env variables

### DIFF
--- a/docs/content/packages/oauth.md
+++ b/docs/content/packages/oauth.md
@@ -36,7 +36,7 @@ const { InstallProvider } = require('@slack/oauth');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret'
+  stateSecret: process.env.SLACK_STATE_SECRET,
 });
 ```
 
@@ -52,7 +52,7 @@ Using a classic Slack app
   const installer = new InstallProvider({
     clientId: process.env.SLACK_CLIENT_ID,
     clientSecret: process.env.SLACK_CLIENT_SECRET,
-    stateSecret: 'my-state-secret',
+    stateSecret: process.env.SLACK_STATE_SECRET,
     authVersion: 'v1' //required for classic Slack apps
   });
   ```
@@ -92,7 +92,7 @@ const { InstallProvider } = require('@slack/oauth');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   renderHtmlForInstallPath: (url) => `<html><body><a href="${url}">Install my app!</a></body></html>`
 });
 ```
@@ -182,7 +182,7 @@ const { createServer } = require('http');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret'
+  stateSecret: process.env.SLACK_STATE_SECRET,
 });
 
 const server = createServer(async (req, res) =>  {
@@ -264,7 +264,7 @@ In the following example, the `installationStore` option is used and the object 
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   installationStore: {
     // takes in an installation object as an argument
     // returns nothing
@@ -417,7 +417,7 @@ const { InstallProvider, LogLevel } = require('@slack/oauth');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   logLevel: LogLevel.DEBUG,
 });
 ```
@@ -450,7 +450,7 @@ const logWritable = createWriteStream('/var/my_log_file'); // Not shown: close t
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   // Creating a logger as a literal object. It's more likely that you'd create a class.
   logger: {
     debug(...msgs): { logWritable.write('debug: ' + JSON.stringify(msgs)); },

--- a/examples/oauth-v1/README.md
+++ b/examples/oauth-v1/README.md
@@ -20,6 +20,7 @@ This app requires you setup a few environment variables. You can get these value
 export SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
 export SLACK_CLIENT_SECRET=YOUR_SLACK_CLIENT_SECRET
 export SLACK_SIGNING_SECRET=YOUR_SLACK_SIGNING_SECRET
+export SLACK_STATE_SECRET=YOUR_SLACK_STATE_SECRET
 ```
 
 ## Run the App

--- a/examples/oauth-v1/README.md
+++ b/examples/oauth-v1/README.md
@@ -1,10 +1,10 @@
 # OAuth v1 Example
 
-This repo contains a sample app for doing OAuth with Slack for [Classic Slack apps](https://api.slack.com/bot-users). Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library. 
+This repo contains a sample app for doing OAuth with Slack for [Classic Slack apps](https://api.slack.com/bot-users). Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library.
 
 Local development requires a public URL where Slack can send requests. In this guide, we'll be using [`ngrok`](https://ngrok.com/download). Checkout [this guide](https://api.slack.com/tutorials/tunneling-with-ngrok) for setting it up.
 
-Before we get started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create). You also need to [create a new app](https://api.slack.com/apps?new_app=1) if you haven’t already. 
+Before we get started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create). You also need to [create a new app](https://api.slack.com/apps?new_app=1) if you haven’t already.
 
 ## Install Dependencies
 
@@ -14,7 +14,7 @@ npm install
 
 ## Setup Environment Variables
 
-This app requires you setup a few environment variables. You can get these values by navigating to your app's [**BASIC INFORMATION** Page](https://api.slack.com/apps). 
+This app requires you setup a few environment variables. You can get these values by navigating to your app's [**BASIC INFORMATION** Page](https://api.slack.com/apps).
 
 ```
 export SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
@@ -32,7 +32,7 @@ npm start
 
 This will start the app on port `3000`.
 
-Now lets start `ngrok` so we can access the app on an external network and create a `redirect url` for OAuth. 
+Now lets start `ngrok` so we can access the app on an external network and create a `redirect url` for OAuth.
 
 ```
 ngrok http 3000
@@ -56,6 +56,6 @@ This app also listens to the `app_home_opened` event to illustrate fetching the 
 https://3cb89939.ngrok.io/slack/events
 ```
 
-Lastly, in the **Events Subscription** page, click **Subscribe to bot events** and add `app_home_opened`.  
+Lastly, in the **Events Subscription** page, click **Subscribe to bot events** and add `app_home_opened`.
 
 Everything is now setup. In your browser, navigate to http://localhost:3000/slack/install to initiate the oAuth flow. Once you install the app, it should redirect you back to your native slack app. Click on the home tab of your app in slack to see the message `Welcome to the App Home!`.

--- a/examples/oauth-v1/app.js
+++ b/examples/oauth-v1/app.js
@@ -15,7 +15,7 @@ const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   authVersion: 'v1',
-  stateSecret: 'super-secret'
+  stateSecret: process.env.SLACK_STATE_SECRET,
 });
 
 app.get('/', (req, res) => res.send('go to /slack/install'));

--- a/examples/oauth-v2/README.md
+++ b/examples/oauth-v2/README.md
@@ -1,12 +1,12 @@
 # OAuth v2 Example
 
-This repo contains a sample app for implementing OAuth with Slack for new granular permission Slack apps. Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library. 
+This repo contains a sample app for implementing OAuth with Slack for new granular permission Slack apps. Checkout `app.js`. The code includes a few different options which have been commented out. As you play around with the app, you can uncomment some of these options to get a deeper understanding of how to use this library.
 
 Local development requires a public URL where Slack can send requests. In this guide, we'll be using [`ngrok`](https://ngrok.com/download). Checkout [this guide](https://api.slack.com/tutorials/tunneling-with-ngrok) for setting it up.
 
-Before we get started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create). You also need to [create a new app](https://api.slack.com/apps?new_app=1) if you haven’t already. 
+Before we get started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create). You also need to [create a new app](https://api.slack.com/apps?new_app=1) if you haven’t already.
 
-This example uses the [Keyv](https://github.com/lukechilds/keyv) library as a database solution. Keyv has adaptors for many popular database solutions. You can use whatever database or wrapper you wish to. 
+This example uses the [Keyv](https://github.com/lukechilds/keyv) library as a database solution. Keyv has adaptors for many popular database solutions. You can use whatever database or wrapper you wish to.
 
 ## Install Dependencies
 
@@ -16,7 +16,7 @@ npm install
 
 ## Setup Environment Variables
 
-This app requires you to setup a few environment variables. You can get these values by navigating to your app's [**BASIC INFORMATION** Page](https://api.slack.com/apps). 
+This app requires you to setup a few environment variables. You can get these values by navigating to your app's [**BASIC INFORMATION** Page](https://api.slack.com/apps).
 
 ```
 export SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
@@ -34,7 +34,7 @@ npm start
 
 This will start the app on port `3000`.
 
-Now lets start `ngrok` so we can access the app on an external network and create a `redirect url` for OAuth. 
+Now lets start `ngrok` so we can access the app on an external network and create a `redirect url` for OAuth.
 
 ```
 ngrok http 3000
@@ -58,6 +58,6 @@ This app also listens to the `app_home_opened` event to illustrate fetching the 
 https://3cb89939.ngrok.io/slack/events
 ```
 
-Lastly, in the **Events Subscription** page, click **Subscribe to bot events** and add `app_home_opened`.  
+Lastly, in the **Events Subscription** page, click **Subscribe to bot events** and add `app_home_opened`.
 
 Everything is now setup. In your browser, navigate to http://localhost:3000/slack/install to initiate the oAuth flow. Once you install the app, it should redirect you back to your native slack app. Click on the home tab of your app in slack to see the message `Welcome to the App Home!`.

--- a/examples/oauth-v2/README.md
+++ b/examples/oauth-v2/README.md
@@ -22,6 +22,7 @@ This app requires you to setup a few environment variables. You can get these va
 export SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
 export SLACK_CLIENT_SECRET=YOUR_SLACK_CLIENT_SECRET
 export SLACK_SIGNING_SECRET=YOUR_SLACK_SIGNING_SECRET
+export SLACK_STATE_SECRET=YOUR_SLACK_STATE_SECRET
 ```
 
 ## Run the App

--- a/examples/oauth-v2/app.js
+++ b/examples/oauth-v2/app.js
@@ -27,7 +27,7 @@ const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   authVersion: 'v2',
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   scopes,
   userScopes,
   installationStore: new FileInstallationStore(),

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -37,7 +37,7 @@ const { InstallProvider } = require('@slack/oauth');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret'
+  stateSecret: process.env.SLACK_STATE_SECRET,
 });
 ```
 
@@ -53,7 +53,7 @@ const installer = new InstallProvider({
   const installer = new InstallProvider({
     clientId: process.env.SLACK_CLIENT_ID,
     clientSecret: process.env.SLACK_CLIENT_SECRET,
-    stateSecret: 'my-state-secret',
+    stateSecret: process.env.SLACK_STATE_SECRET,
     authVersion: 'v1' //required for classic Slack apps
   });
   ```
@@ -168,7 +168,7 @@ In the following example, the `installationStore` option is used and the object 
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   installationStore: {
     // takes in an installation object as an argument
     // returns nothing
@@ -306,7 +306,7 @@ const { InstallProvider, LogLevel } = require('@slack/oauth');
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   logLevel: LogLevel.DEBUG,
 });
 ```
@@ -339,7 +339,7 @@ const logWritable = createWriteStream('/var/my_log_file'); // Not shown: close t
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
+  stateSecret: process.env.SLACK_STATE_SECRET,
   // Creating a logger as a literal object. It's more likely that you'd create a class.
   logger: {
     debug(...msgs): { logWritable.write('debug: ' + JSON.stringify(msgs)); },


### PR DESCRIPTION
### Summary

This PR replaces examples of hardcoded state secrets with an environment variable to match https://github.com/slackapi/bolt-js/pull/2220

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
