### PR TITLE
cli-test(feat): Added `datastore` CLI commands

### DIFF
--- a/packages/cli-test/src/cli/commands/datastore.spec.ts
+++ b/packages/cli-test/src/cli/commands/datastore.spec.ts
@@ -36,7 +36,11 @@ describe('datastore commands', () => {
   });
   describe('put method', () => {
     it('should invoke `datastore put [item details]`', async () => {
-      await datastore.datastorePut({ appPath: '/some/path', datastoreName: 'datastore', putItem: '{ "id": "1"}' });
+      const itemObj: any = {
+        id: "1",
+        content: "text"
+      };
+      await datastore.datastorePut({ appPath: '/some/path', datastoreName: 'datastore', putItem: itemObj });
       sandbox.assert.calledWith(
         spawnSpy,
         sinon.match(`datastore put`),
@@ -45,7 +49,10 @@ describe('datastore commands', () => {
   });
   describe('query method', () => {
     it('should invoke `datastore query [expression]`', async () => {
-      await datastore.datastoreQuery({ appPath: '/some/path',  datastoreName: 'datastore', queryExpression: 'id = :id', queryExpressionValues: '{ ":id": "1"}'});
+      const expressObj: any = {
+        id: "1",
+      };
+      await datastore.datastoreQuery({ appPath: '/some/path',  datastoreName: 'datastore', queryExpression: 'id = :id', queryExpressionValues: expressObj});
       sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore query`));
     });
   });

--- a/packages/cli-test/src/cli/commands/datastore.spec.ts
+++ b/packages/cli-test/src/cli/commands/datastore.spec.ts
@@ -36,7 +36,7 @@ describe('datastore commands', () => {
   });
   describe('put method', () => {
     it('should invoke `datastore put [item details]`', async () => {
-      const itemObj: any = {
+      const itemObj = {
         id: "1",
         content: "text"
       };
@@ -49,7 +49,7 @@ describe('datastore commands', () => {
   });
   describe('query method', () => {
     it('should invoke `datastore query [expression]`', async () => {
-      const expressObj: any = {
+      const expressObj = {
         id: "1",
       };
       await datastore.datastoreQuery({ appPath: '/some/path',  datastoreName: 'datastore', queryExpression: 'id = :id', queryExpressionValues: expressObj});

--- a/packages/cli-test/src/cli/commands/datastore.spec.ts
+++ b/packages/cli-test/src/cli/commands/datastore.spec.ts
@@ -1,0 +1,52 @@
+import sinon from 'sinon';
+
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+import datastore from './datastore';
+
+describe('datastore commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'something',
+      finished: true,
+      output: 'hi',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('put method', () => {
+    it('should invoke `datastore put [item details]`', async () => {
+      await datastore.datastorePut({ appPath: '/some/path', putDetails: '{ "datastore": "datastore", "item": { "id": "1"} }' });
+      sandbox.assert.calledWith(
+        spawnSpy,
+        sinon.match(`datastore put '{ "datastore": "datastore", "item": { "id": "1"} }'`),
+      );
+    });
+  });
+  describe('get method', () => {
+    it('should invoke `datastore get <query>`', async () => {
+      await datastore.datastoreGet({ appPath: '/some/path', getQuery: '{ "datastore": "datastore", "id": "1" }' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore get '{ "datastore": "datastore", "id": "1" }'`));
+    });
+  });
+  describe('delete method', () => {
+    it('should invoke `datastore delete <query>`', async () => {
+      await datastore.datastoreDelete({ appPath: '/some/path', deleteQuery: '{ "datastore": "datastore", "id": "1" }' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore delete '{ "datastore": "datastore", "id": "1" }'`));
+    });
+  });
+  describe('query method', () => {
+    it('should invoke `datastore query [expression]`', async () => {
+      await datastore.datastoreQuery({ appPath: '/some/path', queryExpression: '{ "datastore": "datastore", "expression": "id = :id", "expression_values": {":id": "1"} }' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore query '{ "datastore": "datastore", "expression": "id = :id", "expression_values": {":id": "1"} }'`));
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/datastore.spec.ts
+++ b/packages/cli-test/src/cli/commands/datastore.spec.ts
@@ -22,31 +22,31 @@ describe('datastore commands', () => {
     sandbox.restore();
   });
 
-  describe('put method', () => {
-    it('should invoke `datastore put [item details]`', async () => {
-      await datastore.datastorePut({ appPath: '/some/path', putDetails: '{ "datastore": "datastore", "item": { "id": "1"} }' });
-      sandbox.assert.calledWith(
-        spawnSpy,
-        sinon.match(`datastore put '{ "datastore": "datastore", "item": { "id": "1"} }'`),
-      );
-    });
-  });
   describe('get method', () => {
     it('should invoke `datastore get <query>`', async () => {
-      await datastore.datastoreGet({ appPath: '/some/path', getQuery: '{ "datastore": "datastore", "id": "1" }' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore get '{ "datastore": "datastore", "id": "1" }'`));
+      await datastore.datastoreGet({ appPath: '/some/path', datastoreName: 'datastore', primaryKeyValue: '1' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore get`));
     });
   });
   describe('delete method', () => {
     it('should invoke `datastore delete <query>`', async () => {
-      await datastore.datastoreDelete({ appPath: '/some/path', deleteQuery: '{ "datastore": "datastore", "id": "1" }' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore delete '{ "datastore": "datastore", "id": "1" }'`));
+      await datastore.datastoreDelete({ appPath: '/some/path', datastoreName: 'datastore', primaryKeyValue: '1' });
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore delete`));
+    });
+  });
+  describe('put method', () => {
+    it('should invoke `datastore put [item details]`', async () => {
+      await datastore.datastorePut({ appPath: '/some/path', datastoreName: 'datastore', putItem: '{ "id": "1"}' });
+      sandbox.assert.calledWith(
+        spawnSpy,
+        sinon.match(`datastore put`),
+      );
     });
   });
   describe('query method', () => {
     it('should invoke `datastore query [expression]`', async () => {
-      await datastore.datastoreQuery({ appPath: '/some/path', queryExpression: '{ "datastore": "datastore", "expression": "id = :id", "expression_values": {":id": "1"} }' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore query '{ "datastore": "datastore", "expression": "id = :id", "expression_values": {":id": "1"} }'`));
+      await datastore.datastoreQuery({ appPath: '/some/path',  datastoreName: 'datastore', queryExpression: 'id = :id', queryExpressionValues: '{ ":id": "1"}'});
+      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore query`));
     });
   });
 });

--- a/packages/cli-test/src/cli/commands/datastore.spec.ts
+++ b/packages/cli-test/src/cli/commands/datastore.spec.ts
@@ -25,13 +25,13 @@ describe('datastore commands', () => {
   describe('get method', () => {
     it('should invoke `datastore get <query>`', async () => {
       await datastore.datastoreGet({ appPath: '/some/path', datastoreName: 'datastore', primaryKeyValue: '1' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore get`));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('datastore get'));
     });
   });
   describe('delete method', () => {
     it('should invoke `datastore delete <query>`', async () => {
       await datastore.datastoreDelete({ appPath: '/some/path', datastoreName: 'datastore', primaryKeyValue: '1' });
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore delete`));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('datastore delete'));
     });
   });
   describe('put method', () => {
@@ -43,7 +43,7 @@ describe('datastore commands', () => {
       await datastore.datastorePut({ appPath: '/some/path', datastoreName: 'datastore', putItem: itemObj });
       sandbox.assert.calledWith(
         spawnSpy,
-        sinon.match(`datastore put`),
+        sinon.match('datastore put'),
       );
     });
   });
@@ -53,7 +53,7 @@ describe('datastore commands', () => {
         id: "1",
       };
       await datastore.datastoreQuery({ appPath: '/some/path',  datastoreName: 'datastore', queryExpression: 'id = :id', queryExpressionValues: expressObj});
-      sandbox.assert.calledWith(spawnSpy, sinon.match(`datastore query`));
+      sandbox.assert.calledWith(spawnSpy, sinon.match('datastore query'));
     });
   });
 });

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -7,11 +7,11 @@ export interface DatastoreCommandArguments {
   /** @description datastore get primary key value*/
   primaryKeyValue: string;
   /** @description datastore put [item details] */
-  putItem: string;
+  putItem: object;
   /** @description datastore query [expression] */
   queryExpression: string;
   /** @description datastore query [expression expression_values] */
-  queryExpressionValues: string;
+  queryExpressionValues: object;
 }
 
 /**

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -26,7 +26,7 @@ export const datastoreGet = async function datastoreGet(
     id: args.primaryKeyValue
   };
   const getQuery = JSON.stringify(getQueryObj);
-  const cmd = new SlackCLIProcess(`datastore get ${getQuery}`, args);
+  const cmd = new SlackCLIProcess(`datastore get '${getQuery}'`, args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -2,41 +2,31 @@ import type { ProjectCommandArguments } from '../../types/commands/common_argume
 import { SlackCLIProcess } from '../cli-process';
 
 export interface DatastoreCommandArguments {
-  /** @description datastore get <query> */
-  getQuery: string;
+  /** @description datastore name */
+  datastoreName: string;
+  /** @description datastore get primary key value*/
+  primaryKeyValue: string;
   /** @description datastore put [item details] */
-  putDetails: string;
+  putItem: string;
   /** @description datastore query [expression] */
   queryExpression: string;
-  /** @description datastore delete <query> */
-  deleteQuery: string;
+  /** @description datastore query [expression expression_values] */
+  queryExpressionValues: string;
 }
-
-/**
- * `slack datastore put`
- * @returns command output
- */
-export const datastorePut = async function datastorePut(
-  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'putDetails'>,
-): Promise<string> {
-  const cmd = new SlackCLIProcess(
-    `datastore put '${args.putDetails}'`,
-    args,
-  );
-  const proc = await cmd.execAsync({
-    cwd: args.appPath,
-  });
-  return proc.output;
-};
 
 /**
  * `slack datastore get`
  * @returns command output
  */
 export const datastoreGet = async function datastoreGet(
-  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'getQuery'>,
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'primaryKeyValue'>,
 ): Promise<string> {
-  const cmd = new SlackCLIProcess(`datastore get '${args.getQuery}'`, args);
+  const getQueryObj: any = {
+    datastore: args.datastoreName,
+    id: args.primaryKeyValue
+  };
+  const getQuery = JSON.stringify(getQueryObj);
+  const cmd = new SlackCLIProcess(`datastore get ${getQuery}`, args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });
@@ -48,9 +38,36 @@ export const datastoreGet = async function datastoreGet(
  * @returns command output
  */
 export const datastoreDelete = async function datastoreDelete(
-  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'deleteQuery'>,
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'primaryKeyValue'>,
 ): Promise<string> {
-  const cmd = new SlackCLIProcess(`datastore delete '${args.deleteQuery}'`, args);
+  const deleteQueryObj: any = {
+    datastore: args.datastoreName,
+    id: args.primaryKeyValue
+  };
+  const deleteQuery = JSON.stringify(deleteQueryObj);
+  const cmd = new SlackCLIProcess(`datastore delete '${deleteQuery}'`, args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack datastore put`
+ * @returns command output
+ */
+export const datastorePut = async function datastorePut(
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'putItem'>,
+): Promise<string> {
+  const putQueryObj: any = {
+    datastore: args.datastoreName,
+    item: args.putItem
+  };
+  const putQuery = JSON.stringify(putQueryObj);
+  const cmd = new SlackCLIProcess(
+    `datastore put '${putQuery}'`,
+    args,
+  );
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });
@@ -62,10 +79,16 @@ export const datastoreDelete = async function datastoreDelete(
  * @returns command output
  */
 export const datastoreQuery = async function datastoreQuery(
-  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'queryExpression'>,
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'queryExpression' | 'queryExpressionValues'>,
 ): Promise<string> {
+  const queryObj: any = {
+    datastore: args.datastoreName,
+    expression: args.queryExpression,
+    expression_values: args.queryExpressionValues
+  };
+  const query = JSON.stringify(queryObj);
   const cmd = new SlackCLIProcess(
-    `datastore query '${args.queryExpression}'`,
+    `datastore query '${query}'`,
     args,
   );
   const proc = await cmd.execAsync({
@@ -75,8 +98,8 @@ export const datastoreQuery = async function datastoreQuery(
 };
 
 export default {
-  datastorePut,
   datastoreGet,
   datastoreDelete,
+  datastorePut,
   datastoreQuery,
 };

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -21,7 +21,7 @@ export interface DatastoreCommandArguments {
 export const datastoreGet = async function datastoreGet(
   args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'primaryKeyValue'>,
 ): Promise<string> {
-  const getQueryObj: any = {
+  const getQueryObj = {
     datastore: args.datastoreName,
     id: args.primaryKeyValue
   };
@@ -40,7 +40,7 @@ export const datastoreGet = async function datastoreGet(
 export const datastoreDelete = async function datastoreDelete(
   args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'primaryKeyValue'>,
 ): Promise<string> {
-  const deleteQueryObj: any = {
+  const deleteQueryObj = {
     datastore: args.datastoreName,
     id: args.primaryKeyValue
   };
@@ -59,7 +59,7 @@ export const datastoreDelete = async function datastoreDelete(
 export const datastorePut = async function datastorePut(
   args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'putItem'>,
 ): Promise<string> {
-  const putQueryObj: any = {
+  const putQueryObj = {
     datastore: args.datastoreName,
     item: args.putItem
   };
@@ -81,7 +81,7 @@ export const datastorePut = async function datastorePut(
 export const datastoreQuery = async function datastoreQuery(
   args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'datastoreName' | 'queryExpression' | 'queryExpressionValues'>,
 ): Promise<string> {
-  const queryObj: any = {
+  const queryObj = {
     datastore: args.datastoreName,
     expression: args.queryExpression,
     expression_values: args.queryExpressionValues

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -1,0 +1,82 @@
+import type { ProjectCommandArguments } from '../../types/commands/common_arguments';
+import { SlackCLIProcess } from '../cli-process';
+
+export interface DatastoreCommandArguments {
+  /** @description datastore get <query> */
+  getQuery: string;
+  /** @description datastore put [item details] */
+  putDetails: string;
+  /** @description datastore query [expression] */
+  queryExpression: string;
+  /** @description datastore delete <query> */
+  deleteQuery: string;
+}
+
+/**
+ * `slack datastore put`
+ * @returns command output
+ */
+export const datastorePut = async function datastorePut(
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'putDetails'>,
+): Promise<string> {
+  const cmd = new SlackCLIProcess(
+    `datastore put '${args.putDetails}'`,
+    args,
+  );
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack datastore get`
+ * @returns command output
+ */
+export const datastoreGet = async function datastoreGet(
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'getQuery'>,
+): Promise<string> {
+  const cmd = new SlackCLIProcess(`datastore get '${args.getQuery}'`, args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack datastore delete`
+ * @returns command output
+ */
+export const datastoreDelete = async function datastoreDelete(
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'deleteQuery'>,
+): Promise<string> {
+  const cmd = new SlackCLIProcess(`datastore delete '${args.deleteQuery}'`, args);
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+/**
+ * `slack datastore query`
+ * @returns command output
+ */
+export const datastoreQuery = async function datastoreQuery(
+  args: ProjectCommandArguments & Pick<DatastoreCommandArguments, 'queryExpression'>,
+): Promise<string> {
+  const cmd = new SlackCLIProcess(
+    `datastore query '${args.queryExpression}'`,
+    args,
+  );
+  const proc = await cmd.execAsync({
+    cwd: args.appPath,
+  });
+  return proc.output;
+};
+
+export default {
+  datastorePut,
+  datastoreGet,
+  datastoreDelete,
+  datastoreQuery,
+};


### PR DESCRIPTION
### Summary

This PR adds basic `datastore` CLI commands for e2e test, it includes `datastore get/put/query/delete` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
