### PR TITLE
oauth(fix): remove double quotes from the default 'add to slack' img alt text

### DIFF
--- a/packages/oauth/src/default-render-html-for-install-path.ts
+++ b/packages/oauth/src/default-render-html-for-install-path.ts
@@ -12,7 +12,7 @@ body {
 </head>
 <body>
 <h2>Slack App Installation</h2>
-<p><a href="${addToSlackUrl}"><img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
+<p><a href="${addToSlackUrl}"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
 </body>
 </html>`;
 }


### PR DESCRIPTION
### Summary

This PR mirrors the changes contributed in https://github.com/slackapi/bolt-python/pull/1170 🙏 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
