### PR TITLE
feat(web-api): add request interceptor and HTTP adapter config to WebClient [ISSUE-2073]

### DIFF
--- a/docs/content/packages/web-api.md
+++ b/docs/content/packages/web-api.md
@@ -662,6 +662,65 @@ const web = new WebClient(token, { agent: proxy });
 
 ---
 
+### Modify outgoing requests with a request interceptor
+
+The client allows you to customize a request
+[`interceptor`](https://axios-http.com/docs/interceptors) to modify outgoing requests.
+Using this option allows you to modify outgoing requests to conform to the requirements of a proxy, which is a common requirement in many corporate settings.
+
+For example you may want to convert wrap all the original request information within a POST request.
+
+```javascript
+const { WebClient } = require('@slack/web-api');
+
+const token = process.env.SLACK_TOKEN;
+
+const webClient = new WebClient(token, {
+  requestInterceptor: (config: RequestConfig) => {
+    config.headers['Content-Type'] = 'application/json';
+
+    config.data  = {
+      method: config.method,
+      base_url: config.baseURL,
+      path: config.url,
+      body: config.data ?? {},
+      query: config.params ?? {},
+      headers: structuredClone(config.headers),
+      test: 'static-body-value',
+    };
+
+    return config;
+  }
+});
+```
+
+---
+
+### Using a pre-configured http client to handle outgoing requests
+
+The client allows you to specify an
+[`adapter`](https://github.com/axios/axios/blob/v1.x/README.md?plain=1#L586) to handle outgoing requests.
+Using this option allows you to used a pre-configured http client, which is a common requirement in many corporate settings.
+
+For example you may want to use a http which is already configured with logging capabilities, desired timeouts, etc.
+
+```javascript
+const { WebClient } = require('@slack/web-api');
+const { CustomHttpClient } = require('@company/http-client')
+
+const token = process.env.SLACK_TOKEN;
+
+const customClient = CustomHttpClient();
+
+const webClient = new WebClient(token, {
+  adapter: (config: RequestConfig) => {
+    return customClient.request(config);
+  }
+});
+```
+
+---
+
 ### Rate limits
 
 When your app calls API methods too frequently, Slack will politely ask (by returning an error) the app to slow down,

--- a/docs/content/packages/web-api.md
+++ b/docs/content/packages/web-api.md
@@ -668,7 +668,7 @@ The client allows you to customize a request
 [`interceptor`](https://axios-http.com/docs/interceptors) to modify outgoing requests.
 Using this option allows you to modify outgoing requests to conform to the requirements of a proxy, which is a common requirement in many corporate settings.
 
-For example you may want to convert wrap all the original request information within a POST request.
+For example you may want to wrap the original request information within a POST request:
 
 ```javascript
 const { WebClient } = require('@slack/web-api');
@@ -676,7 +676,7 @@ const { WebClient } = require('@slack/web-api');
 const token = process.env.SLACK_TOKEN;
 
 const webClient = new WebClient(token, {
-  requestInterceptor: (config: RequestConfig) => {
+  requestInterceptor: (config) => {
     config.headers['Content-Type'] = 'application/json';
 
     config.data  = {
@@ -700,9 +700,9 @@ const webClient = new WebClient(token, {
 
 The client allows you to specify an
 [`adapter`](https://github.com/axios/axios/blob/v1.x/README.md?plain=1#L586) to handle outgoing requests.
-Using this option allows you to used a pre-configured http client, which is a common requirement in many corporate settings.
+Using this option allows you to use a pre-configured http client, which is a common requirement in many corporate settings.
 
-For example you may want to use a http which is already configured with logging capabilities, desired timeouts, etc.
+For example you may want to use an HTTP client which is already configured with logging capabilities, desired timeouts, etc.
 
 ```javascript
 const { WebClient } = require('@slack/web-api');

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1032,7 +1032,6 @@ describe('WebClient', () => {
             test: 'static-body-value',
           });
 
-          await new Promise((resolve) => setTimeout(resolve, 100));
           config.data = expectedBody;
 
           config.headers.test = 'static-header-value';

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -303,7 +303,7 @@ export class WebClient extends Methods {
     if (requestInterceptor) {
       this.axios.interceptors.request.use(requestInterceptor, null, { synchronous: true });
     }
-    this.axios.interceptors.request.use(this.serializeApiCallData.bind(this), null, { synchronous: true });
+    this.axios.interceptors.request.use(this.serializeApiCallData.bind(this), null);
 
     this.logger.debug('initialized');
   }

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -302,7 +302,7 @@ export class WebClient extends Methods {
     // request interceptors have reversed execution order
     // see: https://github.com/axios/axios/blob/v1.x/test/specs/interceptors.spec.js#L88
     if (requestInterceptor) {
-      this.axios.interceptors.request.use(requestInterceptor, null, { synchronous: true });
+      this.axios.interceptors.request.use(requestInterceptor, null);
     }
     this.axios.interceptors.request.use(this.serializeApiCallData.bind(this), null);
 

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -10,6 +10,7 @@ import axios, {
   type AxiosHeaderValue,
   type AxiosInstance,
   type AxiosResponse,
+  type AxiosAdapter,
 } from 'axios';
 import FormData from 'form-data';
 import isElectron from 'is-electron';
@@ -94,7 +95,18 @@ export interface WebClientOptions {
    * @default true
    */
   attachOriginalToWebAPIRequestError?: boolean;
+  /**
+   * Custom function to modify outgoing requests.
+   * @type {Function | undefined}
+   * @default undefined
+   */
   requestInterceptor?: RequestInterceptor;
+  /**
+   * Custom functions for modifing and handling outgoing requests.
+   * Useful if you would like to manage outgoing request with a custom http client.
+   * @type {Function | undefined}
+   * @default undefined
+   */
   adapter?: AdapterConfig;
 }
 
@@ -136,11 +148,23 @@ export type PageAccumulator<R extends PageReducer> = R extends (
   ? A
   : never;
 
+/**
+ * An alias to {@link https://github.com/axios/axios/blob/v1.x/index.d.ts#L367 Axios' `InternalAxiosRequestConfig`} object,
+ * which is the main parameter type provided to Axios interceptors and adapters.
+ */
 export type RequestConfig = InternalAxiosRequestConfig;
 
+/**
+ * An alias to {@link https://github.com/axios/axios/blob/v1.x/index.d.ts#L489 Axios' `AxiosInterceptorManager<InternalAxiosRequestConfig>` onFufilled} method,
+ * which controls the custom request interceptor logic
+ */
 export type RequestInterceptor = (config: RequestConfig) => RequestConfig | Promise<RequestConfig>;
 
-export type AdapterConfig = (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>;
+/**
+ * An alias to {@link https://github.com/axios/axios/blob/v1.x/index.d.ts#L112 Axios' `AxiosAdapter`} interface,
+ * which is the contract required to specify an adapter
+ */
+export type AdapterConfig = AxiosAdapter;
 
 /**
  * A client for Slack's Web API
@@ -208,6 +232,9 @@ export class WebClient extends Methods {
 
   /**
    * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
+   * @param {Object} [webClientOptions] - Configuration options.
+   * @param {Function} [webClientOptions.requestInterceptor] - An interceptor to mutate outgoing requests. See {@link https://axios-http.com/docs/interceptors Axios interceptors}
+   * @param {Function} [webClientOptions.adapter] - An adapter to allow custom handling of requests. Useful if you would like to use a pre-configured http client. See {@link https://github.com/axios/axios/blob/v1.x/README.md?plain=1#L586 Axios adapter}
    */
   public constructor(
     token?: string,

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -295,7 +295,7 @@ export class WebClient extends Methods {
       // protocols), users of this package should use the `agent` option to configure a proxy.
       proxy: false,
     });
-    // serializeApiCallOptions will always determine the appropriate content-type
+    // serializeApiCallData will always determine the appropriate content-type
     this.axios.defaults.headers.post['Content-Type'] = undefined;
 
     // request interceptors have reversed execution order
@@ -303,7 +303,7 @@ export class WebClient extends Methods {
     if (requestInterceptor) {
       this.axios.interceptors.request.use(requestInterceptor, null, { synchronous: true });
     }
-    this.axios.interceptors.request.use(this.serializeApiCallOptions.bind(this), null, { synchronous: true });
+    this.axios.interceptors.request.use(this.serializeApiCallData.bind(this), null, { synchronous: true });
 
     this.logger.debug('initialized');
   }
@@ -717,14 +717,14 @@ export class WebClient extends Methods {
    * multipart/form-data.
    * @param config - The Axios request configuration object
    */
-  private serializeApiCallOptions(config: InternalAxiosRequestConfig): InternalAxiosRequestConfig {
-    const { data: options, headers } = config;
+  private serializeApiCallData(config: InternalAxiosRequestConfig): InternalAxiosRequestConfig {
+    const { data, headers } = config;
 
     // The following operation both flattens complex objects into a JSON-encoded strings and searches the values for
     // binary content
     let containsBinaryData = false;
     // biome-ignore lint/suspicious/noExplicitAny: call options can be anything
-    const flattened = Object.entries(options).map<[string, any] | []>(([key, value]) => {
+    const flattened = Object.entries(data).map<[string, any] | []>(([key, value]) => {
       if (value === undefined || value === null) {
         return [];
       }

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -95,6 +95,7 @@ export interface WebClientOptions {
    */
   attachOriginalToWebAPIRequestError?: boolean;
   requestInterceptor?: RequestInterceptor;
+  adapter?: AdapterConfig;
 }
 
 export type TLSOptions = Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
@@ -138,6 +139,8 @@ export type PageAccumulator<R extends PageReducer> = R extends (
 export type RequestConfig = InternalAxiosRequestConfig;
 
 export type RequestInterceptor = (config: RequestConfig) => RequestConfig | Promise<RequestConfig>;
+
+export type AdapterConfig = (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>;
 
 /**
  * A client for Slack's Web API
@@ -222,6 +225,7 @@ export class WebClient extends Methods {
       teamId = undefined,
       attachOriginalToWebAPIRequestError = true,
       requestInterceptor = undefined,
+      adapter = undefined,
     }: WebClientOptions = {},
   ) {
     super();
@@ -250,6 +254,7 @@ export class WebClient extends Methods {
     if (this.token && !headers.Authorization) headers.Authorization = `Bearer ${this.token}`;
 
     this.axios = axios.create({
+      adapter: adapter ? (config: InternalAxiosRequestConfig) => adapter({ ...config, adapter: undefined }) : undefined,
       timeout,
       baseURL: slackApiUrl,
       headers: isElectron() ? headers : { 'User-Agent': getUserAgent(), ...headers },

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -96,7 +96,7 @@ export interface WebClientOptions {
    */
   attachOriginalToWebAPIRequestError?: boolean;
   /**
-   * Custom function to modify outgoing requests.
+   * Custom function to modify outgoing requests. See {@link https://axios-http.com/docs/interceptors Axios interceptor documentation} for more details.
    * @type {Function | undefined}
    * @default undefined
    */
@@ -104,6 +104,7 @@ export interface WebClientOptions {
   /**
    * Custom functions for modifing and handling outgoing requests.
    * Useful if you would like to manage outgoing request with a custom http client.
+   * See {@link https://github.com/axios/axios/blob/v1.x/README.md?plain=1#L586 Axios adapter documentation} for more information.
    * @type {Function | undefined}
    * @default undefined
    */
@@ -723,7 +724,7 @@ export class WebClient extends Methods {
     // The following operation both flattens complex objects into a JSON-encoded strings and searches the values for
     // binary content
     let containsBinaryData = false;
-    // biome-ignore lint/suspicious/noExplicitAny: call options can be anything
+    // biome-ignore lint/suspicious/noExplicitAny: HTTP request data can be anything
     const flattened = Object.entries(data).map<[string, any] | []>(([key, value]) => {
       if (value === undefined || value === null) {
         return [];


### PR DESCRIPTION
# Summary

Resolves https://github.com/slackapi/node-slack-sdk/issues/2073

## Features
- ability to configure one [axios request interceptor](https://axios-http.com/docs/interceptors)
    - useful for clients who would like to manipulate outgoing requests to conform to their custom proxies
- ability to configure an [axios adapter](https://axios-http.com/docs/req_config)
    - useful for client who would like to used their existing http client
        - ex: client may have a dedicated http client configured to be used with their internal proxy

## Contribution Pre-Requisites 

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
