### PR TITLE
feat(web-api): add new `is_send_allowed` optional parameter to `assistant.threads.setStatus` method

### DIFF
--- a/packages/web-api/src/types/request/assistant.ts
+++ b/packages/web-api/src/types/request/assistant.ts
@@ -8,6 +8,8 @@ export interface AssistantThreadsSetStatusArguments extends TokenOverridable {
   status: string;
   /** @description Message timestamp of the thread. */
   thread_ts: string;
+  /** @description Whether or not the user is allowed to send a message while the status is being displayed. Defaults to `false`. */
+  is_send_allowed?: boolean;
 }
 
 // https://api.slack.com/methods/assistant.threads.setSuggestedPrompts


### PR DESCRIPTION
See https://api.slack.com/methods/assistant.threads.setStatus#arg_is_send_allowed

Relates to https://github.com/slackapi/python-slack-sdk/pull/1577