### PR TITLE
Revert "feat(web-api): add new `is_send_allowed` optional parameter to `assistant.threads.setStatus` method"

### DIFF
--- a/packages/web-api/src/types/request/assistant.ts
+++ b/packages/web-api/src/types/request/assistant.ts
@@ -8,8 +8,6 @@ export interface AssistantThreadsSetStatusArguments extends TokenOverridable {
   status: string;
   /** @description Message timestamp of the thread. */
   thread_ts: string;
-  /** @description Whether or not the user is allowed to send a message while the status is being displayed. Defaults to `false`. */
-  is_send_allowed?: boolean;
 }
 
 // https://api.slack.com/methods/assistant.threads.setSuggestedPrompts


### PR DESCRIPTION
Reverts slackapi/node-slack-sdk#2079. This property has not yet been finalized by the responsible team.