### PR TITLE
fix(cli-hooks): silence node warnings that can break @slack/cli-hooks

### DIFF
--- a/packages/cli-hooks/README.md
+++ b/packages/cli-hooks/README.md
@@ -76,7 +76,7 @@ Below is an example `slack.json` file that overrides the default `start` hook:
 ```json
 {
   "hooks": {
-    "get-hooks": "npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks",
+    "get-hooks": "NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks",
     "start": "npm run dev"
   }
 }

--- a/packages/cli-hooks/src/get-hooks.js
+++ b/packages/cli-hooks/src/get-hooks.js
@@ -45,9 +45,9 @@ if (fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
 export default function getHooks() {
   return {
     hooks: {
-      doctor: 'npx -q --no-install -p @slack/cli-hooks slack-cli-doctor',
-      'check-update': 'npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
-      'get-manifest': 'npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
+      doctor: 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor',
+      'check-update': 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
+      'get-manifest': 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
       start: 'npx -q --no-install -p @slack/cli-hooks slack-cli-start',
     },
     config: {

--- a/packages/cli-hooks/src/get-hooks.js
+++ b/packages/cli-hooks/src/get-hooks.js
@@ -43,6 +43,8 @@ if (fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
  * @returns {SDKInterface} Information about the hooks currently supported.
  */
 export default function getHooks() {
+  // NODE_NO_WARNINGS=1 silences node process warnings. These warnings can occur
+  // on some node version (e.g. v23.2.0) and cause invalid JSON hook responses.
   return {
     hooks: {
       doctor: 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor',

--- a/packages/cli-hooks/src/get-hooks.spec.js
+++ b/packages/cli-hooks/src/get-hooks.spec.js
@@ -6,9 +6,13 @@ import getHooks from './get-hooks.js';
 describe('get-hooks implementation', async () => {
   it('should return scripts for required hooks', async () => {
     const { hooks } = getHooks();
-    assert(hooks.doctor === 'npx -q --no-install -p @slack/cli-hooks slack-cli-doctor');
-    assert(hooks['check-update'] === 'npx -q --no-install -p @slack/cli-hooks slack-cli-check-update');
-    assert(hooks['get-manifest'] === 'npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest');
+    assert(hooks.doctor === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor');
+    assert(
+      hooks['check-update'] === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
+    );
+    assert(
+      hooks['get-manifest'] === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
+    );
     assert(hooks.start === 'npx -q --no-install -p @slack/cli-hooks slack-cli-start');
   });
 

--- a/packages/cli-hooks/src/protocols.js
+++ b/packages/cli-hooks/src/protocols.js
@@ -42,7 +42,7 @@ export function DefaultProtocol(args) {
   // If the particular hook invocation is requesting manifest generation we
   // ensure any logging is a no-op to prevent littering stdout with logging
   // and confusing the CLI's manifest JSON payload parsing.
-  const loggerMethod = manifestOnly ? () => { } : console.log;
+  const loggerMethod = manifestOnly ? () => {} : console.log;
   return {
     name: DEFAULT_PROTOCOL,
     log: loggerMethod,


### PR DESCRIPTION
### Summary

This pull request updates the `@slack/cli-hooks` to silence the node process warning output.

The reason for this update is that warnings can break some hooks, such as `get-manifest`, because the output must be valid JSON and the warning message is plain-text. For other hooks, such as `doctor` the warning is displayed to the user when the CLI command is executed, which can be confusing. I've left the warning for `start` because the user's code may need to print warning messages to the console.

### Example of a node warning message

This is an example using node v23.2.0:

```bash
$ npx slack-cli-get-hooks

(node:52368) ExperimentalWarning: CommonJS module /Users/michael.brooks/.nvm/versions/node/v23.2.0/lib/node_modules/npm/node_modules/debug/src/node.js is loading ES Module /Users/michael.brooks/.nvm/versions/node/v23.2.0/lib/node_modules/npm/node_modules/supports-color/index.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
{"hooks":{"doctor":"NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor","check-update":"NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update","get-manifest":"NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest","start":"npx -q --no-install -p @slack/cli-hooks slack-cli-start"},"config":{"watch":{"filter-regex":"^manifest\\.json$","paths":["."]},"protocol-version":["message-boundaries"],"sdk-managed-connection-enabled":true},"runtime":"node"}
```

### Expected `get-hooks` JSON

```json
{
   "config" : {
      "protocol-version" : [
         "message-boundaries"
      ],
      "sdk-managed-connection-enabled" : true,
      "watch" : {
         "filter-regex" : "^manifest\\.json$",
         "paths" : [
            "."
         ]
      }
   },
   "hooks" : {
      "check-update" : "NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update",
      "doctor" : "NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor",
      "get-manifest" : "NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest",
      "start" : "npx -q --no-install -p @slack/cli-hooks slack-cli-start"
   },
   "runtime" : "node"
}
```

### Reviewers

```bash
# Change into the cli-hooks package
$ cd node-slack-sdk/packages/cli-hooks

# Install the dependencies
$ npm install

# Run the get-hooks and (optionally) format the JSON
$ npx slack-cli-get-hooks | json_pp

# Expect the JSON response above
# - Confirm `NODE_NO_WARNINGS=1` for `check-update`, `doctor`, and `get-manifest`
# - You may see a warning when you run `get-hooks`, this warning can be safely ignored
#   because it will be silenced in `slack.json`

```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
