### PR TITLE
chore(deps): bump minimum axios version for web-api and webhook to avoid security vuln

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -38,7 +38,7 @@
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
     "@types/retry": "0.12.0",
-    "axios": "^1.7.4",
+    "axios": "^1.7.8",
     "eventemitter3": "^5.0.1",
     "form-data": "^4.0.0",
     "is-electron": "2.2.2",

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
-    "axios": "^1.7.4"
+    "axios": "^1.7.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",


### PR DESCRIPTION
### Summary

As described in issue https://github.com/slackapi/node-slack-sdk/issues/2115, a major security vuln has been patched in Axios `1.7.8`. Updating all packages that use this (`web-api` and `webhook`) so that minimum version is now `1.7.8`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
