### PR TITLE
Update webhook and web-api dependencies in oauth, rtm-api, and socket-mode

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,8 +48,8 @@
     "@slack/logger": ">=1.0.0 <3.0.0",
     "@slack/rtm-api": "^5.0.3",
     "@slack/types": "^1.2.1",
-    "@slack/web-api": "^5.3.0",
-    "@slack/webhook": "^5.0.2"
+    "@slack/web-api": "^7.8.0",
+    "@slack/webhook": "^7.0.4"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,8 +48,8 @@
     "@slack/logger": ">=1.0.0 <3.0.0",
     "@slack/rtm-api": "^5.0.3",
     "@slack/types": "^1.2.1",
-    "@slack/web-api": "^7.8.0",
-    "@slack/webhook": "^7.0.4"
+    "@slack/web-api": "^5.3.0",
+    "@slack/webhook": "^5.0.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.3.4",
+    "@slack/web-api": "^7.8.0",
     "@types/jsonwebtoken": "^9",
     "@types/node": ">=18",
     "jsonwebtoken": "^9",

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.3.4",
+    "@slack/web-api": "^7.8.0",
     "@types/node": ">=18",
     "eventemitter3": "^5",
     "finity": "^0.5.4",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.3.4",
+    "@slack/web-api": "^7.8.0",
     "@types/node": ">=18",
     "@types/ws": "^8",
     "eventemitter3": "^5",


### PR DESCRIPTION
### Summary

With medium security vulns upgrades causing version bumps in `webhook` and `web-api` (https://github.com/slackapi/node-slack-sdk/pull/2118), we can now update other packages that have these dependencies to the latest!

Once this PR is merged and `rtm-api`, `oauth`, and `socket-mode` patch versions are released, `bolt-js` will be updated with the latest versions of each of these.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
