### PR TITLE
Release: @slack/socket-mode@2.0.3, @slack/oauth@3.0.2, @slack/rtm-api@7.0.2

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/oauth",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Official library for interacting with Slack's Oauth endpoints",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/rtm-api",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Official library for using the Slack Platform's Real Time Messaging API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/socket-mode",
-  "version": "2.0.3-rc.1",
+  "version": "2.0.4",
   "description": "Official library for using the Slack Platform's Socket Mode API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
### Summary
Releases  @slack/socket-mode@2.0.3, @slack/oauth@3.0.2, @slack/rtm-api@7.0.2 to patch security vulns

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
