### PR TITLE
build: allow breaking change when updating typedoc for documentation builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -146,6 +146,9 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+          - "docusaurus-plugin-typedoc"
+          - "typedoc"
+          - "typedoc-plugin-markdown"
       slack:
         patterns:
           - "@slack/*"

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "@docusaurus/types": "3.6.3",
     "@tsconfig/recommended": "^1.0.8",
     "docusaurus-plugin-typedoc": "^1.0.5",
-    "typedoc": "^0.26.11",
+    "typedoc": ">=0.26.11",
     "typedoc-plugin-markdown": "^4.2.10"
   },
   "browserslist": {


### PR DESCRIPTION
### Summary

This PR fixes the breaking builds found in https://github.com/slackapi/node-slack-sdk/pull/2108 and #2121 by allowing breaking changes to the `typedoc` package of `docs` 📚 

### Notes

I'm hoping @dependabot can help with the actual update to `0.27.x` needed for these breaking builds, but this PR unlocks the update between `0.26.x` and `0.27.x` 🙏 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
