### PR TITLE
docs: replace redirected or missing links to sdk documentation

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -13,10 +13,10 @@ The Node Slack SDK has corresponding packages for Slack APIs. They are small and
 
 | Slack API    | Use | NPM package      |
 |--------------|--------------|-------------------|
-| Web API      | Send data to or query data from Slack using any of [over 200 methods](https://api.slack.com/methods). | [`@slack/web-api`](https://tools.slack.dev/node-slack-sdk/web-api) |
-| OAuth        | Set up the authentication flow using V2 OAuth for Slack apps as well as V1 OAuth for classic Slack apps. | [`@slack/oauth`](https://tools.slack.dev/node-slack-sdk/oauth) |
-| Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](https://tools.slack.dev/node-slack-sdk/webhook) |
-| Socket Mode  | Listen for incoming messages and a limited set of events happening in Slack, using WebSocket. | [`@slack/socket-mode`](https://tools.slack.dev/node-slack-sdk/socket-mode) |
+| Web API      | Send data to or query data from Slack using any of [over 200 methods](https://api.slack.com/methods). | [`@slack/web-api`](/web-api) |
+| OAuth        | Set up the authentication flow using V2 OAuth for Slack apps as well as V1 OAuth for classic Slack apps. | [`@slack/oauth`](/oauth) |
+| Incoming Webhooks | Send notifications to a single channel which the user picks on installation. | [`@slack/webhook`](/webhook) |
+| Socket Mode  | Listen for incoming messages and a limited set of events happening in Slack, using WebSocket. | [`@slack/socket-mode`](/socket-mode) |
 
 :::warning[Deprecation Notice]
 

--- a/docs/content/packages/oauth.md
+++ b/docs/content/packages/oauth.md
@@ -170,7 +170,7 @@ app.get('/slack/oauth_redirect', (req, res) => {
 
 There are many situations where you may want to persist some custom data relevant to your application across the entire OAuth flow. For example, you may want to map Slack resources (like users) to your own application's resources, or verify and gate eligibility for proceeding with installing your Slack application to a workspace based on your application's requirements. To this end, this package provides a series of hooks, or callbacks, that allow your application to integrate throughout key points of the OAuth flow.
 
-These are all callbacks customizable via the [`CallbackOptions`](reference/oauth#callbackoptions) and [`InstallPathOptions`](reference/oauth#installpathoptions) interfaces - check their [reference documentation](reference/oauth) for more details.
+These are all callbacks customizable via the [`CallbackOptions`](/reference/oauth/interfaces/CallbackOptions) and [`InstallPathOptions`](/reference/oauth/interfaces/InstallPathOptions) interfaces - check their [reference documentation](reference/oauth) for more details.
 
 For example, you may wish to store some information relevant to your application in a cookie before starting the OAuth flow and redirecting the user to the slack.com authorize URL. Once the user completes the authorization process on slack.com and is redirected back to your application, you can read this cookie and determine if the user has the appropriate permissions to proceed with installation of your application:
 
@@ -248,6 +248,7 @@ app.get('/slack/oauth_redirect', (req, res) => {
 });
 ```
 </details>
+
 ---
 
 ### Storing installations in a database

--- a/docs/content/packages/rtm-api.md
+++ b/docs/content/packages/rtm-api.md
@@ -646,7 +646,7 @@ const rtm = new RTMClient(token, options);
 
 ### Custom WebClient
 
-In some cases, you might want to customize the underlying component making HTTP requests to the Slack API, the [`WebClient`](reference/web-api#webclient), beyond the provided [`RTMClientOptions`](reference/rtm-api#rtmclientoptions). Note that overriding the [`WebClient`](reference/web-api#webclient) instance takes precedence over any other [`RTMClientOptions`](reference/rtm-api#rtmclientoptions) specified.
+In some cases, you might want to customize the underlying component making HTTP requests to the Slack API, the [`WebClient`](/reference/web-api/classes/WebClient), beyond the provided [`RTMClientOptions`](/reference/rtm-api/interfaces/RTMClientOptions). Note that overriding the [`WebClient`](/reference/web-api/classes/WebClient) instance takes precedence over any other [`RTMClientOptions`](/reference/rtm-api/interfaces/RTMClientOptions) specified.
 
 ```javascript
 const { RTMClient } = require('@slack/rtm-api');
@@ -674,7 +674,7 @@ The client can receive a snapshot of a portion of the workspace's state while it
 app needs to keep track of some data as it changes while the app runs, but it needs the initial start to get started.
 However, **this can also cause the client to fail to connect on large teams**. Our recommendation is to call the [Web
 API](/web-api) to retrieve workspace state while your app is connecting, instead of
-relying on the cache. See [sending rich messages](#send-messages) for an example of using the `WebClient` class inside
+relying on the cache. See [send rich messages](#send-a-message) for an example of using the `WebClient` class inside
 your app, and use [some of the other methods](https://api.slack.com/methods) to get data.
 
 If you're certain that you'd like to receive the snapshot, you can set the `useRtmConnect` option to `false`. This

--- a/docs/content/packages/web-api.md
+++ b/docs/content/packages/web-api.md
@@ -31,7 +31,7 @@ This article contains the steps you must follow to get your access token:
 3. [Install the app to a workspace](https://api.slack.com/authentication/basics#installing)
 4. Finally, [get your access token](https://api.slack.com/authentication/basics#getting-your-authentication-token)
 
-You can also read the [Getting Started guide](../getting-started) which guides
+You can also read the [Getting Started guide](/getting-started) which guides
 you through creating an app, retrieving an access token, and using this `@slack/web-api`
 package to post a message.
 

--- a/docs/content/packages/webhook.md
+++ b/docs/content/packages/webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Incoming Webhooks
-permalink: /webhook
+slug: /webhook
 ---
 
 # Slack Incoming Webhooks

--- a/docs/content/packages/webhook.md
+++ b/docs/content/packages/webhook.md
@@ -3,13 +3,6 @@ title: Incoming Webhooks
 slug: /webhook
 ---
 
-# Slack Incoming Webhooks
-
-[![build-ci](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/node-slack-sdk/actions/workflows/ci-build.yml)
-<!-- TODO: per-flag badge https://docs.codecov.io/docs/flags#section-flag-badges-and-graphs -->
-[![codecov](https://codecov.io/gh/slackapi/node-slack-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/slackapi/node-slack-sdk)
-<!-- TODO: npm versions with scoped packages: https://github.com/rvagg/nodei.co/issues/24 -->
-
 The `@slack/webhook` package contains a helper for making requests to Slack's [Incoming
 Webhooks](https://api.slack.com/incoming-webhooks). Use it in your app to send a notification to a channel.
 

--- a/packages/cli-hooks/package.json
+++ b/packages/cli-hooks/package.json
@@ -23,7 +23,7 @@
     "type": "git",
     "url": "git+https://github.com/slackapi/node-slack-sdk.git"
   },
-  "homepage": "https://slack.dev/node-slack-sdk",
+  "homepage": "https://tools.slack.dev/node-slack-sdk",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,7 +13,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk",
+  "homepage": "https://tools.slack.dev/node-slack-sdk",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -16,13 +16,13 @@ $ npm install @slack/oauth
 
 ## Usage
 
-These examples show how to get started using the most common features. You'll find more extensive [documentation on the package's website](https://slack.dev/node-slack-sdk/oauth).
+These examples show how to get started using the most common features. You'll find more extensive [documentation on the package's website](https://tools.slack.dev/node-slack-sdk/oauth).
 
 <!-- END: Remove before copying into the docs directory -->
 
 Before building an app, you'll need to [create a Slack app](https://api.slack.com/apps/new) and install it to your development workspace. You'll also need to copy the **Client ID** and **Client Secret** given to you by Slack under the **Basic Information** of your app configuration.
 
-It may be helpful to read the tutorials on [getting started](https://slack.dev/node-slack-sdk/getting-started) and [getting a public URL that can be used for development](https://slack.dev/node-slack-sdk/tutorials/local-development).
+It may be helpful to read the tutorials on [getting started](https://tools.slack.dev/node-slack-sdk/getting-started) and [getting a public URL that can be used for development](https://tools.slack.dev/node-slack-sdk/tutorials/local-development).
 
 ---
 

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -12,7 +12,7 @@
     "npm": ">=8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/oauth",
+  "homepage": "https://tools.slack.dev/node-slack-sdk/oauth",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -3,7 +3,7 @@
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://api.slack.com/rtm). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
-**Note**: RTM isn't available for modern scoped apps anymore. We recommend using the [Events API](https://slack.dev/node-slack-sdk/events-api) and [Web API](https://slack.dev/node-slack-sdk/web-api) instead. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [legacy scoped app](https://api.slack.com/apps?new_classic_app=1). If you have an existing RTM app, do not update its scopes as it will be updated to a modern scoped app and stop working with RTM.
+**Note**: The RTM API isn't available for modern granular-permissions apps, and you can no longer create new legacy apps. We recommend using [Bolt for JavaScript](https://tools.slack.dev/bolt-js). If you have an existing RTM app, do not update its scopes as it will be updated to a granular-permissions app and stop working with the RTM API.
 
 ## Installation
 
@@ -16,7 +16,7 @@ $ npm install @slack/rtm-api
 ## Usage
 
 These examples show the most common features of the `RTMClient`. You'll find even more extensive [documentation on the
-package's website](https://slack.dev/node-slack-sdk/rtm-api).
+package's website](https://tools.slack.dev/node-slack-sdk/rtm-api).
 
 <!-- END: Remove before copying into the docs directory -->
 
@@ -72,7 +72,7 @@ user ID and team ID, you can look those up any time the client is connected as t
 
 Options passed to the `.start()` method are passed through as arguments to the [`rtm.connect` Web API
 method](https://api.slack.com/methods/rtm.connect). These arguments deal with presence, which is discussed in more
-detail [on the documentation website](https://slack.dev/node-slack-sdk/rtm-api#presence).
+detail [on the documentation website](https://tools.slack.dev/node-slack-sdk/rtm-api/#presence).
 
 </details>
 

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -13,7 +13,7 @@
     "npm": ">=8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/rtm-api",
+  "homepage": "https://tools.slack.dev/node-slack-sdk/rtm-api",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/socket-mode",
+  "homepage": "https://tools.slack.dev/node-slack-sdk/socket-mode",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
     "npm": ">= 6.12.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk",
+  "homepage": "https://tools.slack.dev/node-slack-sdk",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -23,7 +23,7 @@ $ npm install @slack/web-api
 ## Usage
 
 These examples show the most common features of the `WebClient`. You'll find even more extensive [documentation on the
-package's website](https://slack.dev/node-slack-sdk/web-api).
+package's website](https://tools.slack.dev/node-slack-sdk/web-api).
 
 <!-- END: Remove before copying into the docs directory -->
 
@@ -101,7 +101,7 @@ const conversationId = '...';
 **Tip**: If you're using an editor that supports TypeScript, even if you're not using TypeScript to write your code,
 you'll get hints for all the arguments each method supports. This helps you save time by reducing the number of
 times you need to pop out to a webpage to check the reference. There's more information about [using
-TypeScript](https://slack.dev/node-slack-sdk/typescript) with this package in the documentation website.
+TypeScript](https://tools.slack.dev/node-slack-sdk/typescript) with this package in the documentation website.
 
 **Tip**: Use the [Block Kit Builder](https://api.slack.com/tools/block-kit-builder) for a playground
 where you can prototype your message's look and feel.
@@ -174,7 +174,7 @@ There are a few more types of errors that you might encounter, each with one of 
 
 * `ErrorCode.RateLimitedError`: The Web API cannot fulfill the API method call because your app has made too many
   requests too quickly. This error has a `retryAfter` property with the number of seconds you should wait before trying
-  again. See [the documentation on rate limit handling](https://slack.dev/node-slack-sdk/web-api/#rate-limits) to
+  again. See [the documentation on rate limit handling](https://tools.slack.dev/node-slack-sdk/web-api/#rate-limits) to
   understand how the client will automatically deal with these problems for you.
 
 * `ErrorCode.HTTPError`: The HTTP response contained an unfamiliar status code. The Web API only responds with `200`
@@ -366,7 +366,7 @@ retrying the API call. If you'd like to opt out of that behavior, set the `rejec
 
 ### More
 
-The [documentation website](https://slack.dev/node-slack-sdk/web-api) has information about these additional features of
+The [documentation website](https://tools.slack.dev/node-slack-sdk/web-api) has information about these additional features of
 the `WebClient`:
 
 *  Upload a file with a `Buffer` or a `ReadableStream`.

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -13,7 +13,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/web-api",
+  "homepage": "https://tools.slack.dev/node-slack-sdk/web-api",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1918,7 +1918,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
      * - multiple upload_files
      * Will try to honor both single file or content data supplied as well
      * as multiple file uploads property.
-     * @see {@link https://slack.dev/node-slack-sdk/web-api#upload-a-file `@slack/web-api` Upload a file documentation}.
+     * @see {@link https://tools.slack.dev/node-slack-sdk/web-api#upload-a-file `@slack/web-api` Upload a file documentation}.
      */
     uploadV2: bindFilesUploadV2<FilesUploadV2Arguments, WebAPICallResult>(this),
     comments: {

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -160,7 +160,7 @@ export interface FilesUploadV2ArgumentsMultipleFiles {
   file_uploads: ExcludeFromUnion<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
 }
 
-// https://slack.dev/node-slack-sdk/web-api#upload-a-file
+// https://tools.slack.dev/node-slack-sdk/web-api#upload-a-file
 export type FilesUploadV2Arguments = TokenOverridable &
   (FileUploadV2 | (Omit<FileUploadV2, 'file' | 'content'> & FilesUploadV2ArgumentsMultipleFiles));
 

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -13,7 +13,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://slack.dev/node-slack-sdk/webhook",
+  "homepage": "https://tools.slack.dev/node-slack-sdk/webhook",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Summary

This PR replaces redirected or unexpected links related to `tools.slack.dev` ✨ 

Some of these were found with searches for "https://slack.dev" and some were found in outputs from `npm run build` for `docs` :books:

### Preview

These updates are made to keep the [homepages on npmjs.com](https://www.npmjs.com/package/@slack/web-api) up to date! On the next releases of these packages I'm hoping this changes 👀 

### Notes

- The reference generation is causing a broken anchor link to appear! I'm hoping #2123 or related changes will fix this, but am avoiding adding CI checks due to this 🙏 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).