### PR TITLE
Add expand prfoperty to section block type

### DIFF
--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -314,6 +314,10 @@ export interface SectionBlock extends Block {
    * @description One of the compatible element objects.
    */
   accessory?: SectionBlockAccessory;
+  /**
+   * Whether or not this section block's text should always expand when rendered. If false or not provided, it may be rendered with a 'see more' option to expand and show the full text. For AI Assistant apps, this allows the app to post long messages without users needing to click 'see more' to expand the message.
+   */
+  expand?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Summary

This pull request adds a missing property to section block type: https://api.slack.com/reference/block-kit/blocks#section_fields

see also:
- https://github.com/slackapi/python-slack-sdk/pull/1635
- https://github.com/slackapi/java-slack-sdk/pull/1420

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
