### PR TITLE
feat(cli-test): include a verbose global option for cli commands

### DIFF
--- a/packages/cli-test/src/cli/cli-process.spec.ts
+++ b/packages/cli-test/src/cli/cli-process.spec.ts
@@ -140,6 +140,15 @@ describe('SlackCLIProcess class', () => {
         );
         spawnProcessSpy.resetHistory();
       });
+      it('should map verbose option to `--verbose`', async () => {
+        let cmd = new SlackCLIProcess(['help'], { verbose: true });
+        await cmd.execAsync();
+        sandbox.assert.calledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--verbose']));
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess(['help']);
+        await cmd.execAsync();
+        sandbox.assert.neverCalledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--verbose']));
+      });
     });
     describe('command options', () => {
       it('should pass command-level key/value options to command in the form `--<key> value`', async () => {

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -43,7 +43,7 @@ export interface SlackCLIGlobalOptions {
   verbose?: boolean;
 }
 
-export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost' | 'verbose'>;
+export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost'>;
 
 export type SlackCLICommandOptions = Record<string, string | boolean | number | undefined>;
 

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -43,7 +43,7 @@ export interface SlackCLIGlobalOptions {
   verbose?: boolean;
 }
 
-export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost'>;
+export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost' | 'verbose'>;
 
 export type SlackCLICommandOptions = Record<string, string | boolean | number | undefined>;
 

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -39,6 +39,8 @@ export interface SlackCLIGlobalOptions {
   team?: string;
   /** @description Access token to use when making Slack API calls. */
   token?: string;
+  /** @description Print debug logging and additional CLI information. */
+  verbose?: boolean;
 }
 
 export type SlackCLIHostTargetOptions = Pick<SlackCLIGlobalOptions, 'qa' | 'dev' | 'apihost'>;
@@ -143,6 +145,9 @@ export class SlackCLIProcess {
       // Specifying custom token
       if (opts.token) {
         cmd = cmd.concat(['--token', opts.token]);
+      }
+      if (opts.verbose) {
+        cmd = cmd.concat(['--verbose']);
       }
     } else {
       cmd = cmd.concat(['--skip-update', '--force', '--app', 'deployed']);

--- a/packages/cli-test/src/cli/commands/auth.ts
+++ b/packages/cli-test/src/cli/commands/auth.ts
@@ -7,13 +7,21 @@ import {
 
 import type { ShellProcess } from '../../types/shell';
 
+type AuthLoginNoPromptArguments = SlackCLIHostTargetOptions & Pick<SlackCLIGlobalOptions, 'verbose'>;
+type AuthLoginChallengeExchangeArugments = SlackCLIHostTargetOptions & {
+  /** @description Challenge string extracted from the Slack client UI after submitting the auth slash command. */
+  challenge: string;
+  /** @description The `authTicket` output from `loginNoPrompt`; required to complete the login flow. */
+  authTicket: string;
+} & Pick<SlackCLIGlobalOptions, 'verbose'>;
+
 export default {
   /**
    *  `slack login --no-prompt`; initiates a CLI login flow. The `authTicketSlashCommand` returned should be entered
    *  into the Slack client, and the challenge code retrieved and fed into the `loginChallengeExchange` method to
    *  complete the CLI login flow.
    */
-  loginNoPrompt: async function loginNoPrompt(args?: SlackCLIHostTargetOptions): Promise<{
+  loginNoPrompt: async function loginNoPrompt(args?: AuthLoginNoPromptArguments): Promise<{
     /** @description Command output */
     output: ShellProcess['output'];
     /**
@@ -57,12 +65,7 @@ export default {
    * @returns
    */
   loginChallengeExchange: async function loginChallengeExchange(
-    args: SlackCLIHostTargetOptions & {
-      /** @description Challenge string extracted from the Slack client UI after submitting the auth slash command. */
-      challenge: string;
-      /** @description The `authTicket` output from `loginNoPrompt`; required to complete the login flow. */
-      authTicket: string;
-    },
+    args: AuthLoginChallengeExchangeArugments,
   ): Promise<string> {
     const cmd = new SlackCLIProcess(['login'], args, {
       '--no-prompt': true,


### PR DESCRIPTION
### Summary

This PR adds a **verbose** option to `@slack/cli-test` to add additional output information to specific commands.

### Preview

```diff
    const createOutput = await SlackCLI.create({
      template: 'slack-samples/deno-starter-template',
      branch: 'main',
      appPath,
+     verbose: true
    });
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).