### PR TITLE
fix(cli-test): remove the trailing newline from parsed cli outputs

### DIFF
--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -72,6 +72,13 @@ describe('shell module', () => {
         sinon.match({ shell: true, env: fakeEnv }),
       );
     });
+    it('should return the command outputs unchanged', () => {
+      const fakeCmd = 'echo';
+      const fakeArgs = ['"greetings"'];
+      const sh = shell.spawnProcess(fakeCmd, fakeArgs);
+      spawnProcess.stdout.emit('data', 'outputs\r\n');
+      assert.equal(sh.output, 'outputs\r\n');
+    });
     it('should raise bubble error details up', () => {
       runSpy.throws(new Error('this is bat country'));
       assert.throw(() => {
@@ -129,6 +136,15 @@ describe('shell module', () => {
       assert.throw(() => {
         shell.spawnProcess('about to explode', []);
       }, /this is bat country/);
+    });
+    it('should return the command outputs unchanged', () => {
+      const fakeCmd = 'echo';
+      const fakeArgs = ['"greetings"'];
+      const sh = shell.spawnProcess(fakeCmd, fakeArgs);
+      spawnProcess.stdout.emit('data', 'outputs\r\n');
+      spawnProcess.stderr.emit('data', 'warning\n');
+      spawnProcess.stdout.emit('data', 'endings\r\n');
+      assert.equal(sh.output, 'outputs\r\nwarning\nendings\r\n');
     });
     if (process.platform === 'win32') {
       it('on Windows, should wrap command to shell out in a `cmd /s /c` wrapper process', () => {

--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -131,12 +131,6 @@ describe('shell module', () => {
         sinon.match({ shell: true, env: fakeEnv }),
       );
     });
-    it('should raise bubble error details up', () => {
-      spawnSpy.throws(new Error('this is bat country'));
-      assert.throw(() => {
-        shell.spawnProcess('about to explode', []);
-      }, /this is bat country/);
-    });
     it('should return the command outputs unchanged', () => {
       const fakeCmd = 'echo';
       const fakeArgs = ['"greetings"'];
@@ -145,6 +139,12 @@ describe('shell module', () => {
       spawnProcess.stderr.emit('data', 'warning\n');
       spawnProcess.stdout.emit('data', 'endings\r\n');
       assert.equal(sh.output, 'outputs\r\nwarning\nendings\r\n');
+    });
+    it('should raise bubble error details up', () => {
+      spawnSpy.throws(new Error('this is bat country'));
+      assert.throw(() => {
+        shell.spawnProcess('about to explode', []);
+      }, /this is bat country/);
     });
     if (process.platform === 'win32') {
       it('on Windows, should wrap command to shell out in a `cmd /s /c` wrapper process', () => {

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -42,17 +42,17 @@ export const shell = {
       // Listen to data event that returns all the output and collect it
       // biome-ignore lint/suspicious/noExplicitAny: stdout can accept a variety of data
       childProcess.stdout.on('data', (data: any) => {
-        const output = this.removeANSIcolors(data.toString()).replace(/\r?\n$/, '');
+        const output = this.removeANSIcolors(data.toString());
         sh.output += output;
-        logger.verbose(`Output: ${output}`);
+        logger.verbose(`Output: ${output.replace(/\r?\n$/, '')}`);
       });
 
       // Collect error output
       // biome-ignore lint/suspicious/noExplicitAny: stderr can accept a variety of data
       childProcess.stderr.on('data', (data: any) => {
-        const output = this.removeANSIcolors(data.toString()).replace(/\r?\n$/, '');
+        const output = this.removeANSIcolors(data.toString());
         sh.output += output;
-        logger.error(`Error: ${output}`);
+        logger.error(`Error: ${output.replace(/\r?\n$/, '')}`);
       });
 
       // Set the finished flag to true on close event
@@ -92,7 +92,7 @@ export const shell = {
       // Log command
       logger.info(`CLI Command finished: ${cmdString}`);
 
-      return this.removeANSIcolors(result.stdout.toString()).replace(/\r?\n$/, '');
+      return this.removeANSIcolors(result.stdout.toString());
     } catch (error) {
       throw new Error(`runCommandSync failed!\nCommand: ${cmdString}\nError: ${error}`);
     }

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -42,15 +42,17 @@ export const shell = {
       // Listen to data event that returns all the output and collect it
       // biome-ignore lint/suspicious/noExplicitAny: stdout can accept a variety of data
       childProcess.stdout.on('data', (data: any) => {
-        sh.output += this.removeANSIcolors(data.toString());
-        logger.verbose(`Output: ${this.removeANSIcolors(data.toString())}`);
+        const output = this.removeANSIcolors(data.toString()).replace(/\r?\n$/, '');
+        sh.output += output;
+        logger.verbose(`Output: ${output}`);
       });
 
       // Collect error output
       // biome-ignore lint/suspicious/noExplicitAny: stderr can accept a variety of data
       childProcess.stderr.on('data', (data: any) => {
-        sh.output += this.removeANSIcolors(data.toString());
-        logger.error(`Error: ${this.removeANSIcolors(data.toString())}`);
+        const output = this.removeANSIcolors(data.toString()).replace(/\r?\n$/, '');
+        sh.output += output;
+        logger.error(`Error: ${output}`);
       });
 
       // Set the finished flag to true on close event
@@ -90,7 +92,7 @@ export const shell = {
       // Log command
       logger.info(`CLI Command finished: ${cmdString}`);
 
-      return this.removeANSIcolors(result.stdout.toString());
+      return this.removeANSIcolors(result.stdout.toString()).replace(/\r?\n$/, '');
     } catch (error) {
       throw new Error(`runCommandSync failed!\nCommand: ${cmdString}\nError: ${error}`);
     }


### PR DESCRIPTION
### Summary

This PR removes the trailing newline found in CLI outputs **before** logging to `error` or `verbose` since the logger adds a newline itself!

No change is made to the captured shell outputs, besides the existing `removeANSIcolors` function, to avoid breaking outputs that expect certain linebreaks 🙏 ✨ 

### Preview

The following example uses changes in #2147 to showcase linebreaks:

#### Before changes

![before](https://github.com/user-attachments/assets/7c65c123-d75e-4920-a938-312fb8daef43)

#### After changes

![after](https://github.com/user-attachments/assets/d601fe36-d0d6-46e1-ad9e-a5a564b86627)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
