### PR TITLE
feat(cli-hooks): output node warnings to stderr for debugging outputs

### DIFF
--- a/packages/cli-hooks/src/get-hooks.js
+++ b/packages/cli-hooks/src/get-hooks.js
@@ -43,13 +43,11 @@ if (fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
  * @returns {SDKInterface} Information about the hooks currently supported.
  */
 export default function getHooks() {
-  // NODE_NO_WARNINGS=1 silences node process warnings. These warnings can occur
-  // on some node version (e.g. v23.2.0) and cause invalid JSON hook responses.
   return {
     hooks: {
-      doctor: 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor',
-      'check-update': 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
-      'get-manifest': 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
+      doctor: 'npx -q --no-install -p @slack/cli-hooks slack-cli-doctor',
+      'check-update': 'npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
+      'get-manifest': 'npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
       start: 'npx -q --no-install -p @slack/cli-hooks slack-cli-start',
     },
     config: {

--- a/packages/cli-hooks/src/get-hooks.spec.js
+++ b/packages/cli-hooks/src/get-hooks.spec.js
@@ -6,13 +6,9 @@ import getHooks from './get-hooks.js';
 describe('get-hooks implementation', async () => {
   it('should return scripts for required hooks', async () => {
     const { hooks } = getHooks();
-    assert(hooks.doctor === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-doctor');
-    assert(
-      hooks['check-update'] === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-check-update',
-    );
-    assert(
-      hooks['get-manifest'] === 'NODE_NO_WARNINGS=1 npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest',
-    );
+    assert(hooks.doctor === 'npx -q --no-install -p @slack/cli-hooks slack-cli-doctor');
+    assert(hooks['check-update'] === 'npx -q --no-install -p @slack/cli-hooks slack-cli-check-update');
+    assert(hooks['get-manifest'] === 'npx -q --no-install -p @slack/cli-hooks slack-cli-get-manifest');
     assert(hooks.start === 'npx -q --no-install -p @slack/cli-hooks slack-cli-start');
   });
 


### PR DESCRIPTION
### Summary

This PR reverts changes made in #2096 that hide Node warnings.

The latest Slack CLI version v2.33.0 has improved handling of `stderr` and will now write unexpected output to debug logs instead of erroring when parsing hook responses! 🎉 

### Preview

https://github.com/user-attachments/assets/e9d2e57c-6505-445a-b076-09fdba3c07fe

### Reviewers

With these changes checked out and installed to an app using `@slack/cli-hooks`, run the following commands with Node v23.2.0:

```sh
$ slack manifest     # Get an app manifest
$ slack manifest -v  # Review debug logs
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
