### PR TITLE
feat(cli-hooks): exit the start process with the subprocess exit code

### DIFF
--- a/packages/cli-hooks/src/start.js
+++ b/packages/cli-hooks/src/start.js
@@ -33,7 +33,7 @@ export default function start(cwd) {
     process.stderr.write(data);
   });
   app.on('close', (code) => {
-    console.log(`Local run exited with code ${code}`);
+    process.exit(code);
   });
 }
 

--- a/packages/cli-hooks/src/start.spec.js
+++ b/packages/cli-hooks/src/start.spec.js
@@ -23,7 +23,7 @@ import start from './start.js';
 describe('start implementation', async () => {
   describe('begins the app process', async () => {
     /** @type {sinon.SinonStub} */
-    let consoleLogStub;
+    let exitStub;
     /** @type {sinon.SinonStub} */
     let stdoutWriteStub;
     /** @type {sinon.SinonStub} */
@@ -34,7 +34,7 @@ describe('start implementation', async () => {
     let spawnStub;
 
     beforeEach(() => {
-      consoleLogStub = sinon.stub(console, 'log');
+      exitStub = sinon.stub(process, 'exit');
       stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stderrWriteStub = sinon.stub(process.stderr, 'write');
       mockSpawnProcess = {
@@ -84,7 +84,7 @@ describe('start implementation', async () => {
         assert.ok(spawnStub.calledWith('node', [path.resolve('tmp', 'start.js')]));
         assert.ok(stdoutWriteStub.calledWith('message'));
         assert.ok(stderrWriteStub.calledWith('warning'));
-        assert.ok(consoleLogStub.calledWith('Local run exited with code 0'));
+        assert.ok(exitStub.calledWith(0));
       });
     });
 
@@ -99,7 +99,7 @@ describe('start implementation', async () => {
         assert.ok(spawnStub.calledWith('node', [path.resolve('tmp', 'app.js')]));
         assert.ok(stdoutWriteStub.calledWith('defaults'));
         assert.ok(stderrWriteStub.calledWith('watch out'));
-        assert.ok(consoleLogStub.calledWith('Local run exited with code 2'));
+        assert.ok(exitStub.calledWith(2));
       });
     });
 
@@ -122,7 +122,7 @@ describe('start implementation', async () => {
         assert.ok(spawnStub.calledWith('node', [path.resolve('application.js')]));
         assert.ok(stdoutWriteStub.calledWith('startled'));
         assert.ok(stderrWriteStub.calledWith('erroneous'));
-        assert.ok(consoleLogStub.calledWith('Local run exited with code 4'));
+        assert.ok(exitStub.calledWith(4));
       });
     });
   });


### PR DESCRIPTION
### Summary

This PR uses `process.exit` to exit the "start" hook with the exit code matching the provided script 👾 

### Preview

https://github.com/user-attachments/assets/e5290507-8adf-4283-868d-01599bd1beda

### Reviewers

Testing this requires a development CLI build that avoids overwriting these exit codes as well!

Recommended `start` hook cases to test might include:

- No change! The app should run or error as expected
- `exit 2`! Use a custom error code
- `sleep 12`! Interrupt a waiting process

### Notes

IIRC the `console.log` that was removed was used as a shortcut for exiting as expected! This is removed which might cause confusion in CLI versions v2.33.0 or earlier since the process hangs intead of exits... Fixes are following in the development build!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
