### PR TITLE
fix: configure dependabot to group react deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -152,6 +152,10 @@ updates:
       slack:
         patterns:
           - "@slack/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
     schedule:
       interval: "monthly"
 


### PR DESCRIPTION
### Summary

#2158 and #2157 are failing tests because dependabot is opening separate PRs for react and react-dom dependencies, I believe these dependencies must stay in sync in order for the tests to pass.

Once this PR is merged dependabot should open one single PR to replace #2158 and #2157

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
