### PR TITLE
fix: make tests more stable

### DIFF
--- a/packages/oauth/.mocharc.json
+++ b/packages/oauth/.mocharc.json
@@ -1,3 +1,7 @@
 {
-  "require": ["ts-node/register", "source-map-support/register"]
+  "require": [
+    "ts-node/register",
+    "source-map-support/register"
+  ],
+  "timeout": "4000"
 }

--- a/packages/oauth/.mocharc.json
+++ b/packages/oauth/.mocharc.json
@@ -1,7 +1,4 @@
 {
-  "require": [
-    "ts-node/register",
-    "source-map-support/register"
-  ],
+  "require": ["ts-node/register", "source-map-support/register"],
   "timeout": "4000"
 }

--- a/packages/oauth/src/state-stores/spec-utils.ts
+++ b/packages/oauth/src/state-stores/spec-utils.ts
@@ -18,7 +18,7 @@ export class StateStoreChaiTestRunner {
     this.shouldVerifyOnlyOnce = args.shouldVerifyOnlyOnce === undefined ? true : args.shouldVerifyOnlyOnce;
   }
 
-  public async enableTests(testTarget: string): Promise<void> {
+  public enableTests(testTarget: string): void {
     describe(testTarget, () => {
       it('should generate and verify valid state values', async () => {
         const { stateStore } = this;


### PR DESCRIPTION
### Summary

This PR aims to make the CI pipeline more stable by extending the timeout requirement of mocha. After looking at the error messages it seems like windows instances may be slower then linux instances making some tests time out

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
