### PR TITLE
Add typing to AppMentionEvent files array

### DIFF
--- a/packages/types/src/events/app.ts
+++ b/packages/types/src/events/app.ts
@@ -134,7 +134,38 @@ export interface AppMentionEvent {
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];
   // TODO: Add more properties once the types library has a file object definition
-  files?: { id: string }[];
+  files?: {
+    id: string;
+    created: number;
+    timestamp: number;
+    name: string;
+    title: string;
+    mimetype: string;
+    filetype: string;
+    pretty_type: string;
+    user: string;
+    user_team: string;
+    editable: boolean;
+    size: number;
+    mode: string;
+    is_external: boolean;
+    external_type: string;
+    is_public: boolean;
+    public_url_shared: boolean;
+    display_as_bot: boolean;
+    username: string;
+    url_private: string;
+    url_private_download: string;
+    media_display_type: string;
+    thumb_pdf?: string;
+    thumb_pdf_w?: number;
+    thumb_pdf_h?: number;
+    permalink: string;
+    permalink_public: string;
+    is_starred: boolean;
+    has_rich_preview: boolean;
+    file_access: string;
+  }[];
   upload?: boolean;
   display_as_bot?: boolean;
   edited?: {


### PR DESCRIPTION
### Summary

This fixes the lack of typing for AppMentionEvent's files array. There's already a note to add it.

See https://github.com/slackapi/node-slack-sdk/blob/039bd050cd736d666d063397067cb014adf23711/packages/types/src/events/app.ts#L136

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
