### PR TITLE
chore(webhook): bump axios to 1.8.2 to address CVE-2025-27152

### DIFF
--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@slack/types": "^2.9.0",
     "@types/node": ">=18.0.0",
-    "axios": "^1.7.8"
+    "axios": "^1.8.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",


### PR DESCRIPTION
### Summary

This PR updates `axios` to `1.8.2` to address CVE-2025-27152 - as noted in #2169 🔐 

A `semver:minor` release for `axios` happened with this change, but AFAICT no other changes are needed. It might be nice to share [these changes](https://github.com/axios/axios/releases/tag/v1.8.0) in a following patch 👀 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
