### PR TITLE
ci: cancel test jobs with a timeout after running for four minutes

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 4
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Summary

This PR changes the test timeout time from "10" minutes to "4" minutes to avoid hanging after failed tests in some cases - related to #2138 #2159.

### Notes

Most **successful** tests tend to finish in ~2 minutes, with 1/200 of the last **successful** runs taking 4:08 which seems to've been a flake...

IMO this doesn't fix the related issues, but it makes rerunning the tests faster in the meantime 😅 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).