### PR TITLE
test(socket-mode): assert a certain amount of close events happen after disconnecting

### DIFF
--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -205,7 +205,7 @@ describe('Integration tests with a WebSocket server', () => {
       // crucially, the bug reported in https://github.com/slackapi/node-slack-sdk/issues/2094 shows that on every reconnection attempt, we spawn _another_ websocket instance, which attempts to reconnect forever and is never cleaned up.
       // effectively: with each reconnection attempt, we double the number of websockets, eventually causing crashes / out-of-memory issues / rate-limiting from Slack APIs.
       // with the bug not fixed, this assertion fails as `close` event was emitted 4 times! if we waited another 20ms, we would see this event count double again (8), and so on.
-      assert.equal(closed, 2, 'unexpected number of times `close` event was raised during reconnection!');
+      const retries = closed;
       await client.disconnect();
       await new Promise((res, rej) => {
         // shut down the bad server
@@ -214,6 +214,7 @@ describe('Integration tests with a WebSocket server', () => {
           else res();
         });
       });
+      assert.equal(retries, 2, 'unexpected number of times `close` event was raised during reconnection!');
     });
   });
   describe('lifecycle events', () => {


### PR DESCRIPTION
### Summary

This PR asserts the "should maintain one serial reconnection attempt if WSS server sends unexpected HTTP response during handshake, like a 409" test has an expected number of retries **after** performing test cleanups.

This fixes an issue where a failing assert causes the test runner to [not complete](https://github.com/slackapi/node-slack-sdk/actions/runs/13909410579/job/38920008887#step:9:155)! This is for better insights into https://github.com/slackapi/node-slack-sdk/issues/2138 and https://github.com/slackapi/node-slack-sdk/issues/2159 patterns following #2178.

### Preview

This video shows this failing test before and after the changes 👾 

https://github.com/user-attachments/assets/ea80a318-3653-4f18-88ed-af2f12383c94

### Notes

Handfuls of reruns makes me believe more and more that **this** test is failing due to how precise CI handles milliseconds and opened ports. This PR doesn't update related logic, but I'm hoping failing test results give us insight into this!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
