### PR TITLE
chore(rtm-api): bump @slack/web-api from 7.8.0 to 7.9.1

### DIFF
--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.8.0",
+    "@slack/web-api": "^7.9.0",
     "@types/node": ">=18",
     "eventemitter3": "^5",
     "finity": "^0.5.4",

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.9.0",
+    "@slack/web-api": "^7.9.1",
     "@types/node": ">=18",
     "eventemitter3": "^5",
     "finity": "^0.5.4",


### PR DESCRIPTION
### Summary

This PR bumps `@slack/web-api` to [7.9.1](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%407.9.1) for the updates of #2172 in [7.9.0](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%407.9.0)🤖 

### Notes

No change to functionality or use since the internal `WebClient` doesn't make use of provided method names!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).