### PR TITLE
fix(web-api): complete file upload v2 calls if absolute urls are not allowed

### DIFF
--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1163,7 +1163,7 @@ describe('WebClient', () => {
         content: 'Happiness!', // test string
         filename: 'happiness.txt',
         title: 'Testing Happiness',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
 
       // returns exactly one file upload
@@ -1176,7 +1176,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
 
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable
@@ -1223,7 +1223,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
       // 1 entry at the top level + 4 jobs from files in files_uploads
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1297,7 +1297,7 @@ describe('WebClient', () => {
         content: 'Happiness!', // test string
         filename: 'happiness.txt',
         title: 'Testing Happiness',
-        channel_id: 'C1234',
+        channels: 'C1234',
       };
 
       // returns exactly one file upload
@@ -1310,7 +1310,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channel_id: 'C1234',
+        channels: 'C1234',
       };
 
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable
@@ -1357,7 +1357,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channel_id: 'C1234',
+        channels: 'C1234',
       };
       // 1 entry at the top level + 4 jobs from files in files_uploads
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1156,6 +1156,140 @@ describe('WebClient', () => {
     });
   });
 
+  describe('filesUploadV2', () => {
+    it('uploads a single file', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/files.getUploadURLExternal', { filename: 'test-txt.txt', length: 18 })
+        .reply(200, {
+          ok: true,
+          file_id: 'F0123456789',
+          upload_url: 'https://files.slack.com/upload/v1/abcdefghijklmnopqrstuvwxyz',
+        })
+        .post('/api/files.completeUploadExternal', { files: '[{"id":"F0123456789","title":"test-txt.txt"}]' })
+        .reply(200, {
+          ok: true,
+          files: [
+            {
+              id: 'F0123456789',
+              name: 'test-txt.txt',
+              permalink: 'https://my-workspace.slack.com/files/U0123456789/F0123456789/test-txt.txt',
+            },
+          ],
+        });
+      const uploader = nock('https://files.slack.com').post('/upload/v1/abcdefghijklmnopqrstuvwxyz').reply(200);
+      const client = new WebClient(token);
+      const response = await client.filesUploadV2({
+        file: fs.createReadStream('./test/fixtures/test-txt.txt'),
+        filename: 'test-txt.txt',
+      });
+      const expected = {
+        ok: true,
+        files: [
+          {
+            ok: true,
+            files: [
+              {
+                id: 'F0123456789',
+                name: 'test-txt.txt',
+                permalink: 'https://my-workspace.slack.com/files/U0123456789/F0123456789/test-txt.txt',
+              },
+            ],
+            response_metadata: {},
+          },
+        ],
+      };
+      assert.deepEqual(response, expected);
+      scope.done();
+      uploader.done();
+    });
+
+    it('uploads multiple files', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/files.getUploadURLExternal', { filename: 'test-png.png', length: 55292 })
+        .reply(200, {
+          ok: true,
+          file_id: 'F0000000001',
+          upload_url: 'https://files.slack.com/upload/v1/zyxwvutsrqponmlkjihgfedcba',
+        })
+        .post('/api/files.getUploadURLExternal', { filename: 'test-txt.txt', length: 18 })
+        .reply(200, {
+          ok: true,
+          file_id: 'F0123456789',
+          upload_url: 'https://files.slack.com/upload/v1/abcdefghijklmnopqrstuvwxyz',
+        })
+        .post('/api/files.completeUploadExternal', (args) => {
+          const { channel_id, thread_ts, initial_comment, files } = args;
+          return (
+            channel_id === 'C0123456789' &&
+            thread_ts === '1223313423434.131321' &&
+            initial_comment === 'success!' &&
+            (files === '[{"id":"F0123456789","title":"test-txt.txt"},{"id":"F0000000001","title":"test-png.png"}]' ||
+              files === '[{"id":"F0000000001","title":"test-png.png"},{"id":"F0123456789","title":"test-txt.txt"}]')
+          );
+        })
+        .reply(200, {
+          ok: true,
+          files: [
+            {
+              id: 'F0123456789',
+              name: 'test-txt.txt',
+              permalink: 'https://my-workspace.slack.com/files/U0123456789/F0123456789/test-txt.txt',
+            },
+            {
+              id: 'F0000000001',
+              name: 'test-png.png',
+              permalink: 'https://my-workspace.slack.com/files/U0123456789/F0000000001/test-png.png',
+            },
+          ],
+        });
+      const uploader = nock('https://files.slack.com')
+        .post('/upload/v1/abcdefghijklmnopqrstuvwxyz')
+        .reply(200)
+        .post('/upload/v1/zyxwvutsrqponmlkjihgfedcba')
+        .reply(200);
+      const client = new WebClient(token, { allowAbsoluteUrls: false });
+      const response = await client.filesUploadV2({
+        channel_id: 'C0123456789',
+        thread_ts: '1223313423434.131321',
+        initial_comment: 'success!',
+        file_uploads: [
+          {
+            file: fs.createReadStream('./test/fixtures/test-txt.txt'),
+            filename: 'test-txt.txt',
+          },
+          {
+            file: fs.createReadStream('./test/fixtures/test-png.png'),
+            filename: 'test-png.png',
+          },
+        ],
+      });
+      const expected = {
+        ok: true,
+        files: [
+          {
+            ok: true,
+            files: [
+              {
+                id: 'F0123456789',
+                name: 'test-txt.txt',
+                permalink: 'https://my-workspace.slack.com/files/U0123456789/F0123456789/test-txt.txt',
+              },
+              {
+                id: 'F0000000001',
+                name: 'test-png.png',
+                permalink: 'https://my-workspace.slack.com/files/U0123456789/F0000000001/test-png.png',
+              },
+            ],
+            response_metadata: {},
+          },
+        ],
+      };
+      assert.deepEqual(response, expected);
+      scope.done();
+      uploader.done();
+    });
+  });
+
   describe('getAllFileUploads', () => {
     const client = new WebClient(token);
     it('adds a single file data to uploads with content supplied', async () => {

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -919,7 +919,7 @@ describe('WebClient', () => {
           await client.apiCall('method', { foo: 'bar' });
           assert.fail('expected error to be thrown');
         } catch (_err) {
-          assert(spy.calledOnceWith(0, sinon.match({ url: 'method', body: { foo: 'bar' } })));
+          assert(spy.calledOnceWith(0, sinon.match({ url: 'https://slack.com/api/method', body: { foo: 'bar' } })));
           scope.done();
         }
       });
@@ -982,7 +982,7 @@ describe('WebClient', () => {
         await client.apiCall('method', { foo: 'bar' });
         assert.fail('expected error to be thrown');
       } catch (_err) {
-        assert(spy.calledOnceWith(0, sinon.match({ url: 'method', body: { foo: 'bar' } })));
+        assert(spy.calledOnceWith(0, sinon.match({ url: 'https://slack.com/api/method', body: { foo: 'bar' } })));
         scope.done();
       }
     });

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -312,7 +312,6 @@ export class WebClient extends Methods {
       adapter: adapter ? (config: InternalAxiosRequestConfig) => adapter({ ...config, adapter: undefined }) : undefined,
       timeout,
       baseURL: slackApiUrl,
-      allowAbsoluteUrls,
       headers: isElectron() ? headers : { 'User-Agent': getUserAgent(), ...headers },
       httpAgent: agent,
       httpsAgent: agent,
@@ -360,8 +359,9 @@ export class WebClient extends Methods {
     const headers: Record<string, string> = {};
     if (options.token) headers.Authorization = `Bearer ${options.token}`;
 
+    const url = this.deriveRequestUrl(method);
     const response = await this.makeRequest(
-      method,
+      url,
       {
         team_id: this.teamId,
         ...options,
@@ -646,8 +646,6 @@ export class WebClient extends Methods {
     // TODO: better input types - remove any
     const task = () =>
       this.requestQueue.add(async () => {
-        const requestURL = this.deriveRequestUrl(url);
-
         try {
           // biome-ignore lint/suspicious/noExplicitAny: TODO: type this
           const config: any = {
@@ -664,7 +662,7 @@ export class WebClient extends Methods {
           if (url.endsWith('apps.event.authorizations.list')) {
             body.token = undefined;
           }
-          this.logger.debug(`http request url: ${requestURL}`);
+          this.logger.debug(`http request url: ${url}`);
           this.logger.debug(`http request body: ${JSON.stringify(redact(body))}`);
           // compile all headers - some set by default under the hood by axios - that will be sent along
           let allHeaders: Record<string, AxiosHeaderValue | undefined> = Object.keys(


### PR DESCRIPTION
### Summary

This PR fixes an issue where setting the [`allowAbsoluteUrls`](https://tools.slack.dev/node-slack-sdk/reference/web-api/interfaces/WebClientOptions#allowabsoluteurls) option to `true` causes the `filesUploadV2` method to error!

Some investigating points at the "https://files.slack.com/..." URL gathered to POST files to having a different base URL than other API request at "https://slack.com/api/..." 🤖 

### Preview

The changes of this PR make the following example upload as expected:

```ts
import webapi, { LogLevel } from "@slack/web-api";

const client = new webapi.WebClient(process.env.SLACK_BOT_TOKEN, {
  allowAbsoluteUrls: false,
  logLevel: LogLevel.DEBUG,
});

const _response = await client.filesUploadV2({
  file: "./path/to/example.png",
  filename: "example.png",
  channel_id: process.env.SLACK_CHANNEL_ID,
});
```

### Notes

Changes were made to derive the absolute URL to use in requests **before** the internal `makeRequest` function. This was done since both `.apiCall` and `.filesUploadV2` make requests using different URLs but the same `axios` client 👾 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
