### PR TITLE
test(web-api): use channel_id instead of channels with files upload v2

### DIFF
--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1163,7 +1163,7 @@ describe('WebClient', () => {
         content: 'Happiness!', // test string
         filename: 'happiness.txt',
         title: 'Testing Happiness',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
 
       // returns exactly one file upload
@@ -1176,7 +1176,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
 
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable
@@ -1223,7 +1223,7 @@ describe('WebClient', () => {
         file: './test/fixtures/test-txt.txt', // test string
         filename: 'test.txt',
         title: 'Test file',
-        channels: 'C1234',
+        channel_id: 'C1234',
       };
       // 1 entry at the top level + 4 jobs from files in files_uploads
       // @ts-expect-error getAllFileUploads is a private method, TODO: refactor into own function/module that is more easily testable


### PR DESCRIPTION
### Summary

This PR replaces `channels` with `channel_id` in tests testing the `filesUploadV2` method to avoid warnings in test output 👾 

### Preview

Before changes: https://github.com/slackapi/node-slack-sdk/actions/runs/13958988507/job/39077186721#step:9:239

```
    getAllFileUploads
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
      ✔ adds a single file data to uploads with content supplied
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
      ✔ adds a single file data to uploads with file supplied
      ✔ adds multiple files data to an upload
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
[WARN]  web-api:WebClient:0 Although the 'channels' parameter is still supported for smoother migration from legacy files.upload, we recommend using the new channel_id parameter with a single str value instead (e.g. 'C12345').
      ✔ adds single and multiple files data to uploads
      ✔ handles multiple files with a single channel_id, initial_comment and/or thread_ts
```

After changes:

```
    getAllFileUploads
      ✔ adds a single file data to uploads with content supplied
      ✔ adds a single file data to uploads with file supplied
      ✔ adds multiple files data to an upload
      ✔ adds single and multiple files data to uploads
      ✔ handles multiple files with a single channel_id, initial_comment and/or thread_ts
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).