### PR TITLE
test: attempt to stabilize socket mode unit tests

### DIFF
--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -206,8 +206,8 @@ describe('Integration tests with a WebSocket server', () => {
       do {
         await sleep(2);
         retries = closed;
-      } while (retries < 2 && 40 < Date.now() - start_time < 50);
-      // after 40 to 50 milliseconds, with a timeout of 20ms, we would expect 2 retries.
+      } while (retries < 2 && Date.now() - start_time < 50);
+      // after less then 50 milliseconds, with a timeout of 20ms, we would expect 2 retries.
       // crucially, the bug reported in https://github.com/slackapi/node-slack-sdk/issues/2094 shows that on every reconnection attempt, we spawn _another_ websocket instance, which attempts to reconnect forever and is never cleaned up.
       // effectively: with each reconnection attempt, we double the number of websockets, eventually causing crashes / out-of-memory issues / rate-limiting from Slack APIs.
       // with the bug not fixed, this assertion fails as `close` event was emitted 4 times! if we waited another 20ms, we would see this event count double again (8), and so on.

--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -223,7 +223,6 @@ describe('Integration tests with a WebSocket server', () => {
         });
       });
       assert.equal(retries, 2, 'unexpected number of times `close` event was raised during reconnection!');
-      console.log(elapseTime);
       assert.isAtLeast(elapseTime, 25, 'unexpectedly rapid `close` events raised during reconnection!');
     });
   });

--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -200,12 +200,17 @@ describe('Integration tests with a WebSocket server', () => {
       });
       // do not use await here, since `start()` won't return until the connection is established. we are intentionally testing connection establishment failure, so that will never finish. so, let's run this in a rogue "thread", e.g. fire off an async method and let it do its thing!
       client.start();
-      await sleep(40);
-      // after 40ms + the overhead, with a timeout of 20ms, we would expect 2 retries.
+
+      const start_time = Date.now();
+      let retries = 0;
+      do {
+        await sleep(2);
+        retries = closed;
+      } while (retries < 2 && 40 < Date.now() - start_time < 50);
+      // after 40 to 50 milliseconds, with a timeout of 20ms, we would expect 2 retries.
       // crucially, the bug reported in https://github.com/slackapi/node-slack-sdk/issues/2094 shows that on every reconnection attempt, we spawn _another_ websocket instance, which attempts to reconnect forever and is never cleaned up.
       // effectively: with each reconnection attempt, we double the number of websockets, eventually causing crashes / out-of-memory issues / rate-limiting from Slack APIs.
       // with the bug not fixed, this assertion fails as `close` event was emitted 4 times! if we waited another 20ms, we would see this event count double again (8), and so on.
-      const retries = closed;
       await client.disconnect();
       await new Promise((res, rej) => {
         // shut down the bad server

--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -199,9 +199,9 @@ describe('Integration tests with a WebSocket server', () => {
         closed++;
       });
 
-      const startTime = Date.now();
       let elapseTime = 0;
       let retries = 0;
+      const startTime = Date.now();
 
       // do not use await here, since `start()` won't return until the connection is established. we are intentionally testing connection establishment failure, so that will never finish. so, let's run this in a rogue "thread", e.g. fire off an async method and let it do its thing!
       client.start();

--- a/packages/socket-mode/test/integration.spec.js
+++ b/packages/socket-mode/test/integration.spec.js
@@ -200,8 +200,8 @@ describe('Integration tests with a WebSocket server', () => {
       });
       // do not use await here, since `start()` won't return until the connection is established. we are intentionally testing connection establishment failure, so that will never finish. so, let's run this in a rogue "thread", e.g. fire off an async method and let it do its thing!
       client.start();
-      await sleep(50);
-      // after 50ms, with a timeout of 20ms, we would expect 2 retries.
+      await sleep(40);
+      // after 40ms + the overhead, with a timeout of 20ms, we would expect 2 retries.
       // crucially, the bug reported in https://github.com/slackapi/node-slack-sdk/issues/2094 shows that on every reconnection attempt, we spawn _another_ websocket instance, which attempts to reconnect forever and is never cleaned up.
       // effectively: with each reconnection attempt, we double the number of websockets, eventually causing crashes / out-of-memory issues / rate-limiting from Slack APIs.
       // with the bug not fixed, this assertion fails as `close` event was emitted 4 times! if we waited another 20ms, we would see this event count double again (8), and so on.


### PR DESCRIPTION
### Summary

Aims to fix #2138

Since  #2187 I've notices that flaky tests error with the following log

```txt
  1) Integration tests with a WebSocket server
       unexpected socket messages sent to client
         should maintain one serial reconnection attempt if WSS server sends unexpected HTTP response during handshake, like a 409:

      unexpected number of times `close` event was raised during reconnection!
      + expected - actual

      -3
      +2
      
      at Context.<anonymous> (test/integration.spec.js:217:14)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
[should maintain one serial reconnection attempt if WSS server sends unexpected HTTP response during handshake, like a 409](https://github.com/slackapi/node-slack-sdk/blob/9210a1cdb419d2ea747dfe9e6874cc562e8f0f59/packages/socket-mode/test/integration.spec.js#L172C9-L172C130) is a real time system unit test, this means that real time elapse dictate the behavior of the unit test. Javascript in combination with event driven design patterns can be used for real time system applications but the implementation of the socket mode client may not be ideal for this.

Regardless, the tests sets clientPingTimeout to `20ms` and then waits `50ms` to expect 2 retry attempts. But it fails to account for the overhead of setting up the time out and executing retry requests, if this overhead takes more then `10ms` a race condition it created between the unit test the socketModeClient and the mock server.

In order to stabilize the test we could increase the `clientPingTimeout` and let the test wait longer, but this increases the time elapsed to run the test. To avoid this, this PR aims to poll the number of retries, if 2 retries are detected within ` 50ms` then we can consider the unit test to be successful.

If we see that this change does not improve the stability of the test in our CI pipeline we can revisit it, see this PR as an experiment.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
