### PR TITLE
test(oauth): increase timeouts for file state store checks with multiple entries

### DIFF
--- a/packages/oauth/src/state-stores/spec-utils.ts
+++ b/packages/oauth/src/state-stores/spec-utils.ts
@@ -68,7 +68,7 @@ export class StateStoreChaiTestRunner {
           } catch (e: any) {
             assert.equal(e.code, 'slack_oauth_invalid_state', `${state} ${JSON.stringify(expectedlyReturnedResult)}`);
           }
-        });
+        }).timeout(4000); // https://github.com/slackapi/node-slack-sdk/issues/2159#issuecomment-2749367820
       }
     });
   }


### PR DESCRIPTION
### Summary

This PR hopes to increase the timeout of the **FileStateStore** "should detect multiple consumption" tests to give time to complete this test without error! For #2159.

### Preview

Here's an example error:

https://github.com/slackapi/node-slack-sdk/actions/runs/14045473785/job/39325240536#step:9:119

```
  1) FileStateStore
       should detect multiple consumption:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (D:\a\node-slack-sdk\node-slack-sdk\packages\oauth\src\state-stores\file-state-store.spec.ts)
```

### Notes

This loop within tests seems to be causing slowdowns on Windows:

https://github.com/slackapi/node-slack-sdk/blob/0903f5f7f44b44e091842820f21ff1d307c31dea/packages/oauth/src/state-stores/spec-utils.ts#L56-L59

Passing tests on `main` tend to be slow for this test so the timeout was increased instead of changing the test logic:

```
✔ should detect multiple consumption (549ms)  https://github.com/slackapi/node-slack-sdk/actions/runs/14044376455/job/39323919898
✔ should detect multiple consumption (299ms)  https://github.com/slackapi/node-slack-sdk/actions/runs/13958988507/job/39077187942
✔ should detect multiple consumption (696ms)  https://github.com/slackapi/node-slack-sdk/actions/runs/13958988507/job/39077189749
✔ should detect multiple consumption (1227ms) https://github.com/slackapi/node-slack-sdk/actions/runs/13958988507/job/39077191608
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
