### PR TITLE
fix: add trailing slash to slackApiUrl if none is provided

### DIFF
--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -58,6 +58,21 @@ describe('WebClient', () => {
       const client = new WebClient();
       assert.instanceOf(client, WebClient);
     });
+
+    it('should add a trailing slash to slackApiUrl if missing', () => {
+      const client = new WebClient(token, { slackApiUrl: 'https://slack.com/api' });
+      assert.equal(client.slackApiUrl, 'https://slack.com/api/');
+    });
+
+    it('should preserve trailing slash in slackApiUrl if provided', () => {
+      const client = new WebClient(token, { slackApiUrl: 'https://slack.com/api/' });
+      assert.equal(client.slackApiUrl, 'https://slack.com/api/');
+    });
+
+    it('should handle custom domains and add trailing slash', () => {
+      const client = new WebClient(token, { slackApiUrl: 'https://example.com/slack/api' });
+      assert.equal(client.slackApiUrl, 'https://example.com/slack/api/');
+    });
   });
 
   describe('Methods superclass', () => {

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -812,6 +812,15 @@ describe('WebClient', () => {
       const client = new WebClient(token, { allowAbsoluteUrls: false });
       await client.apiCall('https://example.com/api/method');
     });
+
+    it('should add a trailing slash to slackApiUrl if missing', async () => {
+      const alternativeUrl = 'http://12.34.56.78/api'; // No trailing slash here
+      nock(alternativeUrl)
+        .post(/api\/method/)
+        .reply(200, { ok: true });
+      const client = new WebClient(token, { slackApiUrl: alternativeUrl });
+      await client.apiCall('method');
+    });
   });
 
   describe('has an option to set request concurrency', () => {

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -314,7 +314,7 @@ export class WebClient extends Methods {
     this.axios = axios.create({
       adapter: adapter ? (config: InternalAxiosRequestConfig) => adapter({ ...config, adapter: undefined }) : undefined,
       timeout,
-      baseURL: slackApiUrl,
+      baseURL: this.slackApiUrl,
       headers: isElectron() ? headers : { 'User-Agent': getUserAgent(), ...headers },
       httpAgent: agent,
       httpsAgent: agent,

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -286,6 +286,9 @@ export class WebClient extends Methods {
 
     this.token = token;
     this.slackApiUrl = slackApiUrl;
+    if (!this.slackApiUrl.endsWith('/')) {
+      this.slackApiUrl += '/';
+    }
 
     this.retryConfig = retryConfig;
     this.requestQueue = new pQueue({ concurrency: maxRequestConcurrency });


### PR DESCRIPTION
### Summary

[Python Slack SDK #1598](https://github.com/slackapi/python-slack-sdk/pull/1598) introduces changes to ensures that all `base_url` values end with a trailing slash, improving URL construction consistency. This PR introduces changes that make the WebClient match this behavior.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
