### PR TITLE
Update web-api response data types (as of 2025-05-17)

### DIFF
--- a/packages/web-api/src/types/response/AdminConversationsSearchResponse.ts
+++ b/packages/web-api/src/types/response/AdminConversationsSearchResponse.ts
@@ -87,6 +87,7 @@ export interface Properties {
   huddles_restricted?: boolean;
   posting_restricted_to?: PostingRestrictedTo;
   tabs?: Tab[];
+  tabz?: Tab[];
   threads_restricted_to?: ThreadsRestrictedTo;
 }
 

--- a/packages/web-api/src/types/response/AdminFunctionsPermissionsLookupResponse.ts
+++ b/packages/web-api/src/types/response/AdminFunctionsPermissionsLookupResponse.ts
@@ -11,6 +11,7 @@ import type { WebAPICallResult } from '../../WebClient';
 export type AdminFunctionsPermissionsLookupResponse = WebAPICallResult & {
   error?: string;
   errors?: Errors;
+  metadata?: { [key: string]: Errors };
   needed?: string;
   ok?: boolean;
   permissions?: { [key: string]: Permission };

--- a/packages/web-api/src/types/response/AppsManifestCreateResponse.ts
+++ b/packages/web-api/src/types/response/AppsManifestCreateResponse.ts
@@ -18,6 +18,8 @@ export type AppsManifestCreateResponse = WebAPICallResult & {
   ok?: boolean;
   provided?: string;
   response_metadata?: ResponseMetadata;
+  team_domain?: string;
+  team_id?: string;
 };
 
 export interface Credentials {

--- a/packages/web-api/src/types/response/ChatPostMessageResponse.ts
+++ b/packages/web-api/src/types/response/ChatPostMessageResponse.ts
@@ -66,6 +66,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -109,7 +110,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -138,7 +139,7 @@ export interface Accessory {
   style?: string;
   text?: DescriptionElement;
   timezone?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
   workflow?: Workflow;
@@ -170,7 +171,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: FluffyType;
+  type?: AccessoryType;
 }
 
 export interface PurpleElement {
@@ -216,14 +217,33 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export enum FluffyType {
+export enum AccessoryType {
+  Button = 'button',
+  ChannelsSelect = 'channels_select',
+  Checkboxes = 'checkboxes',
+  ConversationsSelect = 'conversations_select',
+  Datepicker = 'datepicker',
+  Datetimepicker = 'datetimepicker',
+  ExternalSelect = 'external_select',
+  Image = 'image',
+  MultiChannelsSelect = 'multi_channels_select',
+  MultiConversationsSelect = 'multi_conversations_select',
+  MultiExternalSelect = 'multi_external_select',
+  MultiStaticSelect = 'multi_static_select',
+  MultiUsersSelect = 'multi_users_select',
+  Overflow = 'overflow',
+  RadioButtons = 'radio_buttons',
   RichTextList = 'rich_text_list',
   RichTextPreformatted = 'rich_text_preformatted',
   RichTextQuote = 'rich_text_quote',
   RichTextSection = 'rich_text_section',
+  StaticSelect = 'static_select',
+  Timepicker = 'timepicker',
+  UsersSelect = 'users_select',
+  WorkflowButton = 'workflow_button',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -313,9 +333,10 @@ export interface FileElement {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -362,6 +383,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -454,7 +476,7 @@ export interface FileElement {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -468,7 +490,7 @@ export interface FileElement {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -480,6 +502,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -555,6 +578,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -567,6 +591,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -633,11 +658,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -648,6 +677,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -711,8 +753,9 @@ export interface Attachment {
   author_link?: string;
   author_name?: string;
   author_subname?: string;
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -783,7 +826,7 @@ export interface Action {
   selected_options?: SelectedOptionElement[];
   style?: string;
   text?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
 }
@@ -888,7 +931,7 @@ export interface FieldMessage {
   app_id?: string;
   assistant_app_thread?: AssistantAppThread;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   bot_link?: string;
   bot_profile?: BotProfile;
@@ -1005,6 +1048,7 @@ export interface MessageFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1051,6 +1095,7 @@ export interface MessageFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1183,6 +1228,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1199,10 +1245,19 @@ export interface Room {
   participants_screenshare_off?: string[];
   participants_screenshare_on?: string[];
   pending_invitees?: EventPayload;
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface PurpleRoot {

--- a/packages/web-api/src/types/response/ChatScheduleMessageResponse.ts
+++ b/packages/web-api/src/types/response/ChatScheduleMessageResponse.ts
@@ -57,6 +57,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -100,7 +101,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -214,7 +215,7 @@ export enum FluffyType {
   RichTextSection = 'rich_text_section',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -304,9 +305,10 @@ export interface File {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -353,6 +355,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -445,7 +448,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -459,7 +462,7 @@ export interface File {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -471,6 +474,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -546,6 +550,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -558,6 +563,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -624,11 +630,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -639,6 +649,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -730,6 +753,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -746,10 +770,19 @@ export interface Room {
   participants_screenshare_off?: string[];
   participants_screenshare_on?: string[];
   pending_invitees?: EventPayload;
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface ResponseMetadata {

--- a/packages/web-api/src/types/response/ChatUpdateResponse.ts
+++ b/packages/web-api/src/types/response/ChatUpdateResponse.ts
@@ -62,6 +62,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -105,7 +106,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -219,7 +220,7 @@ export enum FluffyType {
   RichTextSection = 'rich_text_section',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -309,9 +310,10 @@ export interface File {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -358,6 +360,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -450,7 +453,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -464,7 +467,7 @@ export interface File {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -476,6 +479,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -551,6 +555,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -563,6 +568,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -629,11 +635,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -644,6 +654,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -740,6 +763,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -756,10 +780,19 @@ export interface Room {
   participants_screenshare_off?: string[];
   participants_screenshare_on?: string[];
   pending_invitees?: EventPayload;
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface ResponseMetadata {

--- a/packages/web-api/src/types/response/ConversationsHistoryResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsHistoryResponse.ts
@@ -13,6 +13,7 @@ export type ConversationsHistoryResponse = WebAPICallResult & {
   channel_actions_ts?: number;
   error?: string;
   has_more?: boolean;
+  latest?: string;
   messages?: MessageElement[];
   needed?: string;
   ok?: boolean;
@@ -82,6 +83,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -125,7 +127,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -154,7 +156,7 @@ export interface Accessory {
   style?: string;
   text?: DescriptionElement;
   timezone?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
   workflow?: Workflow;
@@ -186,7 +188,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: FluffyType;
+  type?: AccessoryType;
 }
 
 export interface PurpleElement {
@@ -232,14 +234,33 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export enum FluffyType {
+export enum AccessoryType {
+  Button = 'button',
+  ChannelsSelect = 'channels_select',
+  Checkboxes = 'checkboxes',
+  ConversationsSelect = 'conversations_select',
+  Datepicker = 'datepicker',
+  Datetimepicker = 'datetimepicker',
+  ExternalSelect = 'external_select',
+  Image = 'image',
+  MultiChannelsSelect = 'multi_channels_select',
+  MultiConversationsSelect = 'multi_conversations_select',
+  MultiExternalSelect = 'multi_external_select',
+  MultiStaticSelect = 'multi_static_select',
+  MultiUsersSelect = 'multi_users_select',
+  Overflow = 'overflow',
+  RadioButtons = 'radio_buttons',
   RichTextList = 'rich_text_list',
   RichTextPreformatted = 'rich_text_preformatted',
   RichTextQuote = 'rich_text_quote',
   RichTextSection = 'rich_text_section',
+  StaticSelect = 'static_select',
+  Timepicker = 'timepicker',
+  UsersSelect = 'users_select',
+  WorkflowButton = 'workflow_button',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -329,9 +350,10 @@ export interface FileElement {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -378,6 +400,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -470,7 +493,7 @@ export interface FileElement {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -484,7 +507,7 @@ export interface FileElement {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -496,6 +519,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -571,6 +595,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -583,6 +608,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -649,11 +675,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -664,6 +694,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -727,8 +770,9 @@ export interface Attachment {
   author_link?: string;
   author_name?: string;
   author_subname?: string;
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -799,7 +843,7 @@ export interface Action {
   selected_options?: SelectedOptionElement[];
   style?: string;
   text?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
 }
@@ -904,7 +948,7 @@ export interface FieldMessage {
   app_id?: string;
   assistant_app_thread?: AssistantAppThread;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   bot_link?: string;
   bot_profile?: BotProfile;
@@ -1021,6 +1065,7 @@ export interface PurpleFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1067,6 +1112,7 @@ export interface PurpleFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1199,6 +1245,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1212,10 +1259,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface PurpleRoot {

--- a/packages/web-api/src/types/response/ConversationsJoinResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsJoinResponse.ts
@@ -56,6 +56,7 @@ export interface Channel {
 export interface Properties {
   canvas?: Canvas;
   tabs?: Tab[];
+  tabz?: Tab[];
 }
 
 export interface Canvas {

--- a/packages/web-api/src/types/response/ConversationsKickResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsKickResponse.ts
@@ -10,7 +10,10 @@
 import type { WebAPICallResult } from '../../WebClient';
 export type ConversationsKickResponse = WebAPICallResult & {
   error?: string;
+  errors?: Errors;
   needed?: string;
   ok?: boolean;
   provided?: string;
 };
+
+export type Errors = {};

--- a/packages/web-api/src/types/response/ConversationsListResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsListResponse.ts
@@ -61,6 +61,7 @@ export interface Properties {
   canvas?: Canvas;
   posting_restricted_to?: RestrictedTo;
   tabs?: Tab[];
+  tabz?: Tab[];
   threads_restricted_to?: RestrictedTo;
 }
 

--- a/packages/web-api/src/types/response/ConversationsOpenResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsOpenResponse.ts
@@ -73,6 +73,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -116,7 +117,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -230,7 +231,7 @@ export enum FluffyType {
   RichTextSection = 'rich_text_section',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -320,9 +321,10 @@ export interface File {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -369,6 +371,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -461,7 +464,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -475,7 +478,7 @@ export interface File {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -487,6 +490,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -562,6 +566,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -574,6 +579,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -640,11 +646,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -655,6 +665,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {

--- a/packages/web-api/src/types/response/ConversationsRepliesResponse.ts
+++ b/packages/web-api/src/types/response/ConversationsRepliesResponse.ts
@@ -71,6 +71,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -114,7 +115,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -143,7 +144,7 @@ export interface Accessory {
   style?: string;
   text?: DescriptionElement;
   timezone?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
   workflow?: Workflow;
@@ -175,7 +176,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: FluffyType;
+  type?: AccessoryType;
 }
 
 export interface PurpleElement {
@@ -221,14 +222,33 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export enum FluffyType {
+export enum AccessoryType {
+  Button = 'button',
+  ChannelsSelect = 'channels_select',
+  Checkboxes = 'checkboxes',
+  ConversationsSelect = 'conversations_select',
+  Datepicker = 'datepicker',
+  Datetimepicker = 'datetimepicker',
+  ExternalSelect = 'external_select',
+  Image = 'image',
+  MultiChannelsSelect = 'multi_channels_select',
+  MultiConversationsSelect = 'multi_conversations_select',
+  MultiExternalSelect = 'multi_external_select',
+  MultiStaticSelect = 'multi_static_select',
+  MultiUsersSelect = 'multi_users_select',
+  Overflow = 'overflow',
+  RadioButtons = 'radio_buttons',
   RichTextList = 'rich_text_list',
   RichTextPreformatted = 'rich_text_preformatted',
   RichTextQuote = 'rich_text_quote',
   RichTextSection = 'rich_text_section',
+  StaticSelect = 'static_select',
+  Timepicker = 'timepicker',
+  UsersSelect = 'users_select',
+  WorkflowButton = 'workflow_button',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -318,9 +338,10 @@ export interface FileElement {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -367,6 +388,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -459,7 +481,7 @@ export interface FileElement {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -473,7 +495,7 @@ export interface FileElement {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -485,6 +507,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -560,6 +583,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -572,6 +596,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -638,11 +663,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -653,6 +682,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -716,8 +758,9 @@ export interface Attachment {
   author_link?: string;
   author_name?: string;
   author_subname?: string;
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -788,7 +831,7 @@ export interface Action {
   selected_options?: SelectedOptionElement[];
   style?: string;
   text?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
 }
@@ -893,7 +936,7 @@ export interface FieldMessage {
   app_id?: string;
   assistant_app_thread?: AssistantAppThread;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   bot_link?: string;
   bot_profile?: BotProfile;
@@ -1010,6 +1053,7 @@ export interface PurpleFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1056,6 +1100,7 @@ export interface PurpleFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1188,6 +1233,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1201,10 +1247,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {

--- a/packages/web-api/src/types/response/FilesCompleteUploadExternalResponse.ts
+++ b/packages/web-api/src/types/response/FilesCompleteUploadExternalResponse.ts
@@ -82,6 +82,7 @@ export interface Shares {
 
 export interface Public {
   channel_name?: string;
+  is_silent_share?: boolean;
   latest_reply?: string;
   reply_count?: number;
   reply_users?: string[];

--- a/packages/web-api/src/types/response/FilesInfoResponse.ts
+++ b/packages/web-api/src/types/response/FilesInfoResponse.ts
@@ -40,6 +40,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -86,6 +87,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -178,7 +180,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -219,6 +221,7 @@ export interface Headers {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -231,6 +234,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -246,116 +250,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -367,6 +262,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -403,7 +299,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -464,7 +360,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -478,7 +374,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -497,7 +393,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -510,7 +406,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -545,6 +448,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesListResponse.ts
+++ b/packages/web-api/src/types/response/FilesListResponse.ts
@@ -24,6 +24,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -70,6 +71,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -162,7 +164,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -213,6 +215,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -225,6 +228,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -240,116 +244,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -361,6 +256,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -397,7 +293,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -458,7 +354,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -472,7 +368,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -491,7 +387,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -504,7 +400,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -539,6 +442,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRemoteAddResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteAddResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRemoteInfoResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteInfoResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRemoteListResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteListResponse.ts
@@ -24,6 +24,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -70,6 +71,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -162,7 +164,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -213,6 +215,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -225,6 +228,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -240,116 +244,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -361,6 +256,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -397,7 +293,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -458,7 +354,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -472,7 +368,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -491,7 +387,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -504,7 +400,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -539,6 +442,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRemoteShareResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteShareResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRemoteUpdateResponse.ts
+++ b/packages/web-api/src/types/response/FilesRemoteUpdateResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesRevokePublicURLResponse.ts
+++ b/packages/web-api/src/types/response/FilesRevokePublicURLResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesSharedPublicURLResponse.ts
+++ b/packages/web-api/src/types/response/FilesSharedPublicURLResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/FilesUploadResponse.ts
+++ b/packages/web-api/src/types/response/FilesUploadResponse.ts
@@ -23,6 +23,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -69,6 +70,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -161,7 +163,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -212,6 +214,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -224,6 +227,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -239,116 +243,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -360,6 +255,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -396,7 +292,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -457,7 +353,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -471,7 +367,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -490,7 +386,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -503,7 +399,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -538,6 +441,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/PinsListResponse.ts
+++ b/packages/web-api/src/types/response/PinsListResponse.ts
@@ -31,6 +31,7 @@ export interface File {
   app_name?: string;
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -77,6 +78,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -169,7 +171,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: TitleBlock[];
+  title_blocks?: Block[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -220,6 +222,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -232,6 +235,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -247,116 +251,7 @@ export interface CreationSource {
   workflow_function_id?: string;
 }
 
-export interface Schema {
-  id?: string;
-  is_primary_column?: boolean;
-  key?: string;
-  name?: string;
-  options?: Options;
-  type?: string;
-}
-
-export interface Options {
-  canvas_id?: string;
-  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
-  choices?: Choice[];
-  currency?: string;
-  currency_format?: string;
-  date_format?: string;
-  default_value?: string;
-  default_value_typed?: DefaultValueTyped;
-  emoji?: string;
-  emoji_team_id?: string;
-  for_assignment?: boolean;
-  format?: string;
-  linked_to?: string[];
-  mark_as_done_when_checked?: boolean;
-  max?: number;
-  notify_users?: boolean;
-  precision?: number;
-  rounding?: string;
-  show_member_name?: boolean;
-  time_format?: string;
-}
-
-export interface CanvasPlaceholderMapping {
-  column?: string;
-  variable?: string;
-}
-
-export interface Choice {
-  color?: string;
-  label?: string;
-  value?: string;
-}
-
-export interface DefaultValueTyped {
-  select?: string[];
-}
-
-export interface View {
-  columns?: Column[];
-  created_by?: string;
-  date_created?: number;
-  id?: string;
-  is_all_items_view?: boolean;
-  is_locked?: boolean;
-  name?: string;
-  position?: string;
-  stick_column_left?: boolean;
-  type?: string;
-}
-
-export interface Column {
-  id?: string;
-  key?: string;
-  position?: string;
-  visible?: boolean;
-  width?: number;
-}
-
-export interface MediaProgress {
-  duration_ms?: number;
-  max_offset_ms?: number;
-  media_watched?: boolean;
-  offset_ms?: number;
-}
-
-export interface Reaction {
-  count?: number;
-  name?: string;
-  url?: string;
-  users?: string[];
-}
-
-export interface Saved {
-  date_completed?: number;
-  date_due?: number;
-  is_archived?: boolean;
-  state?: string;
-}
-
-export interface Shares {
-  private?: { [key: string]: Private[] };
-  public?: { [key: string]: Private[] };
-}
-
-export interface Private {
-  access?: string;
-  channel_name?: string;
-  date_last_shared?: number;
-  latest_reply?: string;
-  reply_count?: number;
-  reply_users?: string[];
-  reply_users_count?: number;
-  share_user_id?: string;
-  source?: string;
-  team_id?: string;
-  thread_ts?: string;
-  ts?: string;
-}
-
-export interface TitleBlock {
+export interface Block {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -368,6 +263,7 @@ export interface TitleBlock {
   description?: Text | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: Text[];
   function_trigger_id?: string;
@@ -404,7 +300,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -465,7 +361,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: string;
+  type?: FluffyType;
 }
 
 export interface PurpleElement {
@@ -479,7 +375,7 @@ export interface PurpleElement {
   team_id?: string;
   text?: string;
   timestamp?: number;
-  type?: ElementType;
+  type?: PurpleType;
   unicode?: string;
   unsafe?: boolean;
   url?: string;
@@ -498,7 +394,7 @@ export interface Style {
   unlink?: boolean;
 }
 
-export enum ElementType {
+export enum PurpleType {
   Broadcast = 'broadcast',
   Channel = 'channel',
   Color = 'color',
@@ -511,7 +407,14 @@ export enum ElementType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export enum FluffyType {
+  RichTextList = 'rich_text_list',
+  RichTextPreformatted = 'rich_text_preformatted',
+  RichTextQuote = 'rich_text_quote',
+  RichTextSection = 'rich_text_section',
+}
+
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -546,6 +449,132 @@ export interface Trigger {
 export interface CustomizableInputParameter {
   name?: string;
   value?: string;
+}
+
+export interface Schema {
+  id?: string;
+  is_primary_column?: boolean;
+  key?: string;
+  name?: string;
+  options?: Options;
+  type?: string;
+}
+
+export interface Options {
+  canvas_id?: string;
+  canvas_placeholder_mapping?: CanvasPlaceholderMapping[];
+  choices?: Choice[];
+  currency?: string;
+  currency_format?: string;
+  date_format?: string;
+  default_value?: string;
+  default_value_typed?: DefaultValueTyped;
+  emoji?: string;
+  emoji_team_id?: string;
+  for_assignment?: boolean;
+  format?: string;
+  linked_to?: string[];
+  mark_as_done_when_checked?: boolean;
+  max?: number;
+  notify_users?: boolean;
+  precision?: number;
+  rounding?: string;
+  show_member_name?: boolean;
+  time_format?: string;
+}
+
+export interface CanvasPlaceholderMapping {
+  column?: string;
+  variable?: string;
+}
+
+export interface Choice {
+  color?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface DefaultValueTyped {
+  select?: string[];
+}
+
+export interface View {
+  columns?: Column[];
+  created_by?: string;
+  date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
+  id?: string;
+  is_all_items_view?: boolean;
+  is_locked?: boolean;
+  name?: string;
+  position?: string;
+  show_completed_items?: boolean;
+  stick_column_left?: boolean;
+  type?: string;
+}
+
+export interface Column {
+  id?: string;
+  key?: string;
+  position?: string;
+  visible?: boolean;
+  width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
+}
+
+export interface MediaProgress {
+  duration_ms?: number;
+  max_offset_ms?: number;
+  media_watched?: boolean;
+  offset_ms?: number;
+}
+
+export interface Reaction {
+  count?: number;
+  name?: string;
+  url?: string;
+  users?: string[];
+}
+
+export interface Saved {
+  date_completed?: number;
+  date_due?: number;
+  is_archived?: boolean;
+  state?: string;
+}
+
+export interface Shares {
+  private?: { [key: string]: Private[] };
+  public?: { [key: string]: Private[] };
+}
+
+export interface Private {
+  access?: string;
+  channel_name?: string;
+  date_last_shared?: number;
+  latest_reply?: string;
+  reply_count?: number;
+  reply_users?: string[];
+  reply_users_count?: number;
+  share_user_id?: string;
+  source?: string;
+  team_id?: string;
+  thread_ts?: string;
+  ts?: string;
 }
 
 export interface Transcription {

--- a/packages/web-api/src/types/response/ReactionsGetResponse.ts
+++ b/packages/web-api/src/types/response/ReactionsGetResponse.ts
@@ -57,6 +57,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -100,7 +101,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -214,7 +215,7 @@ export enum FluffyType {
   RichTextSection = 'rich_text_section',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -304,9 +305,10 @@ export interface File {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -353,6 +355,7 @@ export interface File {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -445,7 +448,7 @@ export interface File {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -459,7 +462,7 @@ export interface File {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -471,6 +474,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -546,6 +550,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -558,6 +563,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -624,11 +630,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -639,6 +649,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -723,6 +746,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -739,6 +763,7 @@ export interface Room {
   participants_screenshare_off?: string[];
   participants_screenshare_on?: string[];
   pending_invitees?: Knocks;
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
@@ -746,3 +771,11 @@ export interface Room {
 }
 
 export type Knocks = {};
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
+}

--- a/packages/web-api/src/types/response/ReactionsListResponse.ts
+++ b/packages/web-api/src/types/response/ReactionsListResponse.ts
@@ -83,6 +83,7 @@ export interface AssistantAppThreadBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];
@@ -126,7 +127,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -155,7 +156,7 @@ export interface Accessory {
   style?: string;
   text?: DescriptionElement;
   timezone?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
   workflow?: Workflow;
@@ -187,7 +188,7 @@ export interface AccessoryElement {
   indent?: number;
   offset?: number;
   style?: string;
-  type?: FluffyType;
+  type?: AccessoryType;
 }
 
 export interface PurpleElement {
@@ -233,14 +234,33 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export enum FluffyType {
+export enum AccessoryType {
+  Button = 'button',
+  ChannelsSelect = 'channels_select',
+  Checkboxes = 'checkboxes',
+  ConversationsSelect = 'conversations_select',
+  Datepicker = 'datepicker',
+  Datetimepicker = 'datetimepicker',
+  ExternalSelect = 'external_select',
+  Image = 'image',
+  MultiChannelsSelect = 'multi_channels_select',
+  MultiConversationsSelect = 'multi_conversations_select',
+  MultiExternalSelect = 'multi_external_select',
+  MultiStaticSelect = 'multi_static_select',
+  MultiUsersSelect = 'multi_users_select',
+  Overflow = 'overflow',
+  RadioButtons = 'radio_buttons',
   RichTextList = 'rich_text_list',
   RichTextPreformatted = 'rich_text_preformatted',
   RichTextQuote = 'rich_text_quote',
   RichTextSection = 'rich_text_section',
+  StaticSelect = 'static_select',
+  Timepicker = 'timepicker',
+  UsersSelect = 'users_select',
+  WorkflowButton = 'workflow_button',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -330,9 +350,10 @@ export interface FileElement {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -379,6 +400,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -471,7 +493,7 @@ export interface FileElement {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: FileBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -485,7 +507,7 @@ export interface FileElement {
   vtt?: string;
 }
 
-export interface FileBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -497,6 +519,7 @@ export interface FileBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -572,6 +595,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -584,6 +608,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -650,11 +675,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -665,6 +694,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -728,8 +770,9 @@ export interface Attachment {
   author_link?: string;
   author_name?: string;
   author_subname?: string;
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -800,7 +843,7 @@ export interface Action {
   selected_options?: SelectedOptionElement[];
   style?: string;
   text?: string;
-  type?: string;
+  type?: AccessoryType;
   url?: string;
   value?: string;
 }
@@ -905,7 +948,7 @@ export interface FieldMessage {
   app_id?: string;
   assistant_app_thread?: AssistantAppThread;
   attachments?: any[];
-  blocks?: FileBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   bot_link?: string;
   bot_profile?: BotProfile;
@@ -1022,6 +1065,7 @@ export interface PurpleFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1068,6 +1112,7 @@ export interface PurpleFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1200,6 +1245,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1216,10 +1262,19 @@ export interface Room {
   participants_screenshare_off?: string[];
   participants_screenshare_on?: string[];
   pending_invitees?: Knocks;
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {

--- a/packages/web-api/src/types/response/RtmStartResponse.ts
+++ b/packages/web-api/src/types/response/RtmStartResponse.ts
@@ -174,6 +174,7 @@ export interface Attachment {
   author_subname?: string;
   blocks?: TitleBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -304,6 +305,7 @@ export interface TitleBlockElement {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -340,7 +342,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -447,7 +449,7 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -510,6 +512,7 @@ export interface FileElement {
   blocks?: TitleBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -556,6 +559,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -699,6 +703,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -711,6 +716,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: TitleBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -777,11 +783,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -792,6 +802,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -1030,6 +1053,7 @@ export interface MessageFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1076,6 +1100,7 @@ export interface MessageFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1208,6 +1233,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1221,10 +1247,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {
@@ -1321,6 +1356,7 @@ export interface LatestBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];

--- a/packages/web-api/src/types/response/SearchAllResponse.ts
+++ b/packages/web-api/src/types/response/SearchAllResponse.ts
@@ -30,6 +30,7 @@ export interface FilesMatch {
   access?: string;
   attachments?: Attachment[];
   bot_id?: string;
+  canvas_printing_enabled?: boolean;
   cc?: Cc[];
   channels?: string[];
   comments_count?: number;
@@ -60,6 +61,7 @@ export interface FilesMatch {
   is_channel_space?: boolean;
   is_external?: boolean;
   is_public?: boolean;
+  is_restricted_sharing_enabled?: boolean;
   is_starred?: boolean;
   last_editor?: LastEditor;
   lines?: number;
@@ -143,8 +145,9 @@ export interface Attachment {
   author_link?: string;
   author_name?: string;
   author_subname?: string;
-  blocks?: AttachmentBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -263,7 +266,7 @@ export enum ActionType {
   WorkflowButton = 'workflow_button',
 }
 
-export interface AttachmentBlock {
+export interface DescriptionBlockElement {
   accessory?: Accessory;
   alt_text?: string;
   app_collaborators?: string[];
@@ -275,6 +278,7 @@ export interface AttachmentBlock {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -311,7 +315,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -418,7 +422,7 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -478,9 +482,10 @@ export interface FileElement {
   app_id?: string;
   app_name?: string;
   attachments?: any[];
-  blocks?: AttachmentBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -527,6 +532,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -619,7 +625,7 @@ export interface FileElement {
   thumb_video_w?: number;
   timestamp?: number;
   title?: string;
-  title_blocks?: AttachmentBlock[];
+  title_blocks?: DescriptionBlockElement[];
   to?: Cc[];
   transcription?: Transcription;
   update_notification?: number;
@@ -675,6 +681,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -687,6 +694,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: DescriptionBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -753,11 +761,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -768,6 +780,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -909,7 +934,7 @@ export interface Message {
   app_id?: string;
   assistant_app_thread?: AssistantAppThread;
   attachments?: any[];
-  blocks?: AttachmentBlock[];
+  blocks?: DescriptionBlockElement[];
   bot_id?: string;
   bot_link?: string;
   bot_profile?: BotProfile;
@@ -1032,6 +1057,7 @@ export interface MessageFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1078,6 +1104,7 @@ export interface MessageFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1210,6 +1237,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1223,10 +1251,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {
@@ -1331,6 +1368,7 @@ export interface MatchTitleBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];

--- a/packages/web-api/src/types/response/SearchFilesResponse.ts
+++ b/packages/web-api/src/types/response/SearchFilesResponse.ts
@@ -28,6 +28,7 @@ export interface Match {
   access?: string;
   attachments?: Attachment[];
   bot_id?: string;
+  canvas_printing_enabled?: boolean;
   cc?: Cc[];
   channels?: string[];
   comments_count?: number;
@@ -58,6 +59,7 @@ export interface Match {
   is_channel_space?: boolean;
   is_external?: boolean;
   is_public?: boolean;
+  is_restricted_sharing_enabled?: boolean;
   is_starred?: boolean;
   last_editor?: LastEditor;
   lines?: number;
@@ -143,6 +145,7 @@ export interface Attachment {
   author_subname?: string;
   blocks?: Block[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -247,6 +250,7 @@ export interface Block {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -283,7 +287,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -397,7 +401,7 @@ export enum FluffyType {
   RichTextSection = 'rich_text_section',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -460,6 +464,7 @@ export interface FileElement {
   blocks?: Block[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -506,6 +511,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -654,6 +660,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -666,6 +673,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: Block[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -732,11 +740,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -747,6 +759,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -1011,6 +1036,7 @@ export interface MessageFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -1057,6 +1083,7 @@ export interface MessageFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1189,6 +1216,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1202,10 +1230,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {
@@ -1310,6 +1347,7 @@ export interface TitleBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];

--- a/packages/web-api/src/types/response/SearchMessagesResponse.ts
+++ b/packages/web-api/src/types/response/SearchMessagesResponse.ts
@@ -55,6 +55,7 @@ export interface Attachment {
   author_subname?: string;
   blocks?: TitleBlockElement[];
   bot_id?: string;
+  bot_team_id?: string;
   callback_id?: string;
   channel_id?: string;
   channel_name?: string;
@@ -185,6 +186,7 @@ export interface TitleBlockElement {
   description?: DescriptionElement | string;
   developer_trace_id?: string;
   elements?: Accessory[];
+  expand?: boolean;
   fallback?: string;
   fields?: DescriptionElement[];
   function_trigger_id?: string;
@@ -221,7 +223,7 @@ export interface Accessory {
   default_to_current_conversation?: boolean;
   elements?: AccessoryElement[];
   fallback?: string;
-  filter?: Filter;
+  filter?: AccessoryFilter;
   focus_on_load?: boolean;
   image_bytes?: number;
   image_height?: number;
@@ -328,7 +330,7 @@ export enum PurpleType {
   Usergroup = 'usergroup',
 }
 
-export interface Filter {
+export interface AccessoryFilter {
   exclude_bot_users?: boolean;
   exclude_external_shared_channels?: boolean;
   include?: any[];
@@ -391,6 +393,7 @@ export interface FileElement {
   blocks?: TitleBlockElement[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: Cc[];
   channel_actions_count?: number;
@@ -437,6 +440,7 @@ export interface FileElement {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -580,6 +584,7 @@ export interface InitialComment {
 export interface ListLimits {
   column_count?: number;
   column_count_limit?: number;
+  max_attachments_per_cell?: number;
   over_column_maximum?: boolean;
   over_row_maximum?: boolean;
   over_view_maximum?: boolean;
@@ -592,6 +597,7 @@ export interface ListLimits {
 export interface ListMetadata {
   creation_source?: CreationSource;
   description?: string;
+  description_blocks?: TitleBlockElement[];
   icon?: string;
   icon_team_id?: string;
   icon_url?: string;
@@ -658,11 +664,15 @@ export interface View {
   columns?: Column[];
   created_by?: string;
   date_created?: number;
+  default_view_key?: string;
+  filters?: FilterElement[];
+  grouping?: Grouping;
   id?: string;
   is_all_items_view?: boolean;
   is_locked?: boolean;
   name?: string;
   position?: string;
+  show_completed_items?: boolean;
   stick_column_left?: boolean;
   type?: string;
 }
@@ -673,6 +683,19 @@ export interface Column {
   position?: string;
   visible?: boolean;
   width?: number;
+}
+
+export interface FilterElement {
+  column_id?: string;
+  key?: string;
+  operator?: string;
+  typed_values?: any[];
+  values?: string[];
+}
+
+export interface Grouping {
+  group_by?: string;
+  group_by_column_id?: string;
 }
 
 export interface MediaProgress {
@@ -927,6 +950,7 @@ export interface MessageFile {
   blocks?: any[];
   bot_id?: string;
   can_toggle_canvas_lock?: boolean;
+  canvas_printing_enabled?: boolean;
   canvas_template_mode?: string;
   cc?: any[];
   channel_actions_count?: number;
@@ -973,6 +997,7 @@ export interface MessageFile {
   lines?: number;
   lines_more?: number;
   linked_channel_id?: string;
+  list_csv_download_url?: string;
   list_limits?: ListLimits;
   list_metadata?: ListMetadata;
   media_display_type?: string;
@@ -1105,6 +1130,7 @@ export interface Room {
   display_id?: string;
   external_unique_id?: string;
   has_ended?: boolean;
+  huddle_link?: string;
   id?: string;
   is_dm_call?: boolean;
   is_prewarmed?: boolean;
@@ -1118,10 +1144,19 @@ export interface Room {
   participants_camera_on?: any[];
   participants_screenshare_off?: any[];
   participants_screenshare_on?: any[];
+  recording?: Recording;
   thread_root_ts?: string;
   was_accepted?: boolean;
   was_missed?: boolean;
   was_rejected?: boolean;
+}
+
+export interface Recording {
+  can_record_summary?: string;
+  notetaking?: boolean;
+  summary?: boolean;
+  summary_status?: string;
+  transcript?: boolean;
 }
 
 export interface Root {
@@ -1218,6 +1253,7 @@ export interface MatchBlock {
   dispatch_action?: boolean;
   element?: Accessory;
   elements?: Accessory[];
+  expand?: boolean;
   external_id?: string;
   fallback?: string;
   fields?: DescriptionElement[];

--- a/packages/web-api/src/types/response/UsergroupsCreateResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsCreateResponse.ts
@@ -28,6 +28,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsergroupsDisableResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsDisableResponse.ts
@@ -29,6 +29,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsergroupsEnableResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsEnableResponse.ts
@@ -28,6 +28,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsergroupsListResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsListResponse.ts
@@ -28,6 +28,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsergroupsUpdateResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsUpdateResponse.ts
@@ -28,6 +28,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsergroupsUsersUpdateResponse.ts
+++ b/packages/web-api/src/types/response/UsergroupsUsersUpdateResponse.ts
@@ -28,6 +28,7 @@ export interface Usergroup {
   handle?: string;
   id?: string;
   is_external?: boolean;
+  is_section?: boolean;
   is_subteam?: boolean;
   is_usergroup?: boolean;
   name?: string;

--- a/packages/web-api/src/types/response/UsersConversationsResponse.ts
+++ b/packages/web-api/src/types/response/UsersConversationsResponse.ts
@@ -64,6 +64,7 @@ export interface Properties {
   huddles_restricted?: boolean;
   posting_restricted_to?: PostingRestrictedTo;
   tabs?: Tab[];
+  tabz?: Tab[];
   threads_restricted_to?: ThreadsRestrictedTo;
 }
 

--- a/packages/web-api/src/types/response/UsersInfoResponse.ts
+++ b/packages/web-api/src/types/response/UsersInfoResponse.ts
@@ -52,6 +52,7 @@ export interface EnterpriseUser {
   id?: string;
   is_admin?: boolean;
   is_owner?: boolean;
+  is_primary_owner?: boolean;
   teams?: string[];
 }
 

--- a/packages/web-api/src/types/response/ViewsOpenResponse.ts
+++ b/packages/web-api/src/types/response/ViewsOpenResponse.ts
@@ -54,6 +54,7 @@ export interface Block {
   dispatch_action?: boolean;
   element?: PurpleElement;
   elements?: StickyElement[];
+  expand?: boolean;
   fallback?: string;
   fields?: Close[];
   hint?: Close;

--- a/packages/web-api/src/types/response/ViewsPublishResponse.ts
+++ b/packages/web-api/src/types/response/ViewsPublishResponse.ts
@@ -54,6 +54,7 @@ export interface Block {
   dispatch_action?: boolean;
   element?: PurpleElement;
   elements?: StickyElement[];
+  expand?: boolean;
   fallback?: string;
   fields?: Close[];
   hint?: Close;

--- a/packages/web-api/src/types/response/ViewsPushResponse.ts
+++ b/packages/web-api/src/types/response/ViewsPushResponse.ts
@@ -54,6 +54,7 @@ export interface Block {
   dispatch_action?: boolean;
   element?: PurpleElement;
   elements?: StickyElement[];
+  expand?: boolean;
   fallback?: string;
   fields?: Close[];
   hint?: Close;

--- a/packages/web-api/src/types/response/ViewsUpdateResponse.ts
+++ b/packages/web-api/src/types/response/ViewsUpdateResponse.ts
@@ -54,6 +54,7 @@ export interface Block {
   dispatch_action?: boolean;
   element?: PurpleElement;
   elements?: StickyElement[];
+  expand?: boolean;
   fallback?: string;
   fields?: Close[];
   hint?: Close;

--- a/scripts/code_generator.rb
+++ b/scripts/code_generator.rb
@@ -29,7 +29,7 @@ class TsWriter
     Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
       stdin.write(input_json)
       stdin.close()
-      source = "#{NOTICE}\nimport { WebAPICallResult } from '../../WebClient';\n" + stdout.read
+      source = "#{NOTICE}\nimport type { WebAPICallResult } from '../../WebClient';\n" + stdout.read
       source.gsub!(
         "export interface #{root_class_name} {",
         "export type #{root_class_name} = WebAPICallResult & {"

--- a/scripts/generate-web-api-types.sh
+++ b/scripts/generate-web-api-types.sh
@@ -23,4 +23,4 @@ popd
 # run lint fixing after type generation
 pushd packages/web-api
 npm i
-npm run lint
+npm run lint:fix

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "quicktype": "^23.0.106"
+    "quicktype": "^23.2.0"
   }
 }


### PR DESCRIPTION
### Summary

This pull request brings the changes by the generator script. Also, I found that it needs some tweak for the compatibility with the biome formatter version currently used. So, the script code is updated too.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
