### PR TITLE
fix: Add new property to API args

### DIFF
--- a/packages/web-api/src/types/request/canvas.ts
+++ b/packages/web-api/src/types/request/canvas.ts
@@ -92,4 +92,6 @@ export interface CanvasesEditArguments extends CanvasID, TokenOverridable {
 export interface ConversationsCanvasesCreateArguments extends ChannelID, TokenOverridable {
   /** @description Structure describing the type and contents of the Canvas being created. */
   document_content?: DocumentContent;
+  /** @description Title of the newly created canvas. */
+  title?: string;
 }

--- a/packages/web-api/test/types/methods/canvas.test-d.ts
+++ b/packages/web-api/test/types/methods/canvas.test-d.ts
@@ -237,5 +237,6 @@ expectError(web.conversations.canvases.create({})); // empty argument
 expectAssignable<Parameters<typeof web.conversations.canvases.create>>([
   {
     channel_id: 'C1234',
+    title: 'Fun Document Title'
   },
 ]);


### PR DESCRIPTION
### Summary

- A new property was added to the [conversations.canvases.create](https://api.slack.com/methods/conversations.canvases.create) API so we should update the corresponding args
- Flagged by [Issue 2258](https://github.com/slackapi/node-slack-sdk/issues/2258)

### Requirements 

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
