### PR TITLE
feat(web-api): include a blocks argument for file uploads

### DIFF
--- a/docs/content/packages/web-api.md
+++ b/docs/content/packages/web-api.md
@@ -501,6 +501,9 @@ of binary data follow soon!
 The `channel_id` and `initial_comment` aren't required, but the file either won't be shared to a channel or it won't be
 posted with a message if these aren't included.
 
+A posted message can be formatted with [Block Kit](https://docs.slack.dev/block-kit) using the `blocks` argument instead
+of the `initial_comment` text.
+
 In a successful response, the `result.files` contains an array of [shared files](https://api.slack.com/types/file).
 These files are "private" and available to just the `token` holder if no `channel_id` is included in the request, and
 are marked "public" when shared to a provided `channel_id`.

--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1190,7 +1190,11 @@ describe('WebClient', () => {
           file_id: 'F0123456789',
           upload_url: 'https://files.slack.com/upload/v1/abcdefghijklmnopqrstuvwxyz',
         })
-        .post('/api/files.completeUploadExternal', { files: '[{"id":"F0123456789","title":"test-txt.txt"}]' })
+        .post('/api/files.completeUploadExternal', {
+          blocks: '[{"type":"section","text":{"type":"plain_text","text":"Hello"}}]',
+          channel_id: 'C010101010',
+          files: '[{"id":"F0123456789","title":"test-txt.txt"}]',
+        })
         .reply(200, {
           ok: true,
           files: [
@@ -1204,6 +1208,8 @@ describe('WebClient', () => {
       const uploader = nock('https://files.slack.com').post('/upload/v1/abcdefghijklmnopqrstuvwxyz').reply(200);
       const client = new WebClient(token);
       const response = await client.filesUploadV2({
+        blocks: [{ type: 'section', text: { type: 'plain_text', text: 'Hello' } }],
+        channel_id: 'C010101010',
         file: fs.createReadStream('./test/fixtures/test-txt.txt'),
         filename: 'test-txt.txt',
       });

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -1,4 +1,5 @@
 import type { Stream } from 'node:stream';
+import type { Block, KnownBlock } from '@slack/types';
 import type { ExcludeFromUnion } from '../helpers';
 import type { FilesGetUploadURLExternalResponse } from '../response/index';
 import type {
@@ -64,10 +65,19 @@ type FileDestinationArgumentChannels = FileChannelDestinationArgumentChannels | 
 // https://api.slack.com/methods/files.completeUploadExternal
 export type FilesCompleteUploadExternalArguments = FileDestinationArgument &
   TokenOverridable & {
-    /** @description Array of file IDs and their corresponding (optional) titles. */
+    /**
+     * @description Array of file IDs and their corresponding (optional) titles.
+     * @example [{"id":"F044GKUHN9Z", "title":"slack-test"}]
+     **/
     files: [FileUploadComplete, ...FileUploadComplete[]];
     /** @description The message text introducing the file in the specified channel. */
     initial_comment?: string;
+    /**
+     * @description An array of structured rich text blocks. If the `initial_comment` field is provided, the `blocks` field is ignored.
+     * @example [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}]
+     * @see {@link https://api.slack.com/reference/block-kit/blocks}
+     */
+    blocks?: (KnownBlock | Block)[];
   };
 
 // https://api.slack.com/methods/files.delete
@@ -148,6 +158,12 @@ export type FilesUploadArguments = FileUpload & TokenOverridable;
 export type FileUploadV2 = FileUpload & {
   /** @description Description of image for screen-reader. */
   alt_text?: string;
+  /**
+   * @description An array of structured rich text blocks. If the `initial_comment` field is provided, the `blocks` field is ignored.
+   * @example [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}]
+   * @see {@link https://api.slack.com/reference/block-kit/blocks}
+   */
+  blocks?: (KnownBlock | Block)[];
   /** @description Channel ID where the file will be shared. If not specified the file will be private. */
   channel_id?: string;
   /** @deprecated use channel_id instead */
@@ -157,7 +173,10 @@ export type FileUploadV2 = FileUpload & {
 };
 
 export interface FilesUploadV2ArgumentsMultipleFiles {
-  file_uploads: ExcludeFromUnion<FileUploadV2, 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'>[];
+  file_uploads: ExcludeFromUnion<
+    FileUploadV2,
+    'blocks' | 'channel_id' | 'channels' | 'initial_comment' | 'thread_ts'
+  >[];
 }
 
 // https://tools.slack.dev/node-slack-sdk/web-api#upload-a-file


### PR DESCRIPTION
### Summary

This PR includes a `blocks` argument for file uploads when using either the [`files.completeUploadExternal`](https://api.slack.com/methods/files.completeUploadExternal) method or the `filesUploadV2` function. Fixes https://github.com/slackapi/node-slack-sdk/issues/2208. 📠 ✨ 

### Reviewers

Please feel free to upload multiple files or one file multiple times with `blocks` using the following examples! 🤖

A bot with the `files:write` scope added to a channel is required!
#### Blocks

```js
const blocks = [
  {
    "type": "section",
    "text": {
      "type": "mrkdwn",
      "text": "The uploaded file has finished processing!\n\n*Select an action or reaction:*"
    }
  },
  {
    "type": "divider"
  },
  {
    "type": "actions",
    "elements": [
      {
        "type": "button",
        "text": {
          "type": "plain_text",
          "text": "Delete",
          "emoji": true
        },
        "value": "delete"
      }
    ]
  }
];
```
#### Single file upload

```js
const result = await web.files.uploadV2({
  channel_id: "C0123456789",
  blocks,
  file: "./index.js",
  filename: "code.js",
});
```

#### Multiple file upload

```js
const result = await web.files.uploadV2({
  channel_id: "C0123456789",
  blocks,
  file_uploads: [
    {
      filename: "code.js",
      file: "./index.js",
    },
    {
      filename: "review.txt",
      content: "LGTM",
    },
  ],
});
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
