### PR TITLE
Fix name of team_domain_change event in types

### DIFF
--- a/packages/types/src/events/team.ts
+++ b/packages/types/src/events/team.ts
@@ -13,7 +13,7 @@ export interface TeamAccessRevokedEvent {
 }
 
 export interface TeamDomainChangedEvent {
-  type: 'team_domain_changed';
+  type: 'team_domain_change';
   url: string;
   domain: string;
 }


### PR DESCRIPTION
### Summary

The event name was incorrect, making it hard to enforce typescript safety.

https://api.slack.com/events/team_domain_change

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
