### PR TITLE
refactor: Replace lodash with es-toolkit

### DIFF
--- a/packages/events-api/package.json
+++ b/packages/events-api/package.json
@@ -49,11 +49,10 @@
   "dependencies": {
     "@types/debug": "^4.1.4",
     "@types/express": "^4.17.0",
-    "@types/lodash.isstring": "^4.0.6",
     "@types/node": ">=12.13.0 < 13",
     "@types/yargs": "^15.0.4",
     "debug": "^2.6.1",
-    "lodash.isstring": "^4.0.1",
+    "es-toolkit": "^1.39.5",
     "raw-body": "^2.3.3",
     "tsscmp": "^1.0.6",
     "yargs": "^15.3.1"
@@ -72,7 +71,7 @@
     "eslint-plugin-node": "^11.1.0",
     "express": "^4.14.0",
     "get-random-port": "0.0.1",
-    "lodash.isfunction": "^3.0.8",
+    "es-toolkit": "^1.39.5",
     "mocha": "^9.1.0",
     "nop": "^1.0.0",
     "nyc": "^14.1.1",

--- a/packages/events-api/src/adapter.ts
+++ b/packages/events-api/src/adapter.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import http, { RequestListener } from 'http';
 import debugFactory from 'debug';
-import isString from 'lodash.isstring';
+import isString from 'es-toolkit/compat/isString';
 import { RequestHandler } from 'express'; // eslint-disable-line import/no-extraneous-dependencies
 import { createHTTPHandler } from './http-handler';
 import { isFalsy } from './util';

--- a/packages/events-api/test/integration/test-adapter-options.js
+++ b/packages/events-api/test/integration/test-adapter-options.js
@@ -1,7 +1,7 @@
 require('mocha');
 const assert = require('assert');
 const request = require('superagent');
-const isFunction = require('lodash.isfunction');
+const isFunction = require('es-toolkit/compat/isFunction');
 
 const { createEventAdapter } = require('../../src/');
 const { createRequestSignature } = require('../helpers');

--- a/packages/interactive-messages/package.json
+++ b/packages/interactive-messages/package.json
@@ -53,17 +53,10 @@
   "dependencies": {
     "@types/debug": "^4.1.4",
     "@types/express": "^4.17.0",
-    "@types/lodash.isfunction": "^3.0.6",
-    "@types/lodash.isplainobject": "^4.0.6",
-    "@types/lodash.isregexp": "^4.0.6",
-    "@types/lodash.isstring": "^4.0.6",
     "@types/node": ">=12.0.0",
     "axios": "^1.7.4",
     "debug": "^3.1.0",
-    "lodash.isfunction": "^3.0.9",
-    "lodash.isplainobject": "^4.0.6",
-    "lodash.isregexp": "^4.0.1",
-    "lodash.isstring": "^4.0.1",
+    "es-toolkit": "^1.39.5",
     "raw-body": "^2.3.3",
     "tsscmp": "^1.0.6"
   },

--- a/packages/interactive-messages/src/adapter.ts
+++ b/packages/interactive-messages/src/adapter.ts
@@ -1,9 +1,9 @@
 import http, { RequestListener, Agent } from 'http';
 import axios, { AxiosInstance } from 'axios';
-import isString from 'lodash.isstring';
-import isRegExp from 'lodash.isregexp';
-import isFunction from 'lodash.isfunction';
-import isPlainObject from 'lodash.isplainobject';
+import isString from 'es-toolkit/compat/isString';
+import isRegExp from 'es-toolkit/compat/isRegExp';
+import isFunction from 'es-toolkit/compat/isFunction';
+import isPlainObject from 'es-toolkit/compat/isPlainObject';
 import debugFactory from 'debug';
 // eslint-disable-next-line import/no-extraneous-dependencies, node/no-extraneous-import
 import { RequestHandler } from 'express';

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -35,8 +35,7 @@
     "@slack/web-api": "^7.9.1",
     "@types/jsonwebtoken": "^9",
     "@types/node": ">=18",
-    "jsonwebtoken": "^9",
-    "lodash.isstring": "^4"
+    "jsonwebtoken": "^9"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",


### PR DESCRIPTION
### Summary

es-toolkit is a modern alternative to lodash that's significantly faster and lighter, which could potentially boost node-slack-sdk's overall performance. It's been tested using lodash's actual test suite.

It's already being adopted by major projects like Storybook, Recharts, Ink, and CKEditor with 2.5M downloads a week on NPM.

You can learn more at https://es-toolkit.dev/intro.html.

#### Test Results

<img width="613" alt="image" src="https://github.com/user-attachments/assets/2a34116c-05d3-4b7e-a976-62d3c02413e6" />
<img width="733" alt="image" src="https://github.com/user-attachments/assets/83eb168f-b900-4d2b-9061-f6652cda9078" />


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
