### PR TITLE
refactor(oauth): remove lodash.isstring from dependencies

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -43,8 +43,7 @@
     "@slack/web-api": "^7.9.1",
     "@types/jsonwebtoken": "^9",
     "@types/node": ">=18",
-    "jsonwebtoken": "^9",
-    "lodash.isstring": "^4"
+    "jsonwebtoken": "^9"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.5",


### PR DESCRIPTION
### Summary

This PR removes an unused `lodash` package from the dependencies of `@slack/oauth` to prefer the `typeof` operator:

https://github.com/slackapi/node-slack-sdk/blob/f1ebcc6e36a9dacf927355b463cece6a5885caa0/packages/oauth/src/install-provider.ts#L367

### Reviewers

Confirm tests continue to pass and no references exist to this import!

### Notes

This package remains imported indirect through `jsonwebtoken` but that is automatic AFAICT:

```
$ npm ls lodash.isstring
@slack/oauth@3.0.3 ~/programming/tools/node-slack-sdk/packages/oauth
└─┬ jsonwebtoken@9.0.2
  └── lodash.isstring@4.0.1
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
