### PR TITLE
fix(web-api): remove bounds on assistant.threads.setSuggestedPrompts prompts count in types

### DIFF
--- a/packages/web-api/src/types/request/assistant.ts
+++ b/packages/web-api/src/types/request/assistant.ts
@@ -15,7 +15,7 @@ export interface AssistantThreadsSetSuggestedPromptsArguments extends TokenOverr
   /** @description Channel ID containing the assistant thread. */
   channel_id: string;
   /** @description Prompt suggestions that appear when opening assistant thread. */
-  prompts: [AssistantPrompt, ...AssistantPrompt[]];
+  prompts: AssistantPrompt[];
   /** @description Message timestamp of the thread. */
   thread_ts: string;
   /** @description Title for the prompts. */


### PR DESCRIPTION
### Summary

This PR removes the minimum bounds in **types** for the `assistant.threads.setSuggestedPrompts` method `prompts` property.

Fixes issues noted in https://github.com/slack-samples/bolt-js-assistant-template/pull/46 and https://github.com/slackapi/bolt-js/issues/2506.

### Notes

- https://docs.slack.dev/reference/methods/assistant.threads.setsuggestedprompts

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
