### PR TITLE
docs(types): fix markdown block type annotation

### DIFF
--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -250,7 +250,7 @@ export interface InputBlock extends Block {
  * @description This block can be used with AI apps when you expect a markdown response from an LLM that can get lost in
  * translation rendering in Slack. Providing it in a markdown block leaves the translating to Slack to ensure your message
  * appears as intended. Note that passing a single block may result in multiple blocks after translation.
- * @see {@link https://api.slack.com/reference/block-kit/blocks#markdown Markdown block reference}
+ * @see {@link https://api.slack.com/reference/block-kit/blocks#markdown Markdown block reference}.
  */
 export interface MarkdownBlock extends Block {
   /**

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -254,7 +254,7 @@ export interface InputBlock extends Block {
  */
 export interface MarkdownBlock extends Block {
   /**
-   * @description The type of block. For a markdown block, `type` is always `input`.
+   * @description The type of block. For a markdown block, `type` is always `markdown`.
    */
   type: 'markdown';
   /**


### PR DESCRIPTION
### Summary

This PR fixes the `markdown` block `type` annotation to match documentation. Following a pasting oops of #2296.

### Notes

> The type of block. For a markdown block, `type` is always `markdown`.

🔗 https://docs.slack.dev/reference/block-kit/blocks/markdown-block#fields

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
