### PR TITLE
feat(web-api): add admin.conversations.{createForObjects|linkObjects|unlinkObjects} methods

### DIFF
--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -28,6 +28,7 @@ import type {
   AdminConversationsConvertToPrivateArguments,
   AdminConversationsConvertToPublicArguments,
   AdminConversationsCreateArguments,
+  AdminConversationsCreateForObjectsArguments,
   AdminConversationsDeleteArguments,
   AdminConversationsDisconnectSharedArguments,
   AdminConversationsEKMListOriginalConnectedChannelInfoArguments,
@@ -35,6 +36,7 @@ import type {
   AdminConversationsGetCustomRetentionArguments,
   AdminConversationsGetTeamsArguments,
   AdminConversationsInviteArguments,
+  AdminConversationsLinkObjectsArguments,
   AdminConversationsLookupArguments,
   AdminConversationsRemoveCustomRetentionArguments,
   AdminConversationsRenameArguments,
@@ -46,6 +48,7 @@ import type {
   AdminConversationsSetCustomRetentionArguments,
   AdminConversationsSetTeamsArguments,
   AdminConversationsUnarchiveArguments,
+  AdminConversationsUnlinkObjectsArguments,
   AdminEmojiAddAliasArguments,
   AdminEmojiAddArguments,
   AdminEmojiListArguments,
@@ -280,6 +283,7 @@ import type {
   AdminConversationsBulkMoveResponse,
   AdminConversationsConvertToPrivateResponse,
   AdminConversationsConvertToPublicResponse,
+  AdminConversationsCreateForObjectsResponse,
   AdminConversationsCreateResponse,
   AdminConversationsDeleteResponse,
   AdminConversationsDisconnectSharedResponse,
@@ -288,6 +292,7 @@ import type {
   AdminConversationsGetCustomRetentionResponse,
   AdminConversationsGetTeamsResponse,
   AdminConversationsInviteResponse,
+  AdminConversationsLinkObjectsResponse,
   AdminConversationsLookupResponse,
   AdminConversationsRemoveCustomRetentionResponse,
   AdminConversationsRenameResponse,
@@ -299,6 +304,7 @@ import type {
   AdminConversationsSetCustomRetentionResponse,
   AdminConversationsSetTeamsResponse,
   AdminConversationsUnarchiveResponse,
+  AdminConversationsUnlinkObjectsResponse,
   AdminEmojiAddAliasResponse,
   AdminEmojiAddResponse,
   AdminEmojiListResponse,
@@ -777,6 +783,14 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
         'admin.conversations.create',
       ),
       /**
+       * @description Create a Salesforce channel for the corresponding object provided.
+       * @see {@link https://docs.slack.dev/reference/methods/admin.conversations.createForObjects `admin.conversations.createForObjects` API reference}.
+       */
+      createForObjects: bindApiCall<
+        AdminConversationsCreateForObjectsArguments,
+        AdminConversationsCreateForObjectsResponse
+      >(this, 'admin.conversations.createForObjects'),
+      /**
        * @description Delete a public or private channel.
        * @see {@link https://docs.slack.dev/reference/methods/admin.conversations.delete `admin.conversations.delete` API reference}.
        */
@@ -843,6 +857,14 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       lookup: bindApiCall<AdminConversationsLookupArguments, AdminConversationsLookupResponse>(
         this,
         'admin.conversations.lookup',
+      ),
+      /**
+       * @description Link a Salesforce record to a channel.
+       * @see {@link https://docs.slack.dev/reference/methods/admin.conversations.linkObjects `admin.conversations.linkObjects` API reference}.
+       */
+      linkObjects: bindApiCall<AdminConversationsLinkObjectsArguments, AdminConversationsLinkObjectsResponse>(
+        this,
+        'admin.conversations.linkObjects',
       ),
       /**
        * @description Remove a conversation's retention policy.
@@ -925,6 +947,14 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
       unarchive: bindApiCall<AdminConversationsUnarchiveArguments, AdminConversationsUnarchiveResponse>(
         this,
         'admin.conversations.unarchive',
+      ),
+      /**
+       * @description Unlink a Salesforce record from a channel.
+       * @see {@link https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects `admin.conversations.unlinkObjects` API reference}.
+       */
+      unlinkObjects: bindApiCall<AdminConversationsUnlinkObjectsArguments, AdminConversationsUnlinkObjectsResponse>(
+        this,
+        'admin.conversations.unlinkObjects',
       ),
     },
     emoji: {

--- a/packages/web-api/src/types/request/admin/conversations.ts
+++ b/packages/web-api/src/types/request/admin/conversations.ts
@@ -92,6 +92,28 @@ export type AdminConversationsCreateArguments = TokenOverridable &
     description?: string;
   };
 
+// https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
+export interface AdminConversationsCreateForObjectsArguments extends TokenOverridable {
+  /**
+   * @description Object / Record ID (15 or 18 digit accepted).
+   * @see See {@link https://help.salesforce.com/s/articleView?id=000385008&type=1 here} for how to look up an ID.
+   * @example 0019000000DmehKAAR
+   **/
+  object_id: string;
+  /**
+   * @description Salesforce org ID (15 or 18 digit accepted).
+   * @see See {@link https://help.salesforce.com/s/articleView?id=000385215&type=1 here} for how to look up Salesforce org ID.
+   * @example 00DGC00000024hsuWY
+   **/
+  salesforce_org_id: string;
+  /**
+   * @description Optional flag to add all team members related to the object to the newly created Salesforce channel. When true, adds a maximum of 100 team members to the channel.
+   * @default false
+   * @example true
+   **/
+  invite_object_team?: boolean;
+}
+
 // https://docs.slack.dev/reference/methods/admin.conversations.delete
 export interface AdminConversationsDeleteArguments extends ChannelID, TokenOverridable {}
 
@@ -117,6 +139,26 @@ export interface AdminConversationsGetTeamsArguments extends ChannelID, TokenOve
 
 // https://docs.slack.dev/reference/methods/admin.conversations.invite
 export interface AdminConversationsInviteArguments extends ChannelID, UserIDs, TokenOverridable {}
+
+// https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
+export interface AdminConversationsLinkObjectsArguments extends TokenOverridable {
+  /**
+   * @description Channel ID for Slack channel that will be linked to a Salesforce record.
+   **/
+  channel: string;
+  /**
+   * @description Salesforce record ID (15 or 18 digit accepted).
+   * @see See {@link https://help.salesforce.com/s/articleView?id=000385008&type=1 here} for how to look up record ID.
+   * @example 0019000000DmehKAAR
+   */
+  record_id: string;
+  /**
+   * @description Salesforce org ID (15 or 18 digit accepted).
+   * @see See {@link https://help.salesforce.com/s/articleView?id=000385215&type=1 here} for how to look up Salesforce org ID.
+   * @example: 00DGC00000024hsuWY
+   **/
+  salesforce_org_id: string;
+}
 
 // https://docs.slack.dev/reference/methods/admin.conversations.lookup
 export interface AdminConversationsLookupArguments extends TeamIDs, TokenOverridable, CursorPaginationEnabled {
@@ -222,3 +264,15 @@ export interface AdminConversationsSetTeamsArguments extends ChannelID, TokenOve
 
 // https://docs.slack.dev/reference/methods/admin.conversations.unarchive
 export interface AdminConversationsUnarchiveArguments extends ChannelID, TokenOverridable {}
+
+// https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
+export interface AdminConversationsUnlinkObjectsArguments extends TokenOverridable {
+  /**
+   * @description Channel ID for Slack channel that will be unlinked from the Salesforce record.
+   **/
+  channel: string;
+  /**
+   * @description Channel name you would like to give to the channel that is being unlinked from the Salesforce record.
+   **/
+  new_name: string;
+}

--- a/packages/web-api/src/types/request/index.ts
+++ b/packages/web-api/src/types/request/index.ts
@@ -31,6 +31,7 @@ export type {
   AdminConversationsConvertToPrivateArguments,
   AdminConversationsConvertToPublicArguments,
   AdminConversationsCreateArguments,
+  AdminConversationsCreateForObjectsArguments,
   AdminConversationsDeleteArguments,
   AdminConversationsDisconnectSharedArguments,
   AdminConversationsEKMListOriginalConnectedChannelInfoArguments,
@@ -38,6 +39,7 @@ export type {
   AdminConversationsGetCustomRetentionArguments,
   AdminConversationsGetTeamsArguments,
   AdminConversationsInviteArguments,
+  AdminConversationsLinkObjectsArguments,
   AdminConversationsLookupArguments,
   AdminConversationsRemoveCustomRetentionArguments,
   AdminConversationsRenameArguments,
@@ -49,6 +51,7 @@ export type {
   AdminConversationsSetCustomRetentionArguments,
   AdminConversationsSetTeamsArguments,
   AdminConversationsUnarchiveArguments,
+  AdminConversationsUnlinkObjectsArguments,
 } from './admin/conversations';
 export type {
   AdminEmojiAddAliasArguments,

--- a/packages/web-api/src/types/response/AdminConversationsCreateForObjectsResponse.ts
+++ b/packages/web-api/src/types/response/AdminConversationsCreateForObjectsResponse.ts
@@ -1,0 +1,14 @@
+import type { WebAPICallResult } from '../../WebClient';
+
+export type AdminConversationsCreateForObjectsResponse = WebAPICallResult & {
+  channel_id?: string;
+  error?: string;
+  needed?: string;
+  ok?: boolean;
+  provided?: string;
+  response_metadata?: ResponseMetadata;
+};
+
+export interface ResponseMetadata {
+  messages?: string[];
+}

--- a/packages/web-api/src/types/response/AdminConversationsLinkObjectsResponse.ts
+++ b/packages/web-api/src/types/response/AdminConversationsLinkObjectsResponse.ts
@@ -1,0 +1,13 @@
+import type { WebAPICallResult } from '../../WebClient';
+
+export type AdminConversationsLinkObjectsResponse = WebAPICallResult & {
+  error?: string;
+  needed?: string;
+  ok?: boolean;
+  provided?: string;
+  response_metadata?: ResponseMetadata;
+};
+
+export interface ResponseMetadata {
+  messages?: string[];
+}

--- a/packages/web-api/src/types/response/AdminConversationsUnlinkObjectsResponse.ts
+++ b/packages/web-api/src/types/response/AdminConversationsUnlinkObjectsResponse.ts
@@ -1,0 +1,13 @@
+import type { WebAPICallResult } from '../../WebClient';
+
+export type AdminConversationsUnlinkObjectsResponse = WebAPICallResult & {
+  error?: string;
+  needed?: string;
+  ok?: boolean;
+  provided?: string;
+  response_metadata?: ResponseMetadata;
+};
+
+export interface ResponseMetadata {
+  messages?: string[];
+}

--- a/packages/web-api/src/types/response/index.ts
+++ b/packages/web-api/src/types/response/index.ts
@@ -28,6 +28,7 @@ export { AdminConversationsBulkDeleteResponse } from './AdminConversationsBulkDe
 export { AdminConversationsBulkMoveResponse } from './AdminConversationsBulkMoveResponse';
 export { AdminConversationsConvertToPrivateResponse } from './AdminConversationsConvertToPrivateResponse';
 export { AdminConversationsConvertToPublicResponse } from './AdminConversationsConvertToPublicResponse';
+export { AdminConversationsCreateForObjectsResponse } from './AdminConversationsCreateForObjectsResponse';
 export { AdminConversationsCreateResponse } from './AdminConversationsCreateResponse';
 export { AdminConversationsDeleteResponse } from './AdminConversationsDeleteResponse';
 export { AdminConversationsDisconnectSharedResponse } from './AdminConversationsDisconnectSharedResponse';
@@ -36,6 +37,7 @@ export { AdminConversationsGetConversationPrefsResponse } from './AdminConversat
 export { AdminConversationsGetCustomRetentionResponse } from './AdminConversationsGetCustomRetentionResponse';
 export { AdminConversationsGetTeamsResponse } from './AdminConversationsGetTeamsResponse';
 export { AdminConversationsInviteResponse } from './AdminConversationsInviteResponse';
+export { AdminConversationsLinkObjectsResponse } from './AdminConversationsLinkObjectsResponse';
 export { AdminConversationsLookupResponse } from './AdminConversationsLookupResponse';
 export { AdminConversationsRemoveCustomRetentionResponse } from './AdminConversationsRemoveCustomRetentionResponse';
 export { AdminConversationsRenameResponse } from './AdminConversationsRenameResponse';
@@ -47,6 +49,7 @@ export { AdminConversationsSetConversationPrefsResponse } from './AdminConversat
 export { AdminConversationsSetCustomRetentionResponse } from './AdminConversationsSetCustomRetentionResponse';
 export { AdminConversationsSetTeamsResponse } from './AdminConversationsSetTeamsResponse';
 export { AdminConversationsUnarchiveResponse } from './AdminConversationsUnarchiveResponse';
+export { AdminConversationsUnlinkObjectsResponse } from './AdminConversationsUnlinkObjectsResponse';
 export { AdminConversationsWhitelistAddResponse } from './AdminConversationsWhitelistAddResponse';
 export { AdminConversationsWhitelistListGroupsLinkedToChannelResponse } from './AdminConversationsWhitelistListGroupsLinkedToChannelResponse';
 export { AdminConversationsWhitelistRemoveResponse } from './AdminConversationsWhitelistRemoveResponse';

--- a/packages/web-api/test/types/methods/admin.conversations.test-d.ts
+++ b/packages/web-api/test/types/methods/admin.conversations.test-d.ts
@@ -182,6 +182,35 @@ expectAssignable<Parameters<typeof web.admin.conversations.create>>([
   },
 ]);
 
+// admin.conversations.createForObjects
+// -- sad path
+expectError(web.admin.conversations.createForObjects()); // lacking argument
+expectError(web.admin.conversations.createForObjects({})); // empty argument
+expectError(
+  web.admin.conversations.createForObjects({
+    object_id: '0019000000DmehKAAR', // missing salesforce_org_id
+  }),
+);
+expectError(
+  web.admin.conversations.createForObjects({
+    salesforce_org_id: '00DGC00000024hsuWY', // missing object_id
+  }),
+);
+// -- happy path
+expectAssignable<Parameters<typeof web.admin.conversations.createForObjects>>([
+  {
+    object_id: '0019000000DmehKAAR',
+    salesforce_org_id: '00DGC00000024hsuWY',
+  },
+]);
+expectAssignable<Parameters<typeof web.admin.conversations.createForObjects>>([
+  {
+    object_id: '0019000000DmehKAAR',
+    salesforce_org_id: '00DGC00000024hsuWY',
+    invite_object_team: true,
+  },
+]);
+
 // admin.conversations.delete
 // -- sad path
 expectError(web.admin.conversations.delete()); // lacking argument
@@ -285,6 +314,40 @@ expectAssignable<Parameters<typeof web.admin.conversations.lookup>>([
   {
     team_ids: ['T1234'],
     last_message_activity_before: 10,
+  },
+]);
+
+// admin.conversations.linkObjects
+// -- sad path
+expectError(web.admin.conversations.linkObjects()); // lacking argument
+expectError(web.admin.conversations.linkObjects({})); // empty argument
+expectError(
+  web.admin.conversations.linkObjects({
+    channel: 'C1234', // missing record_id and salesforce_org_id
+  }),
+);
+expectError(
+  web.admin.conversations.linkObjects({
+    record_id: '0019000000DmehKAAR', // missing channel and salesforce_org_id
+  }),
+);
+expectError(
+  web.admin.conversations.linkObjects({
+    salesforce_org_id: '00DGC00000024hsuWY', // missing channel and record_id
+  }),
+);
+expectError(
+  web.admin.conversations.linkObjects({
+    channel: 'C1234',
+    record_id: '0019000000DmehKAAR', // missing salesforce_org_id
+  }),
+);
+// -- happy path
+expectAssignable<Parameters<typeof web.admin.conversations.linkObjects>>([
+  {
+    channel: 'C1234',
+    record_id: '0019000000DmehKAAR',
+    salesforce_org_id: '00DGC00000024hsuWY',
   },
 ]);
 
@@ -445,5 +508,27 @@ expectError(web.admin.conversations.unarchive({})); // empty argument
 expectAssignable<Parameters<typeof web.admin.conversations.unarchive>>([
   {
     channel_id: 'C1234',
+  },
+]);
+
+// admin.conversations.unlinkObjects
+// -- sad path
+expectError(web.admin.conversations.unlinkObjects()); // lacking argument
+expectError(web.admin.conversations.unlinkObjects({})); // empty argument
+expectError(
+  web.admin.conversations.unlinkObjects({
+    channel: 'C1234', // missing new_name
+  }),
+);
+expectError(
+  web.admin.conversations.unlinkObjects({
+    new_name: 'new-channel-name', // missing channel
+  }),
+);
+// -- happy path
+expectAssignable<Parameters<typeof web.admin.conversations.unlinkObjects>>([
+  {
+    channel: 'C1234',
+    new_name: 'new-channel-name',
   },
 ]);


### PR DESCRIPTION
### Summary

This PR adds the following API methods to `@slack/web-api`:

- https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
- https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
- https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects

### Preview

Examples of these methods with placeholder values can be found below:

```ts
const response = await client.admin.conversations.createForObjects({
  object_id: "0019000000DmehKAAR",
  salesforce_org_id: "0019000000DmehKAAR",
  invite_object_team: false,
});
```

```ts
const response = await client.admin.conversations.linkObjects({
  channel: "C0123456789",
  record_id: "0019000000DmehKAAR",
  salesforce_org_id: "0019000000DmehKAAR",
});
```

```ts
const response = await client.admin.conversations.unlinkObjects({
  channel: "C0123456789",
  new_name: "example-",
});
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
