### PR TITLE
bump form-data to at least 4.0.4. to resolve  CVE-2025-7783

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -54,7 +54,7 @@
     "@types/retry": "0.12.0",
     "axios": "^1.8.3",
     "eventemitter3": "^5.0.1",
-    "form-data": "^4.0.0",
+    "form-data": "^4.0.4",
     "is-electron": "2.2.2",
     "is-stream": "^2",
     "p-queue": "^6",


### PR DESCRIPTION
### Summary

Bumps form-data to at least 4.0.4 to resolve [CVE-2025-7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783) 
- Details in this issue: https://github.com/slackapi/node-slack-sdk/issues/2307
- Further detail from the form-data team at https://github.com/form-data/form-data/security/advisories/GHSA-fjxv-7rqg-78g4

I did not bump version numbers on the package since I'm not sure what the release procedure is.  

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
