### PR TITLE
chore(rtm-api): bump @slack/web-api to 7.10.0

### DIFF
--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4",
-    "@slack/web-api": "^7.9.1",
+    "@slack/web-api": "^7.10.0",
     "@types/node": ">=18",
     "eventemitter3": "^5",
     "finity": "^0.5.4",


### PR DESCRIPTION
### Summary

This PR bumps `@slack/web-api` to the latest [7.10.0](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%407.10.0) to ensure the latest dependencies are installed 🔏 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
