### PR TITLE
feat(cli-test): add version command

### DIFF
--- a/packages/cli-test/src/cli/commands/version.spec.ts
+++ b/packages/cli-test/src/cli/commands/version.spec.ts
@@ -1,0 +1,32 @@
+import sinon from 'sinon';
+
+import { mockProcess } from '../../utils/test';
+import { shell } from '../shell';
+import version from './version';
+
+describe('version commands', () => {
+  const sandbox = sinon.createSandbox();
+  let spawnSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    const process = mockProcess();
+    spawnSpy = sandbox.stub(shell, 'spawnProcess').returns({
+      command: 'version',
+      finished: true,
+      output: 'Using slack v3.4.5',
+      process,
+    });
+    sandbox.stub(shell, 'checkIfFinished').resolves();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('version method', () => {
+    it('should invoke `version`', async () => {
+      const actual = await version.version();
+      sandbox.assert.calledWith(spawnSpy, sinon.match.string, sinon.match.array.contains(['version']));
+      sinon.assert.match(actual, 'v3.4.5');
+    });
+  });
+});

--- a/packages/cli-test/src/cli/commands/version.ts
+++ b/packages/cli-test/src/cli/commands/version.ts
@@ -1,0 +1,15 @@
+import { SlackCLIProcess } from '../cli-process';
+
+/**
+ * `slack version`
+ * @returns command output
+ */
+export const version = async function version(): Promise<string> {
+  const cmd = new SlackCLIProcess(['version']);
+  const proc = await cmd.execAsync();
+  return proc.output;
+};
+
+export default {
+  version,
+};

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -14,6 +14,7 @@ import func from './commands/function';
 import manifest from './commands/manifest';
 import platform from './commands/platform';
 import trigger from './commands/trigger';
+import version from './commands/version';
 
 /**
  * Set of functions to spawn and interact with Slack Platform CLI processes and commands
@@ -30,6 +31,7 @@ export const SlackCLI = {
   manifest,
   platform,
   trigger,
+  version,
 
   /**
    * Delete app and Log out of current team session


### PR DESCRIPTION
### Summary

This PR adds the Slack CLI `version` command to the test runner to confirm the right version is found in adjacent tests.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
