### PR TITLE
build: use latest biome schema version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -10,9 +10,7 @@
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,
-    "includes": [
-      "**"
-    ],
+    "includes": ["**"],
     "attributePosition": "auto",
     "indentStyle": "space",
     "indentWidth": 2,

--- a/packages/cli-hooks/biome.json
+++ b/packages/cli-hooks/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/cli-test/biome.json
+++ b/packages/cli-test/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/logger/biome.json
+++ b/packages/logger/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/oauth/biome.json
+++ b/packages/oauth/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/rtm-api/biome.json
+++ b/packages/rtm-api/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/socket-mode/biome.json
+++ b/packages/socket-mode/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/types/biome.json
+++ b/packages/types/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }

--- a/packages/web-api/biome.json
+++ b/packages/web-api/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"],
   "overrides": [
     {

--- a/packages/webhook/biome.json
+++ b/packages/webhook/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["../../biome.json"]
 }


### PR DESCRIPTION
### Summary

This PR prefers the `latest` biome schema version to avoid warnings in build scripts.

### Preview

#### Before changes

```
$ npm run lint

> @slack/web-api@7.10.0 lint
> npx @biomejs/biome check .

biome.json:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The configuration schema version does not match the CLI version 2.2.0

    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "extends": ["../../biome.json"],
    4 │   "overrides": [

  ℹ   Expected:                     2.2.0
      Found:                        2.0.5


  ℹ Run the command biome migrate to migrate the configuration file.


Checked 430 files in 63ms. No fixes applied.
Found 1 warning.
```

#### After changes

```
$ npm run lint

> @slack/web-api@7.10.0 lint
> npx @biomejs/biome check .

Checked 430 files in 63ms. No fixes applied.
```

### Notes

This might encourage us to keep following the latest version of `biome` with a minimum version requirement?

https://github.com/slackapi/node-slack-sdk/blob/893a37dd3da2a66cc6cfbbd9d66e57eeab22295a/packages/cli-hooks/package.json#L58

Although that isn't [recommended](https://biomejs.dev/internals/versioning/)...

> Due to the nature of these changes, it’s **highly recommended** to save the exact version in your package.json, instead of using range operators.

I'd be interested in revisiting how we include some dependencies like `tsc` and `biome` to use pinned versions later or instead of this change since unexpected updates to these would be an unfortunate reason to error?

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
