### PR TITLE
feat(web-api): add message to chat.stopStream response type

### DIFF
--- a/packages/web-api/src/types/response/ChatStopStreamResponse.ts
+++ b/packages/web-api/src/types/response/ChatStopStreamResponse.ts
@@ -1,3 +1,4 @@
+import type { Block, KnownBlock } from '@slack/types';
 import type { WebAPICallResult } from '../../WebClient';
 export type ChatStopStreamResponse = WebAPICallResult & {
   channel?: string;
@@ -6,4 +7,18 @@ export type ChatStopStreamResponse = WebAPICallResult & {
   ok?: boolean;
   provided?: string;
   ts?: string;
+  message?: ChatStopStreamResponseMessage;
 };
+
+export interface ChatStopStreamResponseMessage {
+  subtype?: string;
+  text?: string;
+  user?: string;
+  streaming_state?: string;
+  type?: string;
+  ts?: string;
+  bot_id?: string;
+  thread_ts?: string;
+  parent_user_id?: string;
+  blocks?: (Block | KnownBlock)[];
+}


### PR DESCRIPTION
### Summary

This PR adds `message` to the response types of `chat.stopStream` with the **blocks** from `@slack/types` in place of autogenerated builds for this time.

### Reviewers

Please do compare these values and types to actual responses! 👁️‍🗨️ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
