### PR TITLE
docs: update package homepage to docs.slack.dev tools reference

### DIFF
--- a/packages/cli-hooks/README.md
+++ b/packages/cli-hooks/README.md
@@ -114,11 +114,11 @@ assistance working through your issue:
 
 <!-- a collection of links -->
 [bolt]: https://github.com/slackapi/bolt-js
-[cli]: https://tools.slack.dev/slack-cli/
+[cli]: https://docs.slack.dev/tools/slack-cli/
 [community]: https://community.slack.com/
 [config]: https://api.slack.com/apps
 [email]: mailto:developers@slack.com
-[install]: https://tools.slack.dev/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux
+[install]: https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux
 [issues]: http://github.com/slackapi/node-slack-sdk/issues
 [manifest]: https://docs.slack.dev/reference/app-manifest
 [node]: https://github.com/nodejs/Release#release-schedule

--- a/packages/cli-hooks/package.json
+++ b/packages/cli-hooks/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "git+https://github.com/slackapi/node-slack-sdk.git"
   },
-  "homepage": "https://tools.slack.dev/node-slack-sdk",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli-test/README.md
+++ b/packages/cli-test/README.md
@@ -70,5 +70,5 @@ describe('Login with the CLI', () => {
 | `SLACK_CLI_PATH`      | yes      | path to Slack CLI binary                                                       |
 | `SLACK_CLI_LOG_LEVEL` | no       | default: `info`. [Logger levels](https://github.com/winstonjs/winston#logging) |
 
-[cli]: https://tools.slack.dev/deno-slack-sdk/guides/getting-started
-[commands]: https://tools.slack.dev/slack-cli/reference/commands/slack
+[cli]: https://docs.slack.dev/tools/slack-cli/
+[commands]: https://docs.slack.dev/tools/slack-cli/reference/commands/slack/

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -18,7 +18,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -16,13 +16,13 @@ $ npm install @slack/oauth
 
 ## Usage
 
-These examples show how to get started using the most common features. You'll find more extensive [documentation on the package's website](https://tools.slack.dev/node-slack-sdk/oauth).
+These examples show how to get started using the most common features. You'll find more extensive [documentation on the package's website](https://docs.slack.dev/tools/node-slack-sdk/oauth/).
 
 <!-- END: Remove before copying into the docs directory -->
 
 Before building an app, you'll need to [create a Slack app](https://api.slack.com/apps/new) and install it to your development workspace. You'll also need to copy the **Client ID** and **Client Secret** given to you by Slack under the **Basic Information** of your app configuration.
 
-It may be helpful to read the tutorials on [getting started](https://tools.slack.dev/node-slack-sdk/getting-started) and [getting a public URL that can be used for development](https://tools.slack.dev/node-slack-sdk/tutorials/local-development).
+It may be helpful to read the tutorials on [getting started](https://docs.slack.dev/tools/node-slack-sdk/getting-started/) and [getting a public URL that can be used for development](https://docs.slack.dev/tools/node-slack-sdk/tutorials/local-development/).
 
 ---
 

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -20,7 +20,7 @@
     "npm": ">=8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk/oauth",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/oauth/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rtm-api/README.md
+++ b/packages/rtm-api/README.md
@@ -3,7 +3,7 @@
 The `@slack/rtm-api` package contains a simple, convenient, and configurable client for receiving events and sending simple messages to Slack's [Real Time Messaging API](https://docs.slack.dev/legacy/legacy-rtm-api). Use it in your
 app to stay connected to the Slack platform over a persistent Websocket connection.
 
-**Note**: The RTM API isn't available for modern granular-permissions apps, and you can no longer create new legacy apps. We recommend using [Bolt for JavaScript](https://tools.slack.dev/bolt-js). If you have an existing RTM app, do not update its scopes as it will be updated to a granular-permissions app and stop working with the RTM API.
+**Note**: The RTM API isn't available for modern granular-permissions apps, and you can no longer create new legacy apps. We recommend using [Bolt for JavaScript](https://docs.slack.dev/tools/bolt-js/). If you have an existing RTM app, do not update its scopes as it will be updated to a granular-permissions app and stop working with the RTM API.
 
 ## Installation
 
@@ -16,7 +16,7 @@ $ npm install @slack/rtm-api
 ## Usage
 
 These examples show the most common features of the `RTMClient`. You'll find even more extensive [documentation on the
-package's website](https://tools.slack.dev/node-slack-sdk/rtm-api).
+package's website](https://docs.slack.dev/tools/node-slack-sdk/rtm-api/).
 
 <!-- END: Remove before copying into the docs directory -->
 
@@ -72,7 +72,7 @@ user ID and team ID, you can look those up any time the client is connected as t
 
 Options passed to the `.start()` method are passed through as arguments to the [`rtm.connect` Web API
 method](https://docs.slack.dev/reference/methods/rtm.connect). These arguments deal with presence, which is discussed in more
-detail [on the documentation website](https://tools.slack.dev/node-slack-sdk/rtm-api/#presence).
+detail [on the documentation website](https://docs.slack.dev/tools/node-slack-sdk/rtm-api/#presence).
 
 </details>
 

--- a/packages/rtm-api/package.json
+++ b/packages/rtm-api/package.json
@@ -26,7 +26,7 @@
     "npm": ">=8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk/rtm-api",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/rtm-api/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -28,7 +28,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk/socket-mode",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/socket-mode/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,7 +20,7 @@
     "npm": ">= 6.12.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/reference/types/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -621,7 +621,7 @@ export interface URLInput extends Actionable, Dispatchable, Focusable, Placehold
 }
 
 /**
- * @description Allows users to run a {@link https://tools.slack.dev/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger} with customizable inputs.
+ * @description Allows users to run a {@link https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger} with customizable inputs.
  * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element Workflow button element reference}.
  */
 export interface WorkflowButton extends Confirmable {
@@ -639,12 +639,12 @@ export interface WorkflowButton extends Confirmable {
    */
   workflow: {
     /**
-     * @description Properties of the {@link https://tools.slack.dev/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger}
+     * @description Properties of the {@link https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger}
      * that will be invoked via this button.
      */
     trigger: {
       /**
-       * @description The trigger URL of the {@link https://tools.slack.dev/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger}
+       * @description The trigger URL of the {@link https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-link-triggers/#workflow_buttons link trigger}
        */
       url: string;
       /**

--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -23,7 +23,7 @@ $ npm install @slack/web-api
 ## Usage
 
 These examples show the most common features of the `WebClient`. You'll find even more extensive [documentation on the
-package's website](https://tools.slack.dev/node-slack-sdk/web-api).
+package's website](https://docs.slack.dev/tools/node-slack-sdk/web-api/).
 
 <!-- END: Remove before copying into the docs directory -->
 
@@ -101,9 +101,9 @@ const conversationId = '...';
 **Tip**: If you're using an editor that supports TypeScript, even if you're not using TypeScript to write your code,
 you'll get hints for all the arguments each method supports. This helps you save time by reducing the number of
 times you need to pop out to a webpage to check the reference. There's more information about [using
-TypeScript](https://tools.slack.dev/node-slack-sdk/typescript) with this package in the documentation website.
+TypeScript](https://docs.slack.dev/tools/node-slack-sdk/typescript/) with this package in the documentation website.
 
-**Tip**: Use the [Block Kit Builder](https://api.slack.com/tools/block-kit-builder) for a playground
+**Tip**: Use the [Block Kit Builder](https://app.slack.com/block-kit-builder) for a playground
 where you can prototype your message's look and feel.
 
 <details>
@@ -174,7 +174,7 @@ There are a few more types of errors that you might encounter, each with one of 
 
 * `ErrorCode.RateLimitedError`: The Web API cannot fulfill the API method call because your app has made too many
   requests too quickly. This error has a `retryAfter` property with the number of seconds you should wait before trying
-  again. See [the documentation on rate limit handling](https://tools.slack.dev/node-slack-sdk/web-api/#rate-limits) to
+  again. See [the documentation on rate limit handling](https://docs.slack.dev/tools/node-slack-sdk/web-api/#rate-limits) to
   understand how the client will automatically deal with these problems for you.
 
 * `ErrorCode.HTTPError`: The HTTP response contained an unfamiliar status code. The Web API only responds with `200`
@@ -366,7 +366,7 @@ retrying the API call. If you'd like to opt out of that behavior, set the `rejec
 
 ### More
 
-The [documentation website](https://tools.slack.dev/node-slack-sdk/web-api) has information about these additional features of
+The [documentation website](https://docs.slack.dev/tools/node-slack-sdk/web-api/) has information about these additional features of
 the `WebClient`:
 
 *  Upload a file with a `Buffer` or a `ReadableStream`.

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -25,7 +25,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk/web-api",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/web-api/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -80,7 +80,7 @@ export interface WebClientOptions {
   /**
    * The base URL requests are sent to. Often unchanged, but might be set for testing techniques.
    *
-   * See {@link https://tools.slack.dev/node-slack-sdk/web-api/#custom-api-url} for more information.
+   * See {@link https://docs.slack.dev/tools/node-slack-sdk/web-api/#custom-api-url} for more information.
    * @default https://slack.com/api/
    */
   slackApiUrl?: string;
@@ -98,7 +98,7 @@ export interface WebClientOptions {
    * Determines if a dynamic method name being an absolute URL overrides the configured slackApiUrl.
    * When set to false, the URL used in Slack API requests will always begin with the slackApiUrl.
    *
-   * See {@link https://tools.slack.dev/node-slack-sdk/web-api#call-a-method} for more details.
+   * See {@link https://docs.slack.dev/tools/node-slack-sdk/web-api/#call-a-method} for more details.
    * See {@link https://github.com/axios/axios?tab=readme-ov-file#request-config} for more details.
    * @default true
    */
@@ -244,7 +244,7 @@ export class WebClient extends Methods {
    * Determines if a dynamic method name being an absolute URL overrides the configured slackApiUrl.
    * When set to false, the URL used in Slack API requests will always begin with the slackApiUrl.
    *
-   * See {@link https://tools.slack.dev/node-slack-sdk/web-api#call-a-method} for more details.
+   * See {@link https://docs.slack.dev/tools/node-slack-sdk/web-api/#call-a-method} for more details.
    * See {@link https://github.com/axios/axios?tab=readme-ov-file#request-config} for more details.
    * @default true
    */

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1926,7 +1926,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
      * - multiple upload_files
      * Will try to honor both single file or content data supplied as well
      * as multiple file uploads property.
-     * @see {@link https://tools.slack.dev/node-slack-sdk/web-api#upload-a-file `@slack/web-api` Upload a file documentation}.
+     * @see {@link https://docs.slack.dev/tools/node-slack-sdk/web-api/#upload-a-file `@slack/web-api` Upload a file documentation}.
      */
     uploadV2: bindFilesUploadV2<FilesUploadV2Arguments, WebAPICallResult>(this),
     comments: {

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -179,7 +179,7 @@ export interface FilesUploadV2ArgumentsMultipleFiles {
   >[];
 }
 
-// https://tools.slack.dev/node-slack-sdk/web-api#upload-a-file
+// https://docs.slack.dev/tools/node-slack-sdk/web-api/#upload-a-file
 export type FilesUploadV2Arguments = TokenOverridable &
   (FileUploadV2 | (Omit<FileUploadV2, 'file' | 'content'> & FilesUploadV2ArgumentsMultipleFiles));
 

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -22,7 +22,7 @@
     "npm": ">= 8.6.0"
   },
   "repository": "slackapi/node-slack-sdk",
-  "homepage": "https://tools.slack.dev/node-slack-sdk/webhook",
+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/webhook/",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Summary

This PR updates package [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) links to reference the redirects docs.slack.dev/tools pages for this SDK.

Some other links were changed to more current pages too! 📚 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
