### PR TITLE
feat(types): add feedback_buttons and icon_button blocks as context_actions block elements

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -139,6 +139,52 @@ export interface EmailInput extends Actionable, Dispatchable, Focusable, Placeho
 }
 
 /**
+ * @description Buttons to indicate positive or negative feedback.
+ */
+export interface FeedbackButtons extends Actionable {
+  /**
+   * @description The type of block. For a feedback buttons block, `type` is always `feedback_buttons`.
+   */
+  type: 'feedback_buttons';
+  /**
+   * @description A button to indicate positive feedback.
+   */
+  positive_button: {
+    /**
+     * @description Defines an object containing some text.
+     * @see {@link https://docs.slack.dev/reference/block-kit/composition-objects/text-object Text object reference}.
+     */
+    text: PlainTextElement;
+    /**
+     * @description A label for longer descriptive text about a button element. This label will be read out by screen readers instead of the button `text` object. Maximum length for this field is 75 characters.
+     */
+    accessibility_label?: string;
+    /**
+     * @description The positive feedback button value.
+     */
+    value: string;
+  }
+  /**
+   * @description A button to indicate negative feedback.
+   */
+  negative_button: {
+    /**
+     * @description Defines an object containing some text.
+     * @see {@link https://docs.slack.dev/reference/block-kit/composition-objects/text-object Text object reference}.
+     */
+    text: PlainTextElement;
+    /**
+     * @description A label for longer descriptive text about a button element. This label will be read out by screen readers instead of the button `text` object. Maximum length for this field is 75 characters.
+     */
+    accessibility_label?: string;
+    /**
+     * @description The negative feedback button value.
+     */
+    value: string;
+  }
+}
+
+/**
  * @description Allows user to upload files. In order to use the `file_input` element within your app,
  * your app must have the `files:read` scope.
  * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/file-input-element File input element reference}.
@@ -159,6 +205,37 @@ export interface FileInput extends Actionable {
    * `10`. Defaults to `10` if not specified.
    */
   max_files?: number;
+}
+
+/**
+ * @description An icon button to perform actions.
+ */
+export interface IconButton extends Actionable, Confirmable {
+  /**
+   * @description The type of element. In this case `type` is always `file_input`.
+   */
+  type: 'icon_button';
+  /**
+   * @description The icon to show.
+   */
+  icon: string;
+  /**
+   * @description Defines an object containing some text.
+   * @see {@link https://docs.slack.dev/reference/block-kit/composition-objects/text-object Text object reference}.
+   */
+  text: PlainTextElement;
+  /**
+   * @description A label for longer descriptive text about a button element. This label will be read out by screen readers instead of the button `text` object. Maximum length for this field is 75 characters.
+   */
+  accessibility_label?: string;
+  /**
+   * @description The positive feedback button value.
+   */
+  value: string;
+  /**
+   * @description User IDs for which the icon appears.
+   */
+  visible_to_user_ids: string[];
 }
 
 /**

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -5,7 +5,9 @@ import type {
   Datepicker,
   DateTimepicker,
   EmailInput,
+  FeedbackButtons,
   FileInput,
+  IconButton,
   ImageElement,
   MultiSelect,
   NumberInput,
@@ -46,6 +48,7 @@ export interface Block {
 export type KnownBlock =
   | ActionsBlock
   | ContextBlock
+  | ContextActionsBlock
   | DividerBlock
   | FileBlock
   | HeaderBlock
@@ -115,6 +118,25 @@ export interface ContextBlock extends Block {
    * Maximum number of items is 10.
    */
   elements: ContextBlockElement[]; // TODO: breaking change: min 1 item
+}
+
+/**
+ * A helper union type of all Block Elements that can be used in a {@link ContextActionsBlock}.
+ */
+export type ContextActionsBlockElement = FeedbackButtons | IconButton;
+
+/**
+ * @description Displays actions as contextual info, which can include both feedback and icons.
+ */
+export interface ContextActionsBlock extends Block {
+  /**
+   * @description The type of block. For a context actions block, `type` is always `context_actions`.
+   */
+  type: 'context_actions';
+  /**
+   * @description An array of {@link FeedbackButtons} or {@link IconButtons} objects.
+   */
+  elements: ContextActionsBlockElement[];
 }
 
 /**


### PR DESCRIPTION
### Summary

This PR adds the following to `@slack/types`:

- `feedback_buttons` block action
- `icon_button` block action
- `context_actions` block

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
