### PR TITLE
feat(types): add streaming_state to bot_message event

### DIFF
--- a/packages/types/src/events/message.ts
+++ b/packages/types/src/events/message.ts
@@ -68,6 +68,7 @@ export interface BotMessageEvent {
   event_ts: string;
   channel: string;
   channel_type: ChannelTypes;
+  streaming_state?: 'in_progress' | 'completed' | 'errored';
   ts: string;
   text: string;
   bot_id: string;


### PR DESCRIPTION
### Summary

This PR adds `streaming_state` to the [`bot_message`](https://docs.slack.dev/reference/events/message/bot_message) message event subtype.

### Reviewers

Confirm that this field appears in message changed event 🤖 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
