### PR TITLE
chore(web-api): bump @slack/types@2.16.0-aiAppsBeta.1

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4.0.0",
-    "@slack/types": "^2.9.0",
+    "@slack/types": "2.16.0-aiAppsBeta.1",
     "@types/node": ">=18.0.0",
     "@types/retry": "0.12.0",
     "axios": "^1.11.0",


### PR DESCRIPTION
### Summary

This PR updates `@slack/web-api` to use `@slack/types@2.16.0-aiAppsBeta.1` for a pre release 🚀 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
