### PR TITLE
fix(types): update jsdoc link to a single icon button

### DIFF
--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -134,7 +134,7 @@ export interface ContextActionsBlock extends Block {
    */
   type: 'context_actions';
   /**
-   * @description An array of {@link FeedbackButtons} or {@link IconButtons} objects.
+   * @description An array of {@link FeedbackButtons} or {@link IconButton} objects.
    */
   elements: ContextActionsBlockElement[];
 }


### PR DESCRIPTION
### Summary

This PR updates JSDoc reference to a single `IconButton` for the `context_actions` block "elements" attribute:

https://github.com/slackapi/node-slack-sdk/blob/bd62ff4767928d57c5bfb72a5ce3e37efcef3fef/packages/types/src/block-kit/block-elements.ts#L210-L217

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
