### PR TITLE
fix(web-api): align files.uploadV2 return type

### DIFF
--- a/docs/english/reference/web-api/classes/Methods.md
+++ b/docs/english/reference/web-api/classes/Methods.md
@@ -3063,7 +3063,10 @@ Use `uploadV2` instead. See [our post on retiring \`files.upload\`](https://docs
 #### uploadV2
 
 ```ts
-uploadV2: MethodWithRequiredArgument<FilesUploadV2Arguments, WebAPICallResult>;
+uploadV2: MethodWithRequiredArgument<
+  FilesUploadV2Arguments,
+  WebAPICallResult & { files: FilesCompleteUploadExternalResponse[] }
+>;
 ```
 
 ##### Description

--- a/docs/english/reference/web-api/classes/WebClient.md
+++ b/docs/english/reference/web-api/classes/WebClient.md
@@ -3151,7 +3151,10 @@ Use `uploadV2` instead. See [our post on retiring \`files.upload\`](https://docs
 #### uploadV2
 
 ```ts
-uploadV2: MethodWithRequiredArgument<FilesUploadV2Arguments, WebAPICallResult>;
+uploadV2: MethodWithRequiredArgument<
+  FilesUploadV2Arguments,
+  WebAPICallResult & { files: FilesCompleteUploadExternalResponse[] }
+>;
 ```
 
 ##### Description

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -573,7 +573,9 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
   }
 
   public abstract apiCall(method: string, options?: Record<string, unknown>): Promise<WebAPICallResult>;
-  public abstract filesUploadV2(options: FilesUploadV2Arguments): Promise<WebAPICallResult>;
+  public abstract filesUploadV2(
+    options: FilesUploadV2Arguments,
+  ): Promise<WebAPICallResult & { files: FilesCompleteUploadExternalResponse[] }>;
 
   public readonly admin = {
     analytics: {
@@ -1928,7 +1930,10 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
      * as multiple file uploads property.
      * @see {@link https://docs.slack.dev/tools/node-slack-sdk/web-api/#upload-a-file `@slack/web-api` Upload a file documentation}.
      */
-    uploadV2: bindFilesUploadV2<FilesUploadV2Arguments, WebAPICallResult>(this),
+    uploadV2: bindFilesUploadV2<
+      FilesUploadV2Arguments,
+      WebAPICallResult & { files: FilesCompleteUploadExternalResponse[] }
+    >(this),
     comments: {
       /**
        * @description Deletes an existing comment on a file.

--- a/packages/web-api/test/types/methods/files.test-d.ts
+++ b/packages/web-api/test/types/methods/files.test-d.ts
@@ -1,5 +1,7 @@
 import { expectAssignable, expectError } from 'tsd';
 import { WebClient } from '../../../src/WebClient';
+import type { WebAPICallResult } from '../../../src/WebClient';
+import type { FilesCompleteUploadExternalResponse } from '../../../src/types/response/FilesCompleteUploadExternalResponse';
 
 const web = new WebClient('TOKEN');
 
@@ -177,6 +179,9 @@ expectAssignable<Parameters<typeof web.files.uploadV2>>([
     content: 'text',
   },
 ]);
+expectAssignable<Promise<WebAPICallResult & { files: FilesCompleteUploadExternalResponse[] }>>(
+  web.files.uploadV2({ content: 'text' }),
+);
 
 // files.comments.delete
 // -- sad path


### PR DESCRIPTION
### Summary

- align the public `files.uploadV2` method to advertise the same return payload as the helper `filesUploadV2`
- update the docs and tsd coverage so callers can rely on the `files` array in the response

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).