### PR TITLE
feat(web-api): add a chat stream method to the web client

### DIFF
--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1214,6 +1214,159 @@ describe('WebClient', () => {
     });
   });
 
+  describe('chatStream', () => {
+    it('streams a short message', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/chat.startStream', {
+          channel: 'C0123456789',
+          thread_ts: '123.000',
+          recipient_team_id: 'T0123456789',
+          recipient_user_id: 'U0123456789',
+        })
+        .reply(200, {
+          ok: true,
+          ts: '123.123',
+        })
+        .post('/api/chat.stopStream', { channel: 'C0123456789', ts: '123.123', markdown_text: 'nice!' })
+        .reply(200, {
+          ok: true,
+        });
+      const streamer = client.chatStream({
+        channel: 'C0123456789',
+        thread_ts: '123.000',
+        recipient_team_id: 'T0123456789',
+        recipient_user_id: 'U0123456789',
+      });
+      await streamer.append({
+        markdown_text: 'nice!',
+      });
+      await streamer.stop();
+      scope.done();
+    });
+
+    it('streams a long message', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/chat.startStream', {
+          channel: 'C0123456789',
+          markdown_text: '**this messag',
+          recipient_team_id: 'T0123456789',
+          recipient_user_id: 'U0123456789',
+          thread_ts: '123.000',
+        })
+        .reply(200, {
+          ok: true,
+          ts: '123.123',
+        })
+        .post('/api/chat.appendStream', {
+          channel: 'C0123456789',
+          markdown_text: 'e is bold!',
+          token: 'xoxb-updated-1',
+          ts: '123.123',
+        })
+        .reply(200, {
+          ok: true,
+        })
+        .post('/api/chat.stopStream', {
+          channel: 'C0123456789',
+          markdown_text: '**',
+          token: 'xoxb-updated-2',
+          ts: '123.123',
+        })
+        .reply(200, {
+          ok: true,
+        });
+      const streamer = client.chatStream({
+        buffer_size: 5,
+        channel: 'C0123456789',
+        recipient_team_id: 'T0123456789',
+        recipient_user_id: 'U0123456789',
+        thread_ts: '123.000',
+      });
+      await streamer.append({
+        markdown_text: '**this messag',
+      });
+      await streamer.append({
+        markdown_text: 'e is',
+        token: 'xoxb-updated-1',
+      });
+      await streamer.append({
+        markdown_text: ' bold!',
+      });
+      await streamer.append({
+        markdown_text: '*',
+      });
+      await streamer.stop({
+        markdown_text: '*',
+        token: 'xoxb-updated-2',
+      });
+      scope.done();
+    });
+
+    it('errors when appending to an unstarted stream', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/chat.startStream', {
+          channel: 'U0123456789',
+          thread_ts: '123.000',
+        })
+        .reply(200, {
+          ok: true,
+          ts: undefined,
+        });
+      const streamer = client.chatStream({
+        channel: 'U0123456789',
+        thread_ts: '123.000',
+      });
+      try {
+        await streamer.stop();
+        assert.fail();
+      } catch (error) {
+        assert.equal((error as Error).message, 'failed to stop stream: stream not started');
+      }
+      scope.done();
+    });
+
+    it('errors when appending to a completed stream', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/chat.startStream', {
+          channel: 'C0123456789',
+          thread_ts: '123.000',
+          recipient_team_id: 'T0123456789',
+          recipient_user_id: 'U0123456789',
+        })
+        .reply(200, {
+          ok: true,
+          ts: '123.123',
+        })
+        .post('/api/chat.stopStream', { channel: 'C0123456789', ts: '123.123', markdown_text: 'nice!' })
+        .reply(200, {
+          ok: true,
+        });
+      const streamer = client.chatStream({
+        channel: 'C0123456789',
+        thread_ts: '123.000',
+        recipient_team_id: 'T0123456789',
+        recipient_user_id: 'U0123456789',
+      });
+      await streamer.append({
+        markdown_text: 'nice!',
+      });
+      await streamer.stop();
+      try {
+        await streamer.append({ markdown_text: 'more...' });
+        assert.fail();
+      } catch (error) {
+        assert.equal((error as Error).message, 'failed to append stream: stream state is completed');
+      }
+      try {
+        await streamer.stop();
+        assert.fail();
+      } catch (error) {
+        assert.equal((error as Error).message, 'failed to stop stream: stream state is completed');
+      }
+      scope.done();
+    });
+  });
+
   describe('filesUploadV2', () => {
     it('uploads a single file', async () => {
       const scope = nock('https://slack.com')

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -513,10 +513,10 @@ export class WebClient extends Methods {
   /**
    * Stream markdown text into a conversation.
    *
-   * @description The "stream" method starts a new chat stream in a coversation that can be appended to. After appending an entire message, the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
+   * @description The "chatStream" method starts a new chat stream in a coversation that can be appended to. After appending an entire message, the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
    *
    * @example
-   * const streamer = await client.stream({
+   * const streamer = await client.chatStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
@@ -534,7 +534,7 @@ export class WebClient extends Methods {
    * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
    * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
    */
-  public async stream(params: ChatStartStreamArguments): Promise<ChatStreamer> {
+  public async chatStream(params: ChatStartStreamArguments): Promise<ChatStreamer> {
     const streamer = new ChatStreamer(this);
     await streamer.start(params);
     return streamer;

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -17,7 +17,7 @@ import isElectron from 'is-electron';
 import isStream from 'is-stream';
 import pQueue from 'p-queue';
 import pRetry, { AbortError } from 'p-retry';
-import ChatStreamer from './chat-stream';
+import { ChatStreamer, type ChatStreamerOptions } from './chat-stream';
 import {
   httpErrorFromResponse,
   platformErrorFromResult,
@@ -516,7 +516,7 @@ export class WebClient extends Methods {
    * @description The "chatStream" method starts a new chat stream in a coversation that can be appended to. After appending an entire message, the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
    *
    * @example
-   * const streamer = await client.chatStream({
+   * const streamer = client.chatStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
@@ -534,10 +534,12 @@ export class WebClient extends Methods {
    * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
    * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
    */
-  public async chatStream(params: ChatStartStreamArguments): Promise<ChatStreamer> {
-    const streamer = new ChatStreamer(this);
-    await streamer.start(params);
-    return streamer;
+  public chatStream(params: Omit<ChatStartStreamArguments & ChatStreamerOptions, 'markdown_text'>): ChatStreamer {
+    const { buffer_size, ...args } = params;
+    const options: ChatStreamerOptions = {
+      buffer_size,
+    };
+    return new ChatStreamer(this, this.logger, args, options);
   }
 
   /**

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -82,7 +82,7 @@ export default class ChatStreamer {
       ...params,
     });
     if (!response.ts) {
-      throw new Error('failed to start stream: ' + response.error);
+      throw new Error(`failed to start stream: ${response.error}`);
     }
     this.channel = params.channel;
     this.state = 'in_progress';

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -1,12 +1,26 @@
-import type { ExcludeFromUnion } from './types/helpers';
+import type { Logger } from '@slack/logger';
 import type { ChatAppendStreamArguments, ChatStartStreamArguments, ChatStopStreamArguments } from './types/request';
 import type { ChatAppendStreamResponse, ChatStartStreamResponse, ChatStopStreamResponse } from './types/response';
 import type WebClient from './WebClient';
 
-export default class ChatStreamer {
-  private channel: string | undefined;
+export interface ChatStreamerOptions {
+  /**
+   * @description The length of markdown_text to buffer in-memory before calling a method. Increasing this value decreases the number of method calls made for the same amount of text, which is useful to avoid rate limits.
+   * @default 250
+   */
+  buffer_size?: number;
+}
+
+export class ChatStreamer {
+  private args: ChatStartStreamArguments;
+
+  private buffer = '';
 
   private client: WebClient;
+
+  private logger: Logger;
+
+  private options: Required<ChatStreamerOptions>;
 
   private state: 'starting' | 'in_progress' | 'completed';
 
@@ -20,13 +34,14 @@ export default class ChatStreamer {
    * @description The "constructor" method creates a unique {@link ChatStreamer} instance that keeps track of one chat stream. The stream must be started.
    * @example
    * const client = new WebClient(process.env.SLACK_BOT_TOKEN);
-   * const streamer = new ChatStreamer(client);
-   * const _response = await streamer.start({
+   * const logger = new ConsoleLogger();
+   * const args = {
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
    *   recipient_user_id: "U0123456789",
-   * });
+   * };
+   * const streamer = new ChatStreamer(client, logger, args, { buffer_size: 500 });
    * await streamer.append({
    *   markdown_text: "**hello world!**",
    * });
@@ -35,59 +50,14 @@ export default class ChatStreamer {
    * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
    * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
    */
-  constructor(client: WebClient) {
+  constructor(client: WebClient, logger: Logger, args: ChatStartStreamArguments, options: ChatStreamerOptions) {
+    this.args = args;
     this.client = client;
+    this.logger = logger;
+    this.options = {
+      buffer_size: options.buffer_size ?? 250,
+    };
     this.state = 'starting';
-  }
-
-  /**
-   * Start a new stream.
-   *
-   * @description The "start" method starts a new chat stream unique to a {@link ChatStreamer} being used. This method can be called once. If the chat stream was created with the {@link WebClient#chatStream} method this method should not be called because the stream is started already.
-   * @example
-   * const streamer = await client.chatStream({
-   *   channel: "C0123456789",
-   *   thread_ts: "1700000001.123456",
-   *   recipient_team_id: "T0123456789",
-   *   recipient_user_id: "U0123456789",
-   * });
-   * await streamer.append({
-   *   markdown_text: "**hello world!**",
-   * });
-   * await streamer.stop();
-   * @example
-   * const client = new WebClient(process.env.SLACK_BOT_TOKEN);
-   * const streamer = new ChatStreamer(client);
-   * const _response = await streamer.start({
-   *   channel: "C0123456789",
-   *   thread_ts: "1700000001.123456",
-   *   recipient_team_id: "T0123456789",
-   *   recipient_user_id: "U0123456789",
-   * });
-   * await streamer.append({
-   *   markdown_text: "**hello world!**",
-   * });
-   * await streamer.stop();
-   * @see {@link https://docs.slack.dev/reference/methods/chat.startStream}
-   */
-  async start(params: ChatStartStreamArguments): Promise<ChatStartStreamResponse> {
-    if (this.state !== 'starting') {
-      throw new Error(`failed to start stream: stream state is ${this.state}`);
-    }
-    if (params.token) {
-      this.token = params.token;
-    }
-    const response = await this.client.chat.startStream({
-      token: this.token,
-      ...params,
-    });
-    if (!response.ts) {
-      throw new Error(`failed to start stream: ${response.error}`);
-    }
-    this.channel = params.channel;
-    this.state = 'in_progress';
-    this.streamTs = response.ts;
-    return response;
   }
 
   /**
@@ -95,7 +65,7 @@ export default class ChatStreamer {
    *
    * @description The "append" method appends to the chat stream being used. This method can be called multiple times. After the stream is stopped this method cannot be called.
    * @example
-   * const streamer = await client.stream({
+   * const streamer = client.startStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
@@ -111,27 +81,28 @@ export default class ChatStreamer {
    * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
    */
   async append(
-    params: ExcludeFromUnion<ChatAppendStreamArguments, 'channel' | 'ts'>,
-  ): Promise<ChatAppendStreamResponse> {
-    if (this.state !== 'in_progress') {
+    params: Omit<ChatAppendStreamArguments, 'channel' | 'ts'>,
+  ): Promise<ChatStartStreamResponse | ChatAppendStreamResponse | null> {
+    if (this.state === 'completed') {
       throw new Error(`failed to append stream: stream state is ${this.state}`);
     }
     if (params.token) {
       this.token = params.token;
     }
-    if (!this.channel) {
-      throw new Error('failed to append stream: channel not found');
+    this.buffer += params.markdown_text;
+    if (this.buffer.length >= this.options.buffer_size) {
+      return await this.flushBuffer(params);
     }
-    if (!this.streamTs) {
-      throw new Error('failed to append stream: ts not found');
-    }
-    const response = await this.client.chat.appendStream({
-      token: this.token,
-      channel: this.channel,
-      ts: this.streamTs,
-      ...params,
-    });
-    return response;
+    const details = {
+      bufferLength: this.buffer.length,
+      bufferSize: this.options.buffer_size,
+      channel: this.args.channel,
+      recipientTeamId: this.args.recipient_team_id,
+      recipientUserId: this.args.recipient_user_id,
+      threadTs: this.args.thread_ts,
+    };
+    this.logger.debug(`ChatStreamer appended to buffer: ${JSON.stringify(details)}`);
+    return null;
   }
 
   /**
@@ -140,7 +111,7 @@ export default class ChatStreamer {
    * @description The "stop" method stops the chat stream being used. This method can be called once to end the stream. Additional "blocks" and "metadata" can be provided.
    *
    * @example
-   * const streamer = await client.stream({
+   * const streamer = client.startStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
@@ -152,26 +123,58 @@ export default class ChatStreamer {
    * await streamer.stop();
    * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
    */
-  async stop(params?: ExcludeFromUnion<ChatStopStreamArguments, 'channel' | 'ts'>): Promise<ChatStopStreamResponse> {
-    if (this.state !== 'in_progress') {
+  async stop(params?: Omit<ChatStopStreamArguments, 'channel' | 'ts'>): Promise<ChatStopStreamResponse> {
+    if (this.state === 'completed') {
       throw new Error(`failed to stop stream: stream state is ${this.state}`);
     }
     if (params?.token) {
       this.token = params.token;
     }
-    if (!this.channel) {
-      throw new Error('failed to stop stream: channel not found');
-    }
     if (!this.streamTs) {
-      throw new Error('failed to stop stream: ts not found');
+      const response = await this.client.chat.startStream({
+        ...this.args,
+        token: this.token,
+      });
+      if (!response.ts) {
+        throw new Error('failed to stop stream: stream not started');
+      }
+      this.streamTs = response.ts;
+      this.state = 'in_progress';
     }
     const response = await this.client.chat.stopStream({
       token: this.token,
-      channel: this.channel,
+      channel: this.args.channel,
       ts: this.streamTs,
       ...params,
+      markdown_text: this.buffer + (params?.markdown_text ?? ''),
     });
     this.state = 'completed';
+    return response;
+  }
+
+  private async flushBuffer(
+    params: Omit<ChatStartStreamArguments | ChatAppendStreamArguments, 'channel' | 'ts'>,
+  ): Promise<ChatStartStreamResponse | ChatAppendStreamResponse> {
+    if (!this.streamTs) {
+      const response = await this.client.chat.startStream({
+        ...this.args,
+        token: this.token,
+        ...params,
+        markdown_text: this.buffer,
+      });
+      this.buffer = '';
+      this.streamTs = response.ts;
+      this.state = 'in_progress';
+      return response;
+    }
+    const response = await this.client.chat.appendStream({
+      token: this.token,
+      channel: this.args.channel,
+      ts: this.streamTs,
+      ...params,
+      markdown_text: this.buffer,
+    });
+    this.buffer = '';
     return response;
   }
 }

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -31,7 +31,7 @@ export class ChatStreamer {
   /**
    * Instantiate a new chat streamer.
    *
-   * @description The "constructor" method creates a unique {@link ChatStreamer} instance that keeps track of one chat stream. The stream must be started.
+   * @description The "constructor" method creates a unique {@link ChatStreamer} instance that keeps track of one chat stream.
    * @example
    * const client = new WebClient(process.env.SLACK_BOT_TOKEN);
    * const logger = new ConsoleLogger();
@@ -65,7 +65,7 @@ export class ChatStreamer {
    *
    * @description The "append" method appends to the chat stream being used. This method can be called multiple times. After the stream is stopped this method cannot be called.
    * @example
-   * const streamer = client.startStream({
+   * const streamer = client.chatStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",
@@ -111,7 +111,7 @@ export class ChatStreamer {
    * @description The "stop" method stops the chat stream being used. This method can be called once to end the stream. Additional "blocks" and "metadata" can be provided.
    *
    * @example
-   * const streamer = client.startStream({
+   * const streamer = client.chatStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -6,7 +6,7 @@ import type WebClient from './WebClient';
 export interface ChatStreamerOptions {
   /**
    * @description The length of markdown_text to buffer in-memory before calling a method. Increasing this value decreases the number of method calls made for the same amount of text, which is useful to avoid rate limits.
-   * @default 250
+   * @default 256
    */
   buffer_size?: number;
 }
@@ -41,7 +41,7 @@ export class ChatStreamer {
    *   recipient_team_id: "T0123456789",
    *   recipient_user_id: "U0123456789",
    * };
-   * const streamer = new ChatStreamer(client, logger, args, { buffer_size: 500 });
+   * const streamer = new ChatStreamer(client, logger, args, { buffer_size: 512 });
    * await streamer.append({
    *   markdown_text: "**hello world!**",
    * });
@@ -55,7 +55,7 @@ export class ChatStreamer {
     this.client = client;
     this.logger = logger;
     this.options = {
-      buffer_size: options.buffer_size ?? 250,
+      buffer_size: options.buffer_size ?? 256,
     };
     this.state = 'starting';
   }

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -81,17 +81,17 @@ export class ChatStreamer {
    * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
    */
   async append(
-    params: Omit<ChatAppendStreamArguments, 'channel' | 'ts'>,
+    args: Omit<ChatAppendStreamArguments, 'channel' | 'ts'>,
   ): Promise<ChatStartStreamResponse | ChatAppendStreamResponse | null> {
     if (this.state === 'completed') {
       throw new Error(`failed to append stream: stream state is ${this.state}`);
     }
-    if (params.token) {
-      this.token = params.token;
+    if (args.token) {
+      this.token = args.token;
     }
-    this.buffer += params.markdown_text;
+    this.buffer += args.markdown_text;
     if (this.buffer.length >= this.options.buffer_size) {
-      return await this.flushBuffer(params);
+      return await this.flushBuffer(args);
     }
     const details = {
       bufferLength: this.buffer.length,
@@ -123,12 +123,12 @@ export class ChatStreamer {
    * await streamer.stop();
    * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
    */
-  async stop(params?: Omit<ChatStopStreamArguments, 'channel' | 'ts'>): Promise<ChatStopStreamResponse> {
+  async stop(args?: Omit<ChatStopStreamArguments, 'channel' | 'ts'>): Promise<ChatStopStreamResponse> {
     if (this.state === 'completed') {
       throw new Error(`failed to stop stream: stream state is ${this.state}`);
     }
-    if (params?.token) {
-      this.token = params.token;
+    if (args?.token) {
+      this.token = args.token;
     }
     if (!this.streamTs) {
       const response = await this.client.chat.startStream({
@@ -145,21 +145,21 @@ export class ChatStreamer {
       token: this.token,
       channel: this.streamArgs.channel,
       ts: this.streamTs,
-      ...params,
-      markdown_text: this.buffer + (params?.markdown_text ?? ''),
+      ...args,
+      markdown_text: this.buffer + (args?.markdown_text ?? ''),
     });
     this.state = 'completed';
     return response;
   }
 
   private async flushBuffer(
-    params: Omit<ChatStartStreamArguments | ChatAppendStreamArguments, 'channel' | 'ts'>,
+    args: Omit<ChatStartStreamArguments | ChatAppendStreamArguments, 'channel' | 'ts'>,
   ): Promise<ChatStartStreamResponse | ChatAppendStreamResponse> {
     if (!this.streamTs) {
       const response = await this.client.chat.startStream({
         ...this.streamArgs,
         token: this.token,
-        ...params,
+        ...args,
         markdown_text: this.buffer,
       });
       this.buffer = '';
@@ -171,7 +171,7 @@ export class ChatStreamer {
       token: this.token,
       channel: this.streamArgs.channel,
       ts: this.streamTs,
-      ...params,
+      ...args,
       markdown_text: this.buffer,
     });
     this.buffer = '';

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -43,9 +43,9 @@ export default class ChatStreamer {
   /**
    * Start a new stream.
    *
-   * @description The "start" method starts a new chat stream unique to a {@link ChatStreamer} being used. This method can be called once. If the chat stream was created with the {@link WebClient#stream} method this method should not be called because the stream is started already.
+   * @description The "start" method starts a new chat stream unique to a {@link ChatStreamer} being used. This method can be called once. If the chat stream was created with the {@link WebClient#chatStream} method this method should not be called because the stream is started already.
    * @example
-   * const streamer = await client.stream({
+   * const streamer = await client.chatStream({
    *   channel: "C0123456789",
    *   thread_ts: "1700000001.123456",
    *   recipient_team_id: "T0123456789",

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -1,0 +1,177 @@
+import type { ExcludeFromUnion } from './types/helpers';
+import type { ChatAppendStreamArguments, ChatStartStreamArguments, ChatStopStreamArguments } from './types/request';
+import type { ChatAppendStreamResponse, ChatStartStreamResponse, ChatStopStreamResponse } from './types/response';
+import type WebClient from './WebClient';
+
+export default class ChatStreamer {
+  private channel: string | undefined;
+
+  private client: WebClient;
+
+  private state: 'starting' | 'in_progress' | 'completed';
+
+  private streamTs: string | undefined;
+
+  private token: string | undefined;
+
+  /**
+   * Instantiate a new chat streamer.
+   *
+   * @description The "constructor" method creates a unique {@link ChatStreamer} instance that keeps track of one chat stream. The stream must be started.
+   * @example
+   * const client = new WebClient(process.env.SLACK_BOT_TOKEN);
+   * const streamer = new ChatStreamer(client);
+   * const _response = await streamer.start({
+   *   channel: "C0123456789",
+   *   thread_ts: "1700000001.123456",
+   *   recipient_team_id: "T0123456789",
+   *   recipient_user_id: "U0123456789",
+   * });
+   * await streamer.append({
+   *   markdown_text: "**hello world!**",
+   * });
+   * await streamer.stop();
+   * @see {@link https://docs.slack.dev/reference/methods/chat.startStream}
+   * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
+   * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
+   */
+  constructor(client: WebClient) {
+    this.client = client;
+    this.state = 'starting';
+  }
+
+  /**
+   * Start a new stream.
+   *
+   * @description The "start" method starts a new chat stream unique to a {@link ChatStreamer} being used. This method can be called once. If the chat stream was created with the {@link WebClient#stream} method this method should not be called because the stream is started already.
+   * @example
+   * const streamer = await client.stream({
+   *   channel: "C0123456789",
+   *   thread_ts: "1700000001.123456",
+   *   recipient_team_id: "T0123456789",
+   *   recipient_user_id: "U0123456789",
+   * });
+   * await streamer.append({
+   *   markdown_text: "**hello world!**",
+   * });
+   * await streamer.stop();
+   * @example
+   * const client = new WebClient(process.env.SLACK_BOT_TOKEN);
+   * const streamer = new ChatStreamer(client);
+   * const _response = await streamer.start({
+   *   channel: "C0123456789",
+   *   thread_ts: "1700000001.123456",
+   *   recipient_team_id: "T0123456789",
+   *   recipient_user_id: "U0123456789",
+   * });
+   * await streamer.append({
+   *   markdown_text: "**hello world!**",
+   * });
+   * await streamer.stop();
+   * @see {@link https://docs.slack.dev/reference/methods/chat.startStream}
+   */
+  async start(params: ChatStartStreamArguments): Promise<ChatStartStreamResponse> {
+    if (this.state !== 'starting') {
+      throw new Error(`failed to start stream: stream state is ${this.state}`);
+    }
+    if (params.token) {
+      this.token = params.token;
+    }
+    const response = await this.client.chat.startStream({
+      token: this.token,
+      ...params,
+    });
+    if (!response.ts) {
+      throw new Error('failed to start stream: ' + response.error);
+    }
+    this.channel = params.channel;
+    this.state = 'in_progress';
+    this.streamTs = response.ts;
+    return response;
+  }
+
+  /**
+   * Append to a stream.
+   *
+   * @description The "append" method appends to the chat stream being used. This method can be called multiple times. After the stream is stopped this method cannot be called.
+   * @example
+   * const streamer = await client.stream({
+   *   channel: "C0123456789",
+   *   thread_ts: "1700000001.123456",
+   *   recipient_team_id: "T0123456789",
+   *   recipient_user_id: "U0123456789",
+   * });
+   * await streamer.append({
+   *   markdown_text: "**hello wo",
+   * });
+   * await streamer.append({
+   *   markdown_text: "rld!**",
+   * });
+   * await streamer.stop();
+   * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream}
+   */
+  async append(
+    params: ExcludeFromUnion<ChatAppendStreamArguments, 'channel' | 'ts'>,
+  ): Promise<ChatAppendStreamResponse> {
+    if (this.state !== 'in_progress') {
+      throw new Error(`failed to append stream: stream state is ${this.state}`);
+    }
+    if (params.token) {
+      this.token = params.token;
+    }
+    if (!this.channel) {
+      throw new Error('failed to append stream: channel not found');
+    }
+    if (!this.streamTs) {
+      throw new Error('failed to append stream: ts not found');
+    }
+    const response = await this.client.chat.appendStream({
+      token: this.token,
+      channel: this.channel,
+      ts: this.streamTs,
+      ...params,
+    });
+    return response;
+  }
+
+  /**
+   * Stop a stream.
+   *
+   * @description The "stop" method stops the chat stream being used. This method can be called once to end the stream. Additional "blocks" and "metadata" can be provided.
+   *
+   * @example
+   * const streamer = await client.stream({
+   *   channel: "C0123456789",
+   *   thread_ts: "1700000001.123456",
+   *   recipient_team_id: "T0123456789",
+   *   recipient_user_id: "U0123456789",
+   * });
+   * await streamer.append({
+   *   markdown_text: "**hello world!**",
+   * });
+   * await streamer.stop();
+   * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream}
+   */
+  async stop(params?: ExcludeFromUnion<ChatStopStreamArguments, 'channel' | 'ts'>): Promise<ChatStopStreamResponse> {
+    if (this.state !== 'in_progress') {
+      throw new Error(`failed to stop stream: stream state is ${this.state}`);
+    }
+    if (params?.token) {
+      this.token = params.token;
+    }
+    if (!this.channel) {
+      throw new Error('failed to stop stream: channel not found');
+    }
+    if (!this.streamTs) {
+      throw new Error('failed to stop stream: ts not found');
+    }
+    const response = await this.client.chat.stopStream({
+      token: this.token,
+      channel: this.channel,
+      ts: this.streamTs,
+      ...params,
+    });
+    this.state = 'completed';
+    return response;
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds a `WebClient#chatStream` method that creates chat streams 🤖

### Preview

```js
const streamer = client.chatStream({
  channel: "C0123456789",
  thread_ts: "1700000001.123456",
  recipient_team_id: "T0123456789",
  recipient_user_id: "U0123456789",
  buffer_size: 500,
});
await streamer.append({
  markdown_text: "**hello wo",
});
await streamer.append({
  markdown_text: "rld!**",
});
await streamer.stop();
```

### Testing

WIP-

### Notes

- Will save documentation generation for a later commit since the `diff` is significant at the moment I find.
- A default text buffer is used to avoid reaching rate limits in frequent updates.
- Super open to thoughts on the approach and implementation - does this seem like an alright change?
- Planning to follow up with tests after discussion to avoid extra changes too 👾 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
