### PR TITLE
docs(types): fix icon_button type in jsdoc description to be icon_button

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -212,7 +212,7 @@ export interface FileInput extends Actionable {
  */
 export interface IconButton extends Actionable, Confirmable {
   /**
-   * @description The type of element. In this case `type` is always `file_input`.
+   * @description The type of element. In this case `type` is always `icon_button`.
    */
   type: 'icon_button';
   /**


### PR DESCRIPTION
### Summary

happens to all of us 


### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
