### PR TITLE
ci: output verbose logs when installing package dependencies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm --version
-      - run: npm install
+      - run: npm install --verbose
         working-directory: packages/${{ matrix.package }}
       - name: Link dependent packages (*nix)
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
### Summary

This PR adds the `--verbose` flag when installing package dependencies in CI tests for improved debugging if needed 🐛 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
