### PR TITLE
refactor(web-api): align chat stream implementation with python sdk

### DIFF
--- a/packages/web-api/src/WebClient.spec.ts
+++ b/packages/web-api/src/WebClient.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import type { ContextActionsBlock } from '@slack/types';
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 import { assert, expect } from 'chai';
 import nock, { type ReplyHeaders } from 'nock';
@@ -1245,6 +1246,36 @@ describe('WebClient', () => {
     });
 
     it('streams a long message', async () => {
+      const contextActionsBlock: ContextActionsBlock = {
+        type: 'context_actions',
+        elements: [
+          {
+            type: 'feedback_buttons',
+            positive_button: {
+              text: {
+                type: 'plain_text',
+                text: 'good',
+              },
+              value: '+1',
+            },
+            negative_button: {
+              text: {
+                type: 'plain_text',
+                text: 'bad',
+              },
+              value: '-1',
+            },
+          },
+          {
+            type: 'icon_button',
+            icon: 'trash',
+            text: {
+              type: 'plain_text',
+              text: 'delete',
+            },
+          },
+        ],
+      };
       const scope = nock('https://slack.com')
         .post('/api/chat.startStream', {
           channel: 'C0123456789',
@@ -1267,6 +1298,7 @@ describe('WebClient', () => {
           ok: true,
         })
         .post('/api/chat.stopStream', {
+          blocks: JSON.stringify([contextActionsBlock]),
           channel: 'C0123456789',
           markdown_text: '**',
           token: 'xoxb-updated-2',
@@ -1296,6 +1328,7 @@ describe('WebClient', () => {
         markdown_text: '*',
       });
       await streamer.stop({
+        blocks: [contextActionsBlock],
         markdown_text: '*',
         token: 'xoxb-updated-2',
       });

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -61,7 +61,7 @@ export class ChatStreamer {
   }
 
   /**
-   * Append to a stream.
+   * Append to the stream.
    *
    * @description The "append" method appends to the chat stream being used. This method can be called multiple times. After the stream is stopped this method cannot be called.
    * @example
@@ -106,7 +106,7 @@ export class ChatStreamer {
   }
 
   /**
-   * Stop a stream.
+   * Stop the stream and finalize the message.
    *
    * @description The "stop" method stops the chat stream being used. This method can be called once to end the stream. Additional "blocks" and "metadata" can be provided.
    *
@@ -130,6 +130,9 @@ export class ChatStreamer {
     if (args?.token) {
       this.token = args.token;
     }
+    if (args?.markdown_text) {
+      this.buffer += args.markdown_text;
+    }
     if (!this.streamTs) {
       const response = await this.client.chat.startStream({
         ...this.streamArgs,
@@ -146,7 +149,7 @@ export class ChatStreamer {
       channel: this.streamArgs.channel,
       ts: this.streamTs,
       ...args,
-      markdown_text: this.buffer + (args?.markdown_text ?? ''),
+      markdown_text: this.buffer,
     });
     this.state = 'completed';
     return response;


### PR DESCRIPTION
### Summary

This PR refactors the `@slack/web-api` implementation of the chat stream helper to match implementation of https://github.com/slackapi/node-slack-sdk/pull/2379 for consistent maintenance.

### Reviewers

No changes to functionalities!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
