### PR TITLE
fix(web-api): remove unfurl arguments from chat.startStream method

### DIFF
--- a/packages/web-api/src/types/request/chat.ts
+++ b/packages/web-api/src/types/request/chat.ts
@@ -218,7 +218,7 @@ export type ChatScheduledMessagesListArguments = OptionalArgument<
     Partial<Channel>
 >;
 
-export interface ChatStartStreamArguments extends TokenOverridable, Channel, Partial<MarkdownText>, ThreadTS, Unfurls {
+export interface ChatStartStreamArguments extends TokenOverridable, Channel, Partial<MarkdownText>, ThreadTS {
   /**
    * @description The ID of the team that is associated with `recipient_user_id`.
    * This is required when starting a streaming conversation outside of a DM.

--- a/packages/web-api/test/types/methods/chat.test-d.ts
+++ b/packages/web-api/test/types/methods/chat.test-d.ts
@@ -617,17 +617,6 @@ expectAssignable<Parameters<typeof web.chat.startStream>>([
     channel: 'C1234',
     thread_ts: '1234.56',
     markdown_text: 'hello',
-    unfurl_links: true,
-    unfurl_media: false,
-  },
-]);
-expectAssignable<Parameters<typeof web.chat.startStream>>([
-  {
-    channel: 'C1234',
-    thread_ts: '1234.56',
-    markdown_text: 'hello',
-    unfurl_links: true,
-    unfurl_media: false,
     recipient_team_id: 'T1234',
     recipient_user_id: 'U1234',
   },


### PR DESCRIPTION
### Summary

This PR removes `unfurl_links` and `unfurl_media` arguments from the "chat.startStream" method to align with the backend.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
