### PR TITLE
build(web-api): bump to minimum @slack/types@2.17.0

### DIFF
--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@slack/logger": "^4.0.0",
-    "@slack/types": "2.16.0-aiAppsBeta.3",
+    "@slack/types": "^2.17.0",
     "@types/node": ">=18.0.0",
     "@types/retry": "0.12.0",
     "axios": "^1.11.0",


### PR DESCRIPTION
### Summary

This PR follows up on findings from @mwbrooks around beta releases in testing from https://github.com/slackapi/node-slack-sdk/pull/2399#discussion_r2408989630 to use the now released `@slack/types@2.17.0` package.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
