### PR TITLE
Add TypeScript types entry to package.json

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -12,6 +12,7 @@
     "api"
   ],
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*"
   ],


### PR DESCRIPTION
### Summary

This fixes type support in TypeScript in ESM mode

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
