### PR TITLE
fix[cli-test]: update buffer type in tests

### DIFF
--- a/packages/cli-test/src/cli/shell.spec.ts
+++ b/packages/cli-test/src/cli/shell.spec.ts
@@ -12,7 +12,7 @@ describe('shell module', () => {
   let spawnSpy: sinon.SinonStub;
   let spawnProcess: child.ChildProcessWithoutNullStreams;
   let runSpy: sinon.SinonStub;
-  let runOutput: child.SpawnSyncReturns<Buffer>;
+  let runOutput: child.SpawnSyncReturns<Buffer<ArrayBuffer>>;
 
   beforeEach(() => {
     spawnProcess = mockProcess();

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -105,7 +105,6 @@ export const shell = {
    */
   checkIfFinished: async function checkIfFinished(proc: ShellProcess): Promise<void> {
     return new Promise((resolve, reject) => {
-      // biome-ignore lint/style/useConst: closing over timeout variable
       let timeout: NodeJS.Timeout;
 
       const killIt = (reason: string) => {


### PR DESCRIPTION
### Summary

These changes update expected `child.SpawnSync` return type to fix types issues that it blocking CI

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
