### PR TITLE
docs(web-api): note the chat stream buffer size default

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -515,6 +515,8 @@ export class WebClient extends Methods {
    *
    * @description The "chatStream" method starts a new chat stream in a conversation that can be appended to. After appending an entire message, the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
    *
+   * The "markdown_text" content is appended to a buffer before being sent to the recipient, with a default buffer size of "256" characters. Setting the "buffer_size" value to a smaller number sends more frequent updates for the same amount of characters, but might reach rate limits more often.
+   *
    * @example
    * const streamer = client.chatStream({
    *   channel: "C0123456789",


### PR DESCRIPTION
### Summary

This PR follows https://github.com/slackapi/bolt-js/issues/2696 to note the [`WebClient#chatStream`](https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/classes/WebClient/#chatstream) default buffer size.

### Note

- Planning to mirror this change to the Python SDK if the wording is alright! 🐍 
- Was unsure if this should be included in a different example? I left this unchanged for now 📚 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
