### PR TITLE
ci: upload test results using the recommended codecov action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,7 +95,7 @@ jobs:
           directory: packages/${{ matrix.package }}/coverage
           fail_ci_if_error: true
           flags: ${{ matrix.package }}
-          report-type: coverage
+          report_type: coverage
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Upload test results to Codecov
@@ -105,6 +105,6 @@ jobs:
           fail_ci_if_error: true
           file: packages/${{ matrix.package }}/coverage/test-results.xml
           flags: ${{ matrix.node-version }},${{ matrix.os }},${{ matrix.package }}
-          report-type: test_results
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
### Summary

This PR uses the recommended [`codecov/codecov-action`](https://github.com/codecov/codecov-action) to both upload test coverage and test  results 🧪 ✨ 

From the pages of the [`codecov/test-results-action`](https://github.com/codecov/test-results-action) action:

> **⚠️ Deprecation Warning ⚠️**
>
> This Action causes issues for users uploading test analytics to Codecov

🔗 https://github.com/codecov/test-results-action?tab=readme-ov-file#%EF%B8%8F-deprecation-warning-%EF%B8%8F

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
