### PR TITLE
docs: link to streaming methods and context actions block reference

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -144,10 +144,12 @@ export interface EmailInput extends Actionable, Dispatchable, Focusable, Placeho
 export interface FeedbackButtons extends Actionable {
   /**
    * @description The type of block. For a feedback buttons block, `type` is always `feedback_buttons`.
+   * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/feedback-buttons-element Feedback buttons element reference}.
    */
   type: 'feedback_buttons';
   /**
    * @description A button to indicate positive feedback.
+   * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/feedback-buttons-element/#button-object-fields Feedback buttons object fields reference}.
    */
   positive_button: {
     /**
@@ -166,6 +168,7 @@ export interface FeedbackButtons extends Actionable {
   };
   /**
    * @description A button to indicate negative feedback.
+   * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/feedback-buttons-element/#button-object-fields Feedback buttons object fields reference}.
    */
   negative_button: {
     /**
@@ -209,6 +212,7 @@ export interface FileInput extends Actionable {
 
 /**
  * @description An icon button to perform actions.
+ * @see {@link https://docs.slack.dev/reference/block-kit/block-elements/icon-button-element Icon button element reference}.
  */
 export interface IconButton extends Actionable, Confirmable {
   /**

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -127,6 +127,7 @@ export type ContextActionsBlockElement = FeedbackButtons | IconButton;
 
 /**
  * @description Displays actions as contextual info, which can include both feedback buttons and icon buttons.
+ * @see {@link https://docs.slack.dev/reference/block-kit/blocks/context-actions-block Context actions block reference}.
  */
 export interface ContextActionsBlock extends Block {
   /**

--- a/packages/web-api/src/methods.ts
+++ b/packages/web-api/src/methods.ts
@@ -1571,6 +1571,7 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
   public readonly chat = {
     /**
      * @description Appends text to an existing streaming conversation.
+     * @see {@link https://docs.slack.dev/reference/methods/chat.appendStream `chat.appendStream` API reference}.
      */
     appendStream: bindApiCall<ChatAppendStreamArguments, ChatAppendStreamResponse>(this, 'chat.appendStream'),
     /**
@@ -1626,10 +1627,12 @@ export abstract class Methods extends EventEmitter<WebClientEvent> {
     },
     /**
      * @description Starts a new streaming conversation.
+     * @see {@link https://docs.slack.dev/reference/methods/chat.startStream `chat.startStream` API reference}.
      */
     startStream: bindApiCall<ChatStartStreamArguments, ChatStartStreamResponse>(this, 'chat.startStream'),
     /**
      * @description Stops a streaming conversation.
+     * @see {@link https://docs.slack.dev/reference/methods/chat.stopStream `chat.stopStream` API reference}.
      */
     stopStream: bindApiCall<ChatStopStreamArguments, ChatStopStreamResponse>(this, 'chat.stopStream'),
     /**


### PR DESCRIPTION
### Summary

This PR adds reference links to various blocks and methods following #2370 🤖 

- `chat.appendStream`
- `chat.startStream`
- `chat.stopStream`
- Context actions block
- Feedback buttons element
- Icon button element

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
