### PR TITLE
docs(types): remove note of maximum length for raw_text

### DIFF
--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -183,7 +183,7 @@ export interface RawTextElement {
    */
   type: 'raw_text';
   /**
-   * @description The text for the block. The minimum length is 1.
+   * @description The text for the block. The minimum length is 1 character.
    */
   text: string;
 }


### PR DESCRIPTION
### Summary

This PR removes the note of a maximum length for `raw_text` from the table block cell.

### Notes

When testing https://github.com/slackapi/python-slack-sdk/pull/1788 it was noticed that 3000+ characters can be contained in a cell, and reference otherwise doesn't indicate a limit:

📚 https://docs.slack.dev/reference/block-kit/blocks/table-block/

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
