### PR TITLE
docs: fixes broken links in docs sidebar

### DIFF
--- a/docs/english/_sidebar.json
+++ b/docs/english/_sidebar.json
@@ -54,16 +54,16 @@
   {
     "type": "link",
     "label": "Release notes",
-    "href": "https://github.com/SlackAPI/node-slack-sdk/releases"
+    "href": "https://github.com/slackapi/node-slack-sdk/releases"
   },
   {
     "type": "link",
     "label": "Code on GitHub",
-    "href": "https://github.com/SlackAPI/node-slack-sdk"
+    "href": "https://github.com/slackapi/node-slack-sdk"
   },
   {
     "type": "link",
     "label": "Contributors Guide",
-    "href": "https://github.com/SlackAPI/node-slack-sdk/blob/main/.github/contributing.md"
+    "href": "https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md"
   }
 ]


### PR DESCRIPTION
### Summary

An overzealous find and replace led to some broken links

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
