### PR TITLE
feat(types): add huddle_state_call_id to UserHuddleChangedEvent

### DIFF
--- a/packages/types/src/events/user.ts
+++ b/packages/types/src/events/user.ts
@@ -109,6 +109,7 @@ export interface UserHuddleChangedEvent {
       status_expiration: number;
       avatar_hash: string;
       huddle_state: string;
+      huddle_state_call_id?: string;
       huddle_state_expiration_ts: number;
       first_name: string;
       last_name: string;


### PR DESCRIPTION
### Summary

Resolves #2427 by adding missing `huddle_state_call_id`. See [payload in docs](https://docs.slack.dev/reference/events/user_huddle_changed/#example) for verification of this property's existence.

Per original issue:

> You will receive a payload typed as UserHuddleChangedEvent. If payload.user.profile.huddle_state has the value in_a_huddle, then the payload you will receive contains payload.user.profile.huddle_state_call_id, which is not listed within the type UserHuddleChangedEvent.

Technically this property only appears as a conditional state based upon another property, but as we're not getting that granular with any other optional property, just leaving it as a simple optional here.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
