### PR TITLE
Add enterprise to MemberJoinedChannelEvent

### DIFF
--- a/packages/types/src/events/member.ts
+++ b/packages/types/src/events/member.ts
@@ -5,6 +5,7 @@ export interface MemberJoinedChannelEvent {
   channel_type: string;
   team: string;
   inviter?: string;
+  enterprise?: string;
   event_ts: string;
 }
 


### PR DESCRIPTION
### Summary

Add missing `enterprise` prop to `MemberJoinedChannelEvent`. [See documentation](https://docs.slack.dev/reference/events/member_joined_channel/) to verify presence.

Resolves #2139.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
