### PR TITLE
feat(web-api): export the chat streamer and related options from the package

### DIFF
--- a/packages/web-api/src/index.ts
+++ b/packages/web-api/src/index.ts
@@ -19,6 +19,8 @@ export { default as retryPolicies, RetryOptions } from './retry-policies';
 export * from './types/request/index';
 export * from './types/response/index';
 
+export { ChatStreamer, ChatStreamerOptions } from './chat-stream';
+
 export {
   PageAccumulator,
   PageReducer,


### PR DESCRIPTION
### Summary

This PR exports the `ChatStreamer` and `ChatStreamerOptions` from `@slack/web-api` for importing elsewhere with type safety 🎁 

### Preview

```js
 /**
 * @param {import("@slack/web-api").ChatStreamer} streamer - Slack chat stream
 */
```

Fixes issues with `jsdoc` noted in sample app changes: https://github.com/slack-samples/bolt-js-assistant-template/pull/98/files#diff-a45b5e2e63df5007d9680c1776b0381dc48bcad3fbd9d443ac19e6dd077c386aR12 🤖 

### Notes

I considered adding the "chat-stream" file to known exports for the following result too, but don't feel so confident in this approach:

```js
 /**
 * @param {import("@slack/web-api/chat-stream").ChatStreamer} streamer - Slack chat stream
 */
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
