### PR TITLE
docs: polishing source wording

### DIFF
--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -703,7 +703,7 @@ export interface URLInput extends Actionable, Dispatchable, Focusable, Placehold
 }
 
 /**
- *  @description A URL source element to reference in a task card block.
+ *  @description A URL source element that displays a URL source for referencing within a task card block.
  *  @see {@link https://docs.slack.dev/reference/block-kit/block-elements/url-source-element}
  */
 

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -411,7 +411,7 @@ interface TableBlockColumnSettings {
  */
 export interface TaskCardBlock extends Block {
   /**
-   * @description The type of element. In this case `type` is always `task_card`.
+   * @description The type of block. For this block, type will always be `task_card`.
    */
   type: 'task_card';
 
@@ -436,12 +436,12 @@ export interface TaskCardBlock extends Block {
   output?: RichTextBlock;
 
   /**
-   * @description List of sources used to generate a response.
+   * @description Array of URL source elements used to generate a response.
    */
   sources?: URLSourceElement[];
 
   /**
-   * @description The state of a task. Either "pending" or "in_progress" or "complete" or "error".
+   * @description The state of a task. Can be "pending", "in_progress", "complete", or "error".
    */
   status: 'pending' | 'in_progress' | 'complete' | 'error';
 }
@@ -462,7 +462,7 @@ export interface PlanBlock extends Block {
   title: string;
 
   /**
-   * @description An array of tasks associated with this plan.
+   * @description A sequence of task card blocks. Each task represents a single action within the plan.
    */
   tasks?: (TaskCardBlock | Record<string, unknown>)[];
 }

--- a/packages/types/src/chunk.ts
+++ b/packages/types/src/chunk.ts
@@ -17,7 +17,7 @@ export interface MarkdownTextChunk extends Chunk {
 }
 
 /**
- * An updated title of plans for task and tool calls.
+ * Used for displaying an updated title of a plan.
  * https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming
  */
 export interface PlanUpdateChunk extends Chunk {
@@ -26,7 +26,7 @@ export interface PlanUpdateChunk extends Chunk {
 }
 
 /**
- * Used for displaying tool execution progress in a timeline-style UI.
+ * Used for displaying task progress in a timeline-style UI.
  * https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming
  */
 export interface TaskUpdateChunk extends Chunk {

--- a/packages/web-api/src/types/request/chat.ts
+++ b/packages/web-api/src/types/request/chat.ts
@@ -257,7 +257,7 @@ export interface ChatStartStreamArguments extends TokenOverridable, Channel, Par
   recipient_user_id?: string;
   /**
    *  @description Specifies how tasks are displayed in the message. A "timeline" displays individual tasks
-   * interleaved with text and "plan" displays all tasks together.
+   *  with text and "plan" displays all tasks together.
    */
   task_display_mode?: string;
 }
@@ -267,7 +267,7 @@ export type ChatStopStreamArguments = TokenOverridable &
   Partial<MarkdownText> &
   Partial<Metadata> & {
     /**
-     * @description An array of {@link https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming chunk objects} to finalize the stream with.
+     * @description An array of {@link https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming chunk objects} to finish the stream with.
      */
     chunks?: AnyChunk[];
     /**


### PR DESCRIPTION
### Summary

Makes it so it all matches the api docs

TODO: update generated reference docs. workspaces update changes some slugs (now full paths, not just subpackage paths), so need to decide if we're okay with all those slug changes appearing here

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
