### PR TITLE
ci: include workflow write permission for changelog steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,10 @@ jobs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
+      id-token: write
+      issues: read
+      packages: write
       pull-requests: write
-      workflows: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Summary

This PR fixes an issue with workflow permissions create a new changeset:

```
/usr/bin/git push origin HEAD:changeset-release/main --force
To https://github.com/slackapi/node-slack-sdk
 ! [remote rejected]   HEAD -> changeset-release/main (refusing to allow a GitHub App to create or update workflow `.github/workflows/release.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/slackapi/node-slack-sdk'
```

🔗 https://github.com/slackapi/node-slack-sdk/actions/runs/21659570314/job/62442776234#step:5:39

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
