### PR TITLE
chore: comment instructional text in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements <!-- Place an `x` in each `[ ]` -->
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
+- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
+- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


### PR DESCRIPTION
### Summary

This PR converts the instructional parenthetical text in the PR template Requirements heading to an HTML comment so it doesn't render visibly.

### Requirements <!-- Place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).