### PR TITLE
fix(types): narrow tag_color to supported color literals

### DIFF
--- a/packages/types/src/message-metadata.ts
+++ b/packages/types/src/message-metadata.ts
@@ -201,7 +201,7 @@ export interface EntityTypedField {
   slack_file?: SlackFile;
   alt_text?: string;
   edit?: EntityEditSupport;
-  tag_color?: string;
+  tag_color?: 'red' | 'yellow' | 'green' | 'gray' | 'blue';
   user?: EntityUserIDField | EntityUserField;
   entity_ref?: EntityRefField;
 }
@@ -214,7 +214,7 @@ export interface EntityStringField {
   icon?: EntityIconField;
   long?: boolean;
   type?: string;
-  tag_color?: string;
+  tag_color?: 'red' | 'yellow' | 'green' | 'gray' | 'blue';
   edit?: EntityEditSupport;
 }
 
@@ -279,7 +279,7 @@ export interface EntityCustomField {
   image_url?: string;
   slack_file?: SlackFile;
   alt_text?: string;
-  tag_color?: string;
+  tag_color?: 'red' | 'yellow' | 'green' | 'gray' | 'blue';
   edit?: EntityEditSupport;
   item_type?: string;
   user?: EntityUserIDField | EntityUserField;


### PR DESCRIPTION
## Summary

- Narrow `tag_color` type from `string` to `'red' | 'yellow' | 'green' | 'gray' | 'blue'` in `EntityTypedField`, `EntityStringField`, and `EntityCustomField`
- Per [Slack docs](https://docs.slack.dev/messaging/work-objects/#supported-properties-for-a-field): can only be set when the type is `string`, allows the string to be highlighted in one of the supported colors

<img width="1043" height="748" alt="image" src="https://github.com/user-attachments/assets/8fa041ef-ad08-4703-b7a2-bd8ed8b65d8e" />

