### PR TITLE
fix: user-agent should be uri safe

### DIFF
--- a/.changeset/safe-user-agent.md
+++ b/.changeset/safe-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@slack/web-api": patch
+---
+
+Fix user-agent header to URI-encode characters outside the Latin-1 range, preventing errors when `process.title` contains non-ASCII characters

--- a/packages/web-api/src/instrument.test.ts
+++ b/packages/web-api/src/instrument.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { afterEach, describe, it } from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+function isLatin1Safe(s: string): boolean {
+  return Buffer.from(s, 'latin1').toString('latin1') === s;
+}
+
+describe('instrument', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'title');
+  const modulePath = require.resolve('./instrument.ts');
+
+  afterEach(() => {
+    // Restore the original process.title property
+    if (originalDescriptor) {
+      Object.defineProperty(process, 'title', originalDescriptor);
+    }
+    // Clear module cache so next require gets a fresh evaluation
+    delete require.cache[modulePath];
+  });
+
+  function mockProcessTitle(title: string): void {
+    Object.defineProperty(process, 'title', {
+      get: () => title,
+      configurable: true,
+    });
+  }
+
+  /**
+   * Returns a fresh import of the instrument module. Since `baseUserAgent` is computed at module
+   * load time, we clear the require cache and re-require to pick up a mocked `process.title`.
+   */
+  function freshImport(): typeof import('./instrument') {
+    delete require.cache[modulePath];
+    return require(modulePath);
+  }
+
+  describe('getUserAgent', () => {
+    it('should contain the package name', () => {
+      const { getUserAgent } = freshImport();
+      const ua = getUserAgent();
+      assert.ok(ua.includes('@slack:web-api'), `User-Agent should contain @slack:web-api: ${ua}`);
+    });
+
+    it('should include an ASCII process.title in the user agent', () => {
+      mockProcessTitle('node');
+      const { getUserAgent } = freshImport();
+      const ua = getUserAgent();
+      assert.ok(ua.includes('node/'), `User-Agent should contain node/: ${ua}`);
+      assert.ok(isLatin1Safe(ua));
+    });
+
+    it('should include other ASCII process.title in the user agent', () => {
+      mockProcessTitle('openclaw-gateway');
+      const { getUserAgent } = freshImport();
+      const ua = getUserAgent();
+      assert.ok(ua.includes('openclaw-gateway/'), `User-Agent should contain openclaw-gateway/: ${ua}`);
+      assert.ok(isLatin1Safe(ua));
+    });
+
+    it('should return a Latin-1 safe user agent when process.title contains non-ASCII characters', () => {
+      const notLatin1SafeTitle = '管理者'
+      assert.strictEqual(isLatin1Safe(notLatin1SafeTitle), false);
+
+      mockProcessTitle(notLatin1SafeTitle);
+      const { getUserAgent } = freshImport();
+      const ua = getUserAgent();
+      assert.ok(isLatin1Safe(ua), `User-Agent contains non-Latin-1 characters: ${ua}`);
+      assert.ok(!ua.includes(notLatin1SafeTitle), 'User-Agent should not contain raw non-ASCII characters');
+    });
+  });
+});

--- a/packages/web-api/src/instrument.test.ts
+++ b/packages/web-api/src/instrument.test.ts
@@ -61,7 +61,7 @@ describe('instrument', () => {
     });
 
     it('should return a Latin-1 safe user agent when process.title contains non-Latin-1 characters', () => {
-      const notLatin1SafeTitle = '管理者: Windows PowerShell'
+      const notLatin1SafeTitle = '管理者: Windows PowerShell';
       assert.strictEqual(isLatin1Safe(notLatin1SafeTitle), false);
 
       mockProcessTitle(notLatin1SafeTitle);
@@ -69,7 +69,10 @@ describe('instrument', () => {
       const ua = getUserAgent();
       assert.ok(isLatin1Safe(ua), `User-Agent contains non-Latin-1 characters: ${ua}`);
       assert.ok(!ua.includes(notLatin1SafeTitle), 'User-Agent should not contain raw non-ASCII characters');
-      assert.ok(ua.includes('%E7%AE%A1%E7%90%86%E8%80%85: Windows PowerShell'), 'User-Agent should percent-encode only non-Latin-1 characters');
+      assert.ok(
+        ua.includes('%E7%AE%A1%E7%90%86%E8%80%85: Windows PowerShell'),
+        'User-Agent should percent-encode only non-Latin-1 characters',
+      );
     });
 
     it('should preserve Latin-1 characters in process.title', () => {

--- a/packages/web-api/src/instrument.test.ts
+++ b/packages/web-api/src/instrument.test.ts
@@ -60,8 +60,8 @@ describe('instrument', () => {
       assert.ok(isLatin1Safe(ua));
     });
 
-    it('should return a Latin-1 safe user agent when process.title contains non-ASCII characters', () => {
-      const notLatin1SafeTitle = '管理者'
+    it('should return a Latin-1 safe user agent when process.title contains non-Latin-1 characters', () => {
+      const notLatin1SafeTitle = '管理者: Windows PowerShell'
       assert.strictEqual(isLatin1Safe(notLatin1SafeTitle), false);
 
       mockProcessTitle(notLatin1SafeTitle);
@@ -69,6 +69,15 @@ describe('instrument', () => {
       const ua = getUserAgent();
       assert.ok(isLatin1Safe(ua), `User-Agent contains non-Latin-1 characters: ${ua}`);
       assert.ok(!ua.includes(notLatin1SafeTitle), 'User-Agent should not contain raw non-ASCII characters');
+      assert.ok(ua.includes('%E7%AE%A1%E7%90%86%E8%80%85: Windows PowerShell'), 'User-Agent should percent-encode only non-Latin-1 characters');
+    });
+
+    it('should preserve Latin-1 characters in process.title', () => {
+      mockProcessTitle('café');
+      const { getUserAgent } = freshImport();
+      const ua = getUserAgent();
+      assert.ok(ua.includes('café/'), `User-Agent should preserve Latin-1 characters: ${ua}`);
+      assert.ok(isLatin1Safe(ua));
     });
   });
 });

--- a/packages/web-api/src/instrument.ts
+++ b/packages/web-api/src/instrument.ts
@@ -10,6 +10,20 @@ function replaceSlashes(s: string): string {
   return s.replace('/', ':');
 }
 
+const MAX_LATIN1_CODE = 0xFF;
+
+/**
+ * Ensures a string is safe for use in HTTP headers by URI-encoding characters outside the Latin-1 (ISO-8859-1) range.
+ * Latin-1 characters (code points 0x00–0xFF) are preserved as-is; all others are percent-encoded via encodeURIComponent.
+ */
+function toLatin1Safe(s: string): string {
+  let result = '';
+  for (const char of s) {
+    result += char.charCodeAt(0) <= MAX_LATIN1_CODE ? char : encodeURIComponent(char);
+  }
+  return result;
+}
+
 // TODO: for the deno build (see the `npm run build:deno` npm run script), we could replace the `os-browserify` npm
 // module shim with our own shim leveraging the deno beta compatibility layer for node's `os` module (for more info
 // see https://deno.land/std@0.116.0/node/os.ts). At the time of writing this TODO (2021/11/25), this required deno
@@ -18,7 +32,7 @@ function replaceSlashes(s: string): string {
 // based code will report "browser/undefined" from a deno runtime.
 const baseUserAgent =
   `${replaceSlashes(packageJson.name)}/${packageJson.version} ` +
-  `${encodeURI(basename(process.title))}/${process.version.replace('v', '')} ` +
+  `${toLatin1Safe(basename(process.title))}/${process.version.replace('v', '')} ` +
   `${os.platform()}/${os.release()}`;
 
 const appMetadata: { [key: string]: string } = {};

--- a/packages/web-api/src/instrument.ts
+++ b/packages/web-api/src/instrument.ts
@@ -18,7 +18,7 @@ function replaceSlashes(s: string): string {
 // based code will report "browser/undefined" from a deno runtime.
 const baseUserAgent =
   `${replaceSlashes(packageJson.name)}/${packageJson.version} ` +
-  `${basename(process.title)}/${process.version.replace('v', '')} ` +
+  `${encodeURI(basename(process.title))}/${process.version.replace('v', '')} ` +
   `${os.platform()}/${os.release()}`;
 
 const appMetadata: { [key: string]: string } = {};

--- a/packages/web-api/src/instrument.ts
+++ b/packages/web-api/src/instrument.ts
@@ -10,7 +10,7 @@ function replaceSlashes(s: string): string {
   return s.replace('/', ':');
 }
 
-const MAX_LATIN1_CODE = 0xFF;
+const MAX_LATIN1_CODE = 0xff;
 
 /**
  * Ensures a string is safe for use in HTTP headers by URI-encoding characters outside the Latin-1 (ISO-8859-1) range.


### PR DESCRIPTION
### Summary

This PR aims to fix #2544

The `user agent` created by the project could include unsafe characters from `process.title`, these changes `url encode` any characters that are not Latin-1 (ISO-8859-1)

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
