### PR TITLE
refactor(cli-hooks): use optional chaining check to gather project dependencies

### DIFF
--- a/.changeset/eleven-apples-retire.md
+++ b/.changeset/eleven-apples-retire.md
@@ -1,0 +1,5 @@
+---
+"@slack/cli-hooks": patch
+---
+
+refactor(cli-hooks): use optional chaining check to gather project dependencies

--- a/packages/cli-hooks/src/check-update.js
+++ b/packages/cli-hooks/src/check-update.js
@@ -191,7 +191,7 @@ async function collectVersionInfo(packageName) {
 async function getProjectPackageVersion(packageName) {
   const stdout = await execWrapper(`npm list ${packageName} --depth=0 --json`);
   const currentVersionOutput = JSON.parse(stdout);
-  if (!currentVersionOutput.dependencies || !currentVersionOutput.dependencies[packageName]) {
+  if (!currentVersionOutput.dependencies?.[packageName]) {
     throw new Error(`Failed to gather project information about ${packageName}`);
   }
   return currentVersionOutput.dependencies[packageName].version;


### PR DESCRIPTION
## Summary

This PR applies Biome lint fixes to normalize code style across the monorepo and improve code readability.

## Changes

* **style**: Normalize line endings from CRLF to LF across 634 files
* **refactor(cli-hooks)**: Simplify optional chaining check in `getProjectPackageVersion()`

## Files Modified

* [`packages/cli-hooks/src/check-update.js`](https://github.com/slackapi/node-slack-sdk/blob/main/packages/cli-hooks/src/check-update.js) — applied optional chaining syntax
* Multiple packages (line ending normalization):

  * [`packages/web-api`](https://github.com/slackapi/node-slack-sdk/tree/main/packages/web-api)
  * [`packages/webhook`](https://github.com/slackapi/node-slack-sdk/tree/main/packages/webhook)
  * [`packages/types`](https://github.com/slackapi/node-slack-sdk/tree/main/packages/types)
  * [`packages/oauth`](https://github.com/slackapi/node-slack-sdk/tree/main/packages/oauth)
  * [`packages/socket-mode`](https://github.com/slackapi/node-slack-sdk/tree/main/packages/socket-mode)
  * and other packages across the monorepo

## Details

### Line Endings Normalization

Configured Biome formatter (`lineEnding: "lf"`) to enforce consistent Unix-style line endings across all files.
This improves cross-platform compatibility and avoids unnecessary diffs between environments.

### Optional Chaining Refactor

Simplified conditional check using optional chaining:

```javascript
// Before
if (!currentVersionOutput.dependencies || !currentVersionOutput.dependencies[packageName])

// After  
if (!currentVersionOutput.dependencies?.[packageName])
```

## Impact

* No functional changes
* Improves code consistency and readability
* Reduces noise in future diffs

## Testing

* No runtime logic changes
* Existing tests should pass without modification

## Notes

* Large diff due to line ending normalization
* Recommended to review commit-by-commit or ignore whitespace changes