### PR TITLE
build(deps): bump minimum axios version to 1.15.0

### DIFF
--- a/.changeset/hip-socks-fetch.md
+++ b/.changeset/hip-socks-fetch.md
@@ -1,0 +1,6 @@
+---
+"@slack/web-api": patch
+"@slack/webhook": patch
+---
+
+build(deps): bump minimum axios version to 1.15.0

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -53,7 +53,7 @@
     "@slack/types": "^2.20.1",
     "@types/node": ">=18",
     "@types/retry": "0.12.0",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "eventemitter3": "^5.0.1",
     "form-data": "^4.0.4",
     "is-electron": "2.2.2",

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@slack/types": "^2.20.1",
     "@types/node": ">=18",
-    "axios": "^1.13.5"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "nock": "^14.0.6"


### PR DESCRIPTION
### Summary

This PR bumps the minimum `axios` version to 1.15.0 to close https://github.com/slackapi/node-slack-sdk/issues/2549 🔏 

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
