### PR TITLE
refactor(cli-test)!: move 'create' to 'project create'

### DIFF
--- a/.changeset/four-ads-hide.md
+++ b/.changeset/four-ads-hide.md
@@ -1,0 +1,17 @@
+---
+"@slack/cli-test": major
+---
+
+refactor(cli-test)!: move 'create' to 'project create'
+
+Before the Slack CLI v4.0.0 release, the `create` command became a `project` subcommand while remaining aliased the same. This project now prefers:
+
+```js
+const createOutput = await SlackCLI.project.create({
+  template: "slack-samples/bolt-js-starter-template",
+  appPath,
+  verbose: true,
+});
+```
+
+But continues to run the `slack create` command for confidence in getting started guides.

--- a/packages/cli-test/src/cli/commands/project.test.ts
+++ b/packages/cli-test/src/cli/commands/project.test.ts
@@ -4,9 +4,9 @@ import sinon from 'sinon';
 
 import { mockProcess } from '../../utils/test';
 import { shell } from '../shell';
-import { create } from './create';
+import project from './project';
 
-describe('create', () => {
+describe('project', () => {
   const sandbox = sinon.createSandbox();
   let spawnSpy: sinon.SinonStub;
 
@@ -24,13 +24,13 @@ describe('create', () => {
     sandbox.restore();
   });
 
-  describe('method', () => {
+  describe('create', () => {
     it('should invoke `create <appPath>`', async () => {
-      await create({ appPath: 'myApp' });
+      await project.create({ appPath: 'myApp' });
       sandbox.assert.calledWith(spawnSpy, sinon.match.string, sinon.match.array.contains(['create', 'myApp']));
     });
     it('should invoke `create <appPath> --template` if template specified', async () => {
-      await create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world' });
+      await project.create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world' });
       sandbox.assert.calledWith(
         spawnSpy,
         sinon.match.string,
@@ -38,7 +38,7 @@ describe('create', () => {
       );
     });
     it('should invoke `create <appPath> --template --branch` if both template and branch specified', async () => {
-      await create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world', branch: 'feat-functions' });
+      await project.create({ appPath: 'myApp', template: 'slack-samples/deno-hello-world', branch: 'feat-functions' });
       sandbox.assert.calledWith(
         spawnSpy,
         sinon.match.string,

--- a/packages/cli-test/src/cli/commands/project.ts
+++ b/packages/cli-test/src/cli/commands/project.ts
@@ -5,7 +5,7 @@ import { type SlackCLICommandOptions, SlackCLIProcess } from '../cli-process';
  * `slack create`
  * @returns command output
  */
-export const create = async function create(
+export const create = async function projectCreate(
   args: ProjectCommandArguments & {
     /** @description URL to an app template to use when creating app. */
     template?: string;
@@ -25,4 +25,6 @@ export const create = async function create(
   return proc.output;
 };
 
-export default create;
+export default {
+  create,
+};

--- a/packages/cli-test/src/cli/index.ts
+++ b/packages/cli-test/src/cli/index.ts
@@ -6,13 +6,13 @@ import logger from '../utils/logger';
 import app from './commands/app';
 import auth from './commands/auth';
 import collaborator from './commands/collaborator';
-import { create } from './commands/create';
 import datastore from './commands/datastore';
 import env from './commands/env';
 import externalAuth from './commands/external-auth';
 import func from './commands/function';
 import manifest from './commands/manifest';
 import platform from './commands/platform';
+import project from './commands/project';
 import trigger from './commands/trigger';
 import version from './commands/version';
 
@@ -23,13 +23,13 @@ export const SlackCLI = {
   app,
   auth,
   collaborator,
-  create,
   datastore,
   env,
   externalAuth,
   function: func,
   manifest,
   platform,
+  project,
   trigger,
   version,
 


### PR DESCRIPTION
## Summary
- Moves the `create` command under a `project` namespace in `@slack/cli-test`
- `SlackCLI.create(...)` → `SlackCLI.project.create(...)`
- Continues to run `slack create` under the hood (matching how `auth` wraps `login`/`logout`)
- Aligns with Slack CLI v4.0.0 where `create` became a `project` subcommand

## Changes
- `packages/cli-test/src/cli/commands/create.ts` → `packages/cli-test/src/cli/commands/project.ts` — renamed module, exported as default object with `create` method
- `packages/cli-test/src/cli/commands/create.test.ts` → `packages/cli-test/src/cli/commands/project.test.ts` — updated tests
- `packages/cli-test/src/cli/index.ts` — replaced `create` import/export with `project`

## Test plan
- [x] `npm test --workspace=packages/cli-test` — all 28 tests pass
- [x] `npx biome check` — no lint issues
- [x] No stale references to old `create` import remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>