### PR TITLE
ci: update package lockfile and docs with changesets release

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -116,7 +116,7 @@ New official package versions are published when the release PR created from cha
 
 1. **Check GitHub Milestones**: Before merging the release PR please check the relevant [Milestones](https://github.com/slackapi/node-slack-sdk/milestones). If issues or pull requests are still open either decide to postpone the release or save those changes for a future update.
 
-2. **Review the release PR**: Verify that version bumps match expectations, `CHANGELOG` entries are clear, and CI checks pass on the `main` branch. Use `npm run docs` to generate documentation and `npm install` to update versions in the `package-lock.json` file.
+2. **Review the release PR**: Verify that version bumps match expectations, `CHANGELOG` entries are clear, and CI checks pass on the `main` branch.
 
 3. **Merge and approve**: Merge the release PR, then approve the [publish](https://github.com/slackapi/node-slack-sdk/actions/workflows/release.yml) workflow to release packages to npm.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           commit: "chore: release"
           title: "chore: release"
-          version: npm run changeset -- version
+          version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "docs": "npm run docs --workspaces --if-present",
     "lint": "npx @biomejs/biome check packages",
     "lint:fix": "npx @biomejs/biome check --write packages",
-    "test": "npm test --workspaces --if-present"
+    "test": "npm test --workspaces --if-present",
+    "version": "npm run changeset version && npm install && npm run docs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.5",


### PR DESCRIPTION
## Summary

- Adds a `version` script that runs `changeset version`, `npm install`, and `npm run docs` so the release PR automatically includes lockfile and documentation updates
- Updates the release workflow to use the new `version` script
- Removes manual `npm install` / `npm run docs` instructions from the maintainers guide

## Notes

This mirrors the release process found in bolt-js: https://github.com/slackapi/bolt-js/pull/2882

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>