### PR TITLE
ci: publish releases using the @slackapi github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,21 @@ jobs:
       contents: write
       id-token: write # OIDC: https://docs.npmjs.com/trusted-publishers
     steps:
+      - name: Gather credentials
+        id: credentials
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
+          token: ${{ steps.credentials.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -86,4 +97,4 @@ jobs:
           createGithubReleases: true
           publish: npm run changeset -- publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.credentials.outputs.token }}


### PR DESCRIPTION
## Summary

- Adds a `Gather credentials` step using `actions/create-github-app-token` to generate an app token for the `@slackapi` GitHub app
- Uses the app token for checkout and publishing so GitHub releases are created under the app identity
- Replaces `secrets.GITHUB_TOKEN` with the app token in the publish and release details steps

## Notes

This mirrors the release process found in bolt-js: https://github.com/slackapi/bolt-js/pull/2883

- We have a few secrets to add alongside these changes before the next release too 🔏
  - `GH_APP_CLIENT_ID`
  - `GH_APP_PRIVATE_KEY`

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>