### PR TITLE
ci: skip publish step if no release is needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      releaseExists: ${{ steps.published.outputs.exists }}
     permissions:
       contents: write
       pull-requests: write
@@ -41,10 +42,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if publish is needed
+        id: published
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          EXISTS=true
+          for PKG in $(npm query .workspace | jq -r '.[].name'); do
+            VERSION=$(npm query "#${PKG}" | jq -r '.[0].version')
+            if ! gh release view "${PKG}@${VERSION}" &>/dev/null; then
+              EXISTS=false
+              break
+            fi
+          done
+          echo "exists=${EXISTS}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     name: Publish
     needs: changelog
-    if: needs.changelog.outputs.hasChangesets == 'false'
+    if: needs.changelog.outputs.hasChangesets == 'false' && needs.changelog.outputs.releaseExists == 'false'
     runs-on: ubuntu-latest
     environment: publish
     permissions:


### PR DESCRIPTION
## Summary

- Adds a check after the changesets step to see if all workspace packages already have GitHub releases for their current versions
- Skips the `publish` job when releases already exist, avoiding unnecessary approval requests

## Notes

This mirrors the release process found in bolt-js: https://github.com/slackapi/bolt-js/pull/2894

Adapted for the monorepo — iterates over all workspaces and checks each package's release tag (`@slack/package@version`) rather than a single `v${VERSION}` tag.

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>