### PR TITLE
fix(socket-mode): terminate closing connections earlier if normal close responses fail

### DIFF
--- a/.changeset/full-spiders-enter.md
+++ b/.changeset/full-spiders-enter.md
@@ -1,0 +1,5 @@
+---
+"@slack/socket-mode": patch
+---
+
+fix: terminate closing connections earlier if normal close responses fails

--- a/.changeset/full-spiders-enter.md
+++ b/.changeset/full-spiders-enter.md
@@ -3,3 +3,5 @@
 ---
 
 fix: terminate closing connections earlier if normal close responses fail
+
+If Slack doesn't respond to a close frame, the WebSocket connection is now force-terminated instead of waiting for a response that won't arrive. Since [disconnects are expected](https://docs.slack.dev/apis/events-api/using-socket-mode/#disconnect) every few hours, this avoids repeated "pong wasn't received" warnings and speeds up reconnection.

--- a/.changeset/full-spiders-enter.md
+++ b/.changeset/full-spiders-enter.md
@@ -2,4 +2,4 @@
 "@slack/socket-mode": patch
 ---
 
-fix: terminate closing connections earlier if normal close responses fails
+fix: terminate closing connections earlier if normal close responses fail

--- a/packages/socket-mode/src/SlackWebSocket.ts
+++ b/packages/socket-mode/src/SlackWebSocket.ts
@@ -159,11 +159,16 @@ export class SlackWebSocket {
       if (this.closeFrameReceived) {
         this.logger.debug('Terminating WebSocket (close frame received).');
         this.terminate();
+      } else if (this.websocket.readyState === WebSocket.CLOSING) {
+        // A close frame was already sent but the peer hasn't responded. Force-terminate rather than
+        // waiting for the ws library's closeTimeout (~30s) while the ping monitor logs repeated warnings.
+        this.logger.debug('Terminating WebSocket (close frame sent but no response, force-terminating).');
+        this.terminate();
       } else {
         // If we haven't received a close frame yet, then we send one to the peer, expecting to receive a close frame
         // in response.
         this.logger.debug('Sending close frame (status=1000).');
-        this.websocket.close(1000); // send a close frame, 1000=Normal Closure
+        this.websocket.close(1000); // 1000 = Normal Closure
       }
     } else {
       this.logger.debug('WebSocket already disconnected, flushing remainder.');

--- a/packages/socket-mode/test/integration.test.js
+++ b/packages/socket-mode/test/integration.test.js
@@ -426,6 +426,10 @@ describe('Integration tests with a WebSocket server', { timeout: 30000 }, () => 
           });
           await new Promise((res) => unresponsiveWsServer.listen(WSS_PORT, res));
           await client.start();
+          let closeCount = 0;
+          client.on('close', () => {
+            closeCount++;
+          });
           // Swap in a working WSS for the reconnection attempt
           client.on('reconnecting', () => {
             if (rawSocket) rawSocket.destroy();
@@ -440,6 +444,8 @@ describe('Integration tests with a WebSocket server', { timeout: 30000 }, () => 
           });
           const reconnectedWaiter = new Promise((res) => client.on('connected', res));
           await reconnectedWaiter;
+          // The force-terminate should produce 1 close event per reconnection attempt
+          assert.strictEqual(closeCount, 1);
           await client.disconnect();
         });
         it('should reconnect if server does not respond with `pong` message within specified client ping timeout after initially responding with `pong`', async () => {

--- a/packages/socket-mode/test/integration.test.js
+++ b/packages/socket-mode/test/integration.test.js
@@ -405,6 +405,43 @@ describe('Integration tests with a WebSocket server', { timeout: 30000 }, () => 
           await reconnectedWaiter;
           await client.disconnect();
         });
+        it('should reconnect if server becomes completely unresponsive and does not respond to close frames', async () => {
+          wss.close();
+          // Use noServer mode so we get access to the raw socket via the upgrade event.
+          // After sending hello, we pause the socket to simulate a fully unresponsive server
+          // that won't respond to pings OR close frames.
+          wss = new WebSocketServer({ noServer: true, autoPong: false });
+          const unresponsiveWsServer = createServer();
+          let rawSocket = null;
+          unresponsiveWsServer.on('upgrade', (req, socket, head) => {
+            rawSocket = socket;
+            wss.handleUpgrade(req, socket, head, (ws) => {
+              ws.on('error', () => {});
+              ws.send(JSON.stringify({ type: 'hello' }));
+              exposed_ws_connection = ws;
+              // Make the server completely unresponsive: it won't process any incoming
+              // data, including ping frames and close frames.
+              socket.pause();
+            });
+          });
+          await new Promise((res) => unresponsiveWsServer.listen(WSS_PORT, res));
+          await client.start();
+          // Swap in a working WSS for the reconnection attempt
+          client.on('reconnecting', () => {
+            if (rawSocket) rawSocket.destroy();
+            unresponsiveWsServer.close();
+            wss.close();
+            wss = new WebSocketServer({ port: WSS_PORT });
+            wss.on('connection', (ws) => {
+              ws.on('error', () => {});
+              ws.send(JSON.stringify({ type: 'hello' }));
+              exposed_ws_connection = ws;
+            });
+          });
+          const reconnectedWaiter = new Promise((res) => client.on('connected', res));
+          await reconnectedWaiter;
+          await client.disconnect();
+        });
         it('should reconnect if server does not respond with `pong` message within specified client ping timeout after initially responding with `pong`', async () => {
           wss.close();
           // override the web socket server so that it DOESNT auto-respond to ping messages with a pong, except for the first time


### PR DESCRIPTION
### Summary

This PR terminates closing connections earlier if normal close responses fail for https://github.com/openclaw/openclaw/issues/72808 🦞

We hope to attempt a reconnection sooner because these reconnection issues can occur for various reasons, including during a server swap on the backend:

📚 https://docs.slack.dev/apis/events-api/using-socket-mode#disconnect

### Preview

#### Before

https://github.com/user-attachments/assets/4265c959-c0a2-40f1-94b7-0e1d467931ec

#### After

https://github.com/user-attachments/assets/65a7acfa-0a1c-4ce0-9f54-d6d01d7e4331

### Reviewers

Please build this branch and test with a Bolt app ⚡ 

```
[INFO]  bolt-app ⚡️ Bolt app is running!
```

After connecting with Socket Mode, turn internet off, grab a glass of water, and turn the internet back on. A reconnection should succeed!

### Notes

- Sometimes `num_connections` returns as "2" instead of "1" after reconnections. I believe this can happen both before and after these changes, but soon resolves after Slack decides the connection is idle 🔬 
- We might prefer the sooner termination because errors in initial retries are not common to resolve if network issues exist. We prefer to attempt reconnecting sooner because of this!

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
