### PR TITLE
ci: build linked packages before generating docs for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,21 @@ jobs:
       - name: Install dependencies
         run: npm ci --verbose
 
+      - name: Build packages
+        run: |
+          # Build base dependencies
+          npm run build --workspace=@slack/logger
+          npm run build --workspace=@slack/types
+
+          # Build packages requiring base dependencies
+          npm run build --workspace=@slack/web-api
+          npm run build --workspace=@slack/webhook
+
+          # Build packages that depend on the Web API
+          npm run build --workspace=@slack/oauth
+          npm run build --workspace=@slack/rtm-api
+          npm run build --workspace=@slack/socket-mode
+
       - name: Create or update release PR
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0


### PR DESCRIPTION
### Summary

This PR builds linked packages before generating docs for releases. For #2569. Follows #2559. 📚 

Fixes an issue where types were assumed to be "any" between packages!

### Notes

We mirror this step before the actual publish in following steps:

https://github.com/slackapi/node-slack-sdk/blob/971da3cbbac4b7d746a9f24dff9c4ff8eeb83a16/.github/workflows/release.yml#L111-L124

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
