### PR TITLE
ci: send release announcements on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,9 +124,30 @@ jobs:
           npm run build --workspace=@slack/socket-mode
 
       - name: Publish to npm and create GitHub releases
+        id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           createGithubReleases: true
           publish: npm run changeset -- publish
         env:
           GITHUB_TOKEN: ${{ steps.credentials.outputs.token }}
+
+      - name: Get publication details
+        if: steps.changesets.outputs.published == 'true'
+        id: release
+        run: |
+          echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "\(.name)@\(.version)"] | join(", ")')" >> "$GITHUB_OUTPUT"
+          echo "action_url=$(echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "https://github.com/${{ github.repository }}/releases/tag/\(.name)@\(.version)"] | join("\n")')" >> "$GITHUB_OUTPUT"
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+
+      - name: Notify Slack
+        if: steps.changesets.outputs.published == 'true'
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_ANNOUNCEMENTS_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            action_url: "${{ steps.release.outputs.action_url }}"
+            message: "${{ steps.release.outputs.message }}"
+            repository: "${{ github.repository }}"


### PR DESCRIPTION
### Summary

This PR posts a release announcement to a Slack channel for more celebrations 🎉 Similar: https://github.com/slackapi/bolt-js/pull/2877

### Reviewers

Confirm this matches expected outputs with these commands:

```sh
export PUBLISHED_PACKAGES='[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]'
echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "\(.name)@\(.version)"] | join(", ")'
echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "https://github.com/${{ github.repository }}/releases/tag/\(.name)@\(.version)"] | join("\n")'
```

```
@xx/xx@1.2.0, @xx/xy@0.8.9
https://github.com/${{ github.repository }}/releases/tag/@xx/xx@1.2.0
https://github.com/${{ github.repository }}/releases/tag/@xx/xy@0.8.9
```

### Notes

- The links are unescaped and don't render as expected in the Slack client but the text is correct so I think this is alright as meaningful reference still!

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
