### PR TITLE
docs(types): align Alert, Card, Carousel block descriptions with official docs

### DIFF
--- a/.changeset/fix-block-descriptions.md
+++ b/.changeset/fix-block-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@slack/types': patch
+---
+
+Align Alert, Card, and Carousel block type descriptions with official documentation

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -113,7 +113,7 @@ export interface ActionsBlock extends Block {
 }
 
 /**
- * @description A prominent notice block for displaying warnings, status updates, or other important information.
+ * @description Displays alerts, warnings, and informational messages.
  * @see {@link https://docs.slack.dev/reference/block-kit/blocks/alert-block Alert block reference}.
  */
 export interface AlertBlock extends Block {
@@ -132,8 +132,7 @@ export interface AlertBlock extends Block {
 }
 
 /**
- * @description A rich display block for presenting structured content such as recommendations, results, or work items.
- * At least one of `hero_image`, `title`, `actions`, or `body` must be provided.
+ * @description Displays content in a card. At least one of `hero_image`, `title`, `actions`, or `body` must be provided.
  * @see {@link https://docs.slack.dev/reference/block-kit/blocks/card-block Card block reference}.
  */
 export interface CardBlock extends Block {
@@ -171,7 +170,7 @@ export interface CardBlock extends Block {
 }
 
 /**
- * @description A horizontally scrollable collection of {@link CardBlock} elements.
+ * @description Displays related card blocks in a horizontally-scrolling container.
  * @see {@link https://docs.slack.dev/reference/block-kit/blocks/carousel-block Carousel block reference}.
  */
 export interface CarouselBlock extends Block {


### PR DESCRIPTION
## Summary
- Updates `AlertBlock` description to "Displays alerts, warnings, and informational messages."
- Updates `CardBlock` description to "Displays content in a card."
- Updates `CarouselBlock` description to "Displays related card blocks in a horizontally-scrolling container."

These align with the official Slack documentation and follow the existing "Displays..." pattern used by other blocks in the codebase.

## Test plan
- [x] `npm run build` passes for `@slack/types`
- [x] `npm test` (tsd type tests) passes for `@slack/types`