### PR TITLE
feat(types): add BlockChunk type to chat.{start,append,stop}Stream methods

### DIFF
--- a/.changeset/add-blocks-chunk.md
+++ b/.changeset/add-blocks-chunk.md
@@ -1,5 +1,5 @@
 ---
-'@slack/types': minor
+'@slack/types': patch
 ---
 
 Add `BlocksChunk` type for passing Block Kit blocks within streaming messages

--- a/.changeset/add-blocks-chunk.md
+++ b/.changeset/add-blocks-chunk.md
@@ -1,0 +1,5 @@
+---
+'@slack/types': minor
+---
+
+Add `BlocksChunk` type for passing Block Kit blocks within streaming messages

--- a/packages/types/src/chunk.ts
+++ b/packages/types/src/chunk.ts
@@ -1,11 +1,22 @@
 import type { URLSourceElement } from './block-kit/block-elements';
 import type { AnyBlock } from './block-kit/blocks';
+
 /**
  * Base interface for streaming message chunks.
  * https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming
  */
 export interface Chunk {
   type: string;
+}
+
+/**
+ * Used for passing an array of blocks within a streaming message.
+ * https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks/
+ */
+export interface BlocksChunk extends Chunk {
+  type: 'blocks';
+  /** @description An array of {@link AnyBlock} objects. Maximum of 50 blocks. */
+  blocks: AnyBlock[];
 }
 
 /**
@@ -41,16 +52,6 @@ export interface TaskUpdateChunk extends Chunk {
 }
 
 /**
- * Used for passing an array of blocks within a streaming message.
- * https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks/
- */
-export interface BlocksChunk extends Chunk {
-  type: 'blocks';
-  /** @description An array of {@link AnyBlock} objects. Maximum of 50 blocks. */
-  blocks: AnyBlock[];
-}
-
-/**
  * Union type of all possible chunk types
  */
-export type AnyChunk = MarkdownTextChunk | PlanUpdateChunk | TaskUpdateChunk | BlocksChunk;
+export type AnyChunk = BlocksChunk | MarkdownTextChunk | PlanUpdateChunk | TaskUpdateChunk;

--- a/packages/types/src/chunk.ts
+++ b/packages/types/src/chunk.ts
@@ -1,4 +1,5 @@
 import type { URLSourceElement } from './block-kit/block-elements';
+import type { AnyBlock } from './block-kit/blocks';
 /**
  * Base interface for streaming message chunks.
  * https://docs.slack.dev/messaging/sending-and-scheduling-messages#text-streaming
@@ -40,6 +41,16 @@ export interface TaskUpdateChunk extends Chunk {
 }
 
 /**
+ * Used for passing an array of blocks within a streaming message.
+ * https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks/
+ */
+export interface BlocksChunk extends Chunk {
+  type: 'blocks';
+  /** @description An array of {@link AnyBlock} objects. Maximum of 50 blocks. */
+  blocks: AnyBlock[];
+}
+
+/**
  * Union type of all possible chunk types
  */
-export type AnyChunk = MarkdownTextChunk | PlanUpdateChunk | TaskUpdateChunk;
+export type AnyChunk = MarkdownTextChunk | PlanUpdateChunk | TaskUpdateChunk | BlocksChunk;

--- a/packages/types/test/chunk.test-d.ts
+++ b/packages/types/test/chunk.test-d.ts
@@ -20,10 +20,7 @@ expectAssignable<BlocksChunk>({
 });
 expectAssignable<BlocksChunk>({
   type: 'blocks',
-  blocks: [
-    { type: 'divider' },
-    { type: 'header', text: { type: 'plain_text', text: 'Hello' } },
-  ],
+  blocks: [{ type: 'divider' }, { type: 'header', text: { type: 'plain_text', text: 'Hello' } }],
 });
 // Unknown block types accepted via generic Block interface
 expectAssignable<BlocksChunk>({

--- a/packages/types/test/chunk.test-d.ts
+++ b/packages/types/test/chunk.test-d.ts
@@ -1,0 +1,35 @@
+import { expectAssignable, expectError } from 'tsd';
+import type { AnyChunk, BlocksChunk } from '../src/index';
+
+// BlocksChunk
+// -- sad path
+expectError<BlocksChunk>({});
+expectError<BlocksChunk>({ type: 'blocks' });
+expectError<BlocksChunk>({ blocks: [] });
+
+// -- happy path
+expectAssignable<BlocksChunk>({ type: 'blocks', blocks: [] });
+expectAssignable<BlocksChunk>({
+  type: 'blocks',
+  blocks: [
+    {
+      type: 'section',
+      text: { type: 'plain_text', text: "Sandra's plan outline" },
+    },
+  ],
+});
+expectAssignable<BlocksChunk>({
+  type: 'blocks',
+  blocks: [
+    { type: 'divider' },
+    { type: 'header', text: { type: 'plain_text', text: 'Hello' } },
+  ],
+});
+// Unknown block types accepted via generic Block interface
+expectAssignable<BlocksChunk>({
+  type: 'blocks',
+  blocks: [{ type: 'future_block_type' }],
+});
+
+// BlocksChunk is assignable to AnyChunk
+expectAssignable<AnyChunk>({ type: 'blocks', blocks: [] });

--- a/packages/web-api/test/types/methods/chat.test-d.ts
+++ b/packages/web-api/test/types/methods/chat.test-d.ts
@@ -33,6 +33,10 @@ expectAssignable<Parameters<typeof web.chat.appendStream>>([
     ts: '1234.56',
     chunks: [
       {
+        type: 'blocks',
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Hello' } }],
+      },
+      {
         type: 'markdown_text',
         text: 'Hello world',
       },
@@ -790,6 +794,10 @@ expectAssignable<Parameters<typeof web.chat.startStream>>([
     thread_ts: '1234.56',
     chunks: [
       {
+        type: 'blocks',
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Hello' } }],
+      },
+      {
         type: 'markdown_text',
         text: 'Hello world',
       },
@@ -913,6 +921,10 @@ expectAssignable<Parameters<typeof web.chat.stopStream>>([
     channel: 'C1234',
     ts: '1234.56',
     chunks: [
+      {
+        type: 'blocks',
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Hello' } }],
+      },
       {
         type: 'markdown_text',
         text: 'Hello world',


### PR DESCRIPTION
### Summary

This PR adds BlocksChunk model class to support the new blocks chunk type in the streaming API (chat.startStream, chat.appendStream, chat.stopStream). Follows the [April 16, 2026 changelog](https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks/) which notes updates to the text-streaming API methods to support streaming blocks.

### Testing
<details><summary>Sample app.js</summary>

```js
import { App, LogLevel } from '@slack/bolt';
import { config } from 'dotenv';

config();

const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  socketMode: true,
  appToken: process.env.SLACK_APP_TOKEN,
  logLevel: LogLevel.DEBUG,
});

app.message(/^test blocks chunk$/, async ({ message, client, logger }) => {
  try {
    const streamer = client.chatStream({
      channel: message.channel,
      thread_ts: message.ts,
      recipient_team_id: message.team,
      recipient_user_id: message.user,
    });

    await streamer.append({
      markdown_text: "Here's a **card** streamed via `BlocksChunk`:\n\n",
    });

    await streamer.append({
      chunks: [
        {
          type: 'blocks',
          blocks: [
            {
              type: 'card',
              title: { type: 'mrkdwn', text: 'Streaming Card' },
              subtitle: { type: 'mrkdwn', text: 'Sent via BlocksChunk' },
              body: { type: 'mrkdwn', text: 'This card was streamed inside a chunks array.' },
            },
          ],
        },
      ],
    });

    await streamer.stop({
      chunks: [
        {
          type: 'blocks',
          blocks: [
            {
              type: 'carousel',
              elements: [
                {
                  type: 'card',
                  title: { type: 'mrkdwn', text: 'Card 1' },
                  subtitle: { type: 'mrkdwn', text: 'First' },
                  body: { type: 'mrkdwn', text: 'First card in carousel.' },
                },
                {
                  type: 'card',
                  title: { type: 'mrkdwn', text: 'Card 2' },
                  subtitle: { type: 'mrkdwn', text: 'Second' },
                  body: { type: 'mrkdwn', text: 'Second card in carousel.' },
                },
                {
                  type: 'card',
                  title: { type: 'mrkdwn', text: 'Card 3' },
                  subtitle: { type: 'mrkdwn', text: 'Third' },
                  body: { type: 'mrkdwn', text: 'Third card in carousel.' },
                },
              ],
            },
          ],
        },
      ],
    });
  } catch (error) {
    logger.error(error);
  }
});

(async () => {
  try {
    await app.start();
    app.logger.info('⚡️ Bolt app is running!');
  } catch (error) {
    app.logger.error('Failed to start the app', error);
  }
})();
```
</details>


### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
