### PR TITLE
test: add coverage for untested WebClient and IncomingWebhook behavior

### DIFF
--- a/packages/web-api/src/WebClient.test.ts
+++ b/packages/web-api/src/WebClient.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import zlib from 'node:zlib';
 import type { ContextActionsBlock } from '@slack/types';
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 import nock, { type ReplyHeaders } from 'nock';
@@ -463,6 +464,40 @@ describe('WebClient', () => {
         assert.ok(error instanceof Error);
         assert.ok(e.original instanceof Error);
       }
+    });
+
+    it('should set error.body to the raw string when HTTP error response is not valid JSON', async () => {
+      const htmlBody = '<html><body><h1>502 Bad Gateway</h1></body></html>';
+      const scope = nock('https://slack.com').post(/api/).reply(502, htmlBody);
+      const client = new WebClient(token, { retryConfig: { retries: 0 } });
+      try {
+        await client.apiCall('method');
+        assert.fail('expected error to be thrown');
+      } catch (error) {
+        const e = error as WebAPIHTTPError;
+        assert.strictEqual(e.code, ErrorCode.HTTPError);
+        assert.strictEqual(e.statusCode, 502);
+        assert.strictEqual(e.body, htmlBody);
+        scope.done();
+      }
+    });
+
+    describe('admin.analytics.getFile GZIP response', () => {
+      it('should decompress GZIP response and return file_data array', async () => {
+        const fileData = [
+          { date: '2024-01-01', user_id: 'U123', messages_posted: 5 },
+          { date: '2024-01-01', user_id: 'U456', messages_posted: 10 },
+        ];
+        const ndjson = fileData.map((d) => JSON.stringify(d)).join('\n');
+        const gzipped = zlib.gzipSync(Buffer.from(ndjson));
+        const scope = nock('https://slack.com')
+          .post('/api/admin.analytics.getFile')
+          .reply(200, gzipped, { 'content-type': 'application/gzip' });
+        const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
+        const result = await client.apiCall('admin.analytics.getFile', { type: 'member' });
+        assert.deepStrictEqual(result.file_data, fileData);
+        scope.done();
+      });
     });
 
     it('should properly serialize simple API arguments', async () => {

--- a/packages/web-api/src/WebClient.test.ts
+++ b/packages/web-api/src/WebClient.test.ts
@@ -478,6 +478,7 @@ describe('WebClient', () => {
         assert.strictEqual(e.code, ErrorCode.HTTPError);
         assert.strictEqual(e.statusCode, 502);
         assert.strictEqual(e.body, htmlBody);
+      } finally {
         scope.done();
       }
     });
@@ -493,10 +494,13 @@ describe('WebClient', () => {
         const scope = nock('https://slack.com')
           .post('/api/admin.analytics.getFile')
           .reply(200, gzipped, { 'content-type': 'application/gzip' });
-        const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
-        const result = await client.apiCall('admin.analytics.getFile', { type: 'member' });
-        assert.deepStrictEqual(result.file_data, fileData);
-        scope.done();
+        try {
+          const client = new WebClient(token, { retryConfig: rapidRetryPolicy });
+          const result = await client.apiCall('admin.analytics.getFile', { type: 'member' });
+          assert.deepStrictEqual(result.file_data, fileData);
+        } finally {
+          scope.done();
+        }
       });
     });
 

--- a/packages/webhook/src/IncomingWebhook.test.ts
+++ b/packages/webhook/src/IncomingWebhook.test.ts
@@ -128,9 +128,12 @@ describe('IncomingWebhook', () => {
         })
           .post(/services/)
           .reply(200, 'ok');
-        const webhook = new IncomingWebhook(url);
-        await webhook.send('Hello');
-        scope.done();
+        try {
+          const webhook = new IncomingWebhook(url);
+          await webhook.send('Hello');
+        } finally {
+          scope.done();
+        }
       });
     });
   });

--- a/packages/webhook/src/IncomingWebhook.test.ts
+++ b/packages/webhook/src/IncomingWebhook.test.ts
@@ -116,5 +116,22 @@ describe('IncomingWebhook', () => {
         }
       });
     });
+
+    describe('User-Agent header', () => {
+      it('should send the User-Agent header with every request', async () => {
+        const scope = nock('https://hooks.slack.com', {
+          reqheaders: {
+            'User-Agent': (value) => {
+              return /@slack:webhook/.test(value);
+            },
+          },
+        })
+          .post(/services/)
+          .reply(200, 'ok');
+        const webhook = new IncomingWebhook(url);
+        await webhook.send('Hello');
+        scope.done();
+      });
+    });
   });
 });


### PR DESCRIPTION
### Summary

These changes are in preparation for upcoming changes 
  - Add GZIP decompression test for admin.analytics.getFile response handling                                                                                                                                                                 
  - Add non-JSON HTTP error body test verifying error.body preserves raw string content                                                                                                                                                       
  - Add User-Agent header test for IncomingWebhook requests                                                                                                                                                                                   

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
