### PR TITLE
fix(cli-test): invoke commands without shell intermediate

### DIFF
--- a/.changeset/itchy-buttons-begin.md
+++ b/.changeset/itchy-buttons-begin.md
@@ -2,7 +2,7 @@
 "@slack/cli-test": patch
 ---
 
-fix(cli-test): invoke commands without shell intermediate
+fix: invoke commands without shell intermediate
 
 Behind the scenes commands are now spawned direct to avoid unexpected input and output redirection or odd argument parsings. This is what happens and what changed:
 

--- a/.changeset/itchy-buttons-begin.md
+++ b/.changeset/itchy-buttons-begin.md
@@ -1,0 +1,21 @@
+---
+"@slack/cli-test": patch
+---
+
+fix(cli-test): invoke commands without shell intermediate
+
+Behind the scenes commands are now spawned direct to avoid unexpected input and output redirection or odd argument parsings. This is what happens and what changed:
+
+Linux:
+
+```diff
+- /bin/sh -c "slack trigger run --workflow #/workflows/give_kudos_workflow"
++ execvp("slack", ["trigger", "run", "--workflow", "#/workflows/give_kudos_workflow"])
+```
+
+Windows:
+
+```diff
+- cmd.exe /s /c "slack trigger run --workflow #/workflows/give_kudos_workflow"
++ CreateProcessW("slack", ["trigger", "run", "--workflow", "#/workflows/give_kudos_workflow"])
+```

--- a/packages/cli-test/package.json
+++ b/packages/cli-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/cli-test",
-  "version": "3.0.2-rc.1",
+  "version": "3.0.2-rc.2",
   "description": "Node.js bindings for the Slack CLI for use in automated testing",
   "author": "Salesforce, Inc.",
   "license": "MIT",

--- a/packages/cli-test/package.json
+++ b/packages/cli-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/cli-test",
-  "version": "3.0.1",
+  "version": "3.0.2-rc.1",
   "description": "Node.js bindings for the Slack CLI for use in automated testing",
   "author": "Salesforce, Inc.",
   "license": "MIT",

--- a/packages/cli-test/package.json
+++ b/packages/cli-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/cli-test",
-  "version": "3.0.2-rc.3",
+  "version": "3.0.1",
   "description": "Node.js bindings for the Slack CLI for use in automated testing",
   "author": "Salesforce, Inc.",
   "license": "MIT",

--- a/packages/cli-test/package.json
+++ b/packages/cli-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/cli-test",
-  "version": "3.0.2-rc.2",
+  "version": "3.0.2-rc.3",
   "description": "Node.js bindings for the Slack CLI for use in automated testing",
   "author": "Salesforce, Inc.",
   "license": "MIT",

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -15,10 +15,10 @@ export interface DatastoreCommandArguments {
 }
 
 /**
- * Used to escape double quotes in JSON strings; this is needed when JSON is passed as a command line argument, which for the datastore commands, it is.
+ * Serializes an object to a JSON string for passing as a command line argument.
  */
 function escapeJSON(obj: Record<string, unknown>): string {
-  return `"${JSON.stringify(obj).replace(/"/g, '\\"')}"`;
+  return JSON.stringify(obj);
 }
 
 /**

--- a/packages/cli-test/src/cli/commands/datastore.ts
+++ b/packages/cli-test/src/cli/commands/datastore.ts
@@ -15,13 +15,6 @@ export interface DatastoreCommandArguments {
 }
 
 /**
- * Serializes an object to a JSON string for passing as a command line argument.
- */
-function escapeJSON(obj: Record<string, unknown>): string {
-  return JSON.stringify(obj);
-}
-
-/**
  * `slack datastore get`
  * @returns command output
  */
@@ -32,7 +25,7 @@ export const datastoreGet = async function datastoreGet(
     datastore: args.datastoreName,
     id: args.primaryKeyValue,
   };
-  const cmd = new SlackCLIProcess(['datastore', 'get', escapeJSON(getQueryObj)], args);
+  const cmd = new SlackCLIProcess(['datastore', 'get', JSON.stringify(getQueryObj)], args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });
@@ -50,7 +43,7 @@ export const datastoreDelete = async function datastoreDelete(
     datastore: args.datastoreName,
     id: args.primaryKeyValue,
   };
-  const cmd = new SlackCLIProcess(['datastore', 'delete', escapeJSON(deleteQueryObj)], args);
+  const cmd = new SlackCLIProcess(['datastore', 'delete', JSON.stringify(deleteQueryObj)], args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });
@@ -68,7 +61,7 @@ export const datastorePut = async function datastorePut(
     datastore: args.datastoreName,
     item: args.putItem,
   };
-  const cmd = new SlackCLIProcess(['datastore', 'put', escapeJSON(putQueryObj)], args);
+  const cmd = new SlackCLIProcess(['datastore', 'put', JSON.stringify(putQueryObj)], args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });
@@ -88,7 +81,7 @@ export const datastoreQuery = async function datastoreQuery(
     expression: args.queryExpression,
     expression_values: args.queryExpressionValues,
   };
-  const cmd = new SlackCLIProcess(['datastore', 'query', escapeJSON(queryObj)], args);
+  const cmd = new SlackCLIProcess(['datastore', 'query', JSON.stringify(queryObj)], args);
   const proc = await cmd.execAsync({
     cwd: args.appPath,
   });

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,12 +65,11 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -86,18 +85,17 @@ describe('shell module', () => {
         shell.runCommandSync('about to explode', []);
       }, /this is bat country/);
     });
-    it('should use shell:false on Windows and shell:true on other platforms', () => {
+    it('should spawn without a shell', () => {
       const fakeEnv = { HEY: 'yo' };
       sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
-      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         runSpy,
         fakeCmd,
-        sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match.array.contains(fakeArgs),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
   });
@@ -110,12 +108,11 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -133,18 +130,17 @@ describe('shell module', () => {
         shell.spawnProcess('about to explode', []);
       }, /this is bat country/);
     });
-    it('should use shell:false on Windows and shell:true on other platforms', () => {
+    it('should spawn without a shell', () => {
       const fakeEnv = { HEY: 'yo' };
       sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
-      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         spawnSpy,
         fakeCmd,
-        sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match.array.contains(fakeArgs),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
   });

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,11 +65,12 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
+      const expectedShell = process.platform === 'win32' ? false : true;
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: false, env: fakeEnv }),
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -85,17 +86,18 @@ describe('shell module', () => {
         shell.runCommandSync('about to explode', []);
       }, /this is bat country/);
     });
-    it('should spawn the command directly without a shell', () => {
+    it('should use shell:false on Windows and shell:true on other platforms', () => {
       const fakeEnv = { HEY: 'yo' };
       sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
+      const expectedShell = process.platform === 'win32' ? false : true;
       sandbox.assert.calledWithMatch(
         runSpy,
         fakeCmd,
-        sinon.match.array.contains(fakeArgs),
-        sinon.match({ shell: false, env: fakeEnv }),
+        sinon.match.array,
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
   });
@@ -108,11 +110,12 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
+      const expectedShell = process.platform === 'win32' ? false : true;
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: false, env: fakeEnv }),
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -130,17 +133,18 @@ describe('shell module', () => {
         shell.spawnProcess('about to explode', []);
       }, /this is bat country/);
     });
-    it('should spawn the command directly without a shell', () => {
+    it('should use shell:false on Windows and shell:true on other platforms', () => {
       const fakeEnv = { HEY: 'yo' };
       sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
+      const expectedShell = process.platform === 'win32' ? false : true;
       sandbox.assert.calledWithMatch(
         spawnSpy,
         fakeCmd,
-        sinon.match.array.contains(fakeArgs),
-        sinon.match({ shell: false, env: fakeEnv }),
+        sinon.match.array,
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
   });

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,12 +65,11 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = false;
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -109,12 +108,11 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = false;
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: expectedShell, env: fakeEnv }),
+        sinon.match({ shell: false, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,11 +65,12 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: true, env: fakeEnv }),
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {
@@ -124,11 +125,12 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
         sinon.match.array,
-        sinon.match({ shell: true, env: fakeEnv }),
+        sinon.match({ shell: expectedShell, env: fakeEnv }),
       );
     });
     it('should return the command outputs unchanged', () => {

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,7 +65,7 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform === 'win32' ? false : true;
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
@@ -92,7 +92,7 @@ describe('shell module', () => {
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
-      const expectedShell = process.platform === 'win32' ? false : true;
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         runSpy,
         fakeCmd,
@@ -110,7 +110,7 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform === 'win32' ? false : true;
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
@@ -139,7 +139,7 @@ describe('shell module', () => {
       const fakeCmd = 'echo';
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
-      const expectedShell = process.platform === 'win32' ? false : true;
+      const expectedShell = process.platform !== 'win32';
       sandbox.assert.calledWithMatch(
         spawnSpy,
         fakeCmd,

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -86,7 +86,7 @@ describe('shell module', () => {
       }, /this is bat country/);
     });
     if (process.platform === 'win32') {
-      it('on Windows, should wrap command to shell out in a `cmd /s /c` wrapper process', () => {
+      it('on Windows, should spawn the command directly without cmd.exe', () => {
         const fakeEnv = { HEY: 'yo' };
         sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
         const fakeCmd = 'echo';
@@ -94,9 +94,9 @@ describe('shell module', () => {
         shell.runCommandSync(fakeCmd, fakeArgs);
         sandbox.assert.calledWithMatch(
           runSpy,
-          'cmd',
-          sinon.match.array.contains(['/s', '/c', fakeCmd, ...fakeArgs]),
-          sinon.match({ shell: true, env: fakeEnv }),
+          fakeCmd,
+          sinon.match.array.contains(fakeArgs),
+          sinon.match({ shell: false, env: fakeEnv }),
         );
       });
     } else {
@@ -147,7 +147,7 @@ describe('shell module', () => {
       }, /this is bat country/);
     });
     if (process.platform === 'win32') {
-      it('on Windows, should wrap command to shell out in a `cmd /s /c` wrapper process', () => {
+      it('on Windows, should spawn the command directly without cmd.exe', () => {
         const fakeEnv = { HEY: 'yo' };
         sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
         const fakeCmd = 'echo';
@@ -155,9 +155,9 @@ describe('shell module', () => {
         shell.spawnProcess(fakeCmd, fakeArgs);
         sandbox.assert.calledWithMatch(
           spawnSpy,
-          'cmd',
-          sinon.match.array.contains(['/s', '/c', fakeCmd, ...fakeArgs]),
-          sinon.match({ shell: true, env: fakeEnv }),
+          fakeCmd,
+          sinon.match.array.contains(fakeArgs),
+          sinon.match({ shell: false, env: fakeEnv }),
         );
       });
     } else {

--- a/packages/cli-test/src/cli/shell.test.ts
+++ b/packages/cli-test/src/cli/shell.test.ts
@@ -65,7 +65,7 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.runCommandSync(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform !== 'win32';
+      const expectedShell = false;
       sandbox.assert.calledWithMatch(
         runSpy,
         sinon.match.string,
@@ -86,35 +86,19 @@ describe('shell module', () => {
         shell.runCommandSync('about to explode', []);
       }, /this is bat country/);
     });
-    if (process.platform === 'win32') {
-      it('on Windows, should spawn the command directly without cmd.exe', () => {
-        const fakeEnv = { HEY: 'yo' };
-        sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-        const fakeCmd = 'echo';
-        const fakeArgs = ['"hi there"'];
-        shell.runCommandSync(fakeCmd, fakeArgs);
-        sandbox.assert.calledWithMatch(
-          runSpy,
-          fakeCmd,
-          sinon.match.array.contains(fakeArgs),
-          sinon.match({ shell: false, env: fakeEnv }),
-        );
-      });
-    } else {
-      it('on non-Windows, should shell out to provided command directly', () => {
-        const fakeEnv = { HEY: 'yo' };
-        sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-        const fakeCmd = 'echo';
-        const fakeArgs = ['"hi there"'];
-        shell.runCommandSync(fakeCmd, fakeArgs);
-        sandbox.assert.calledWithMatch(
-          runSpy,
-          fakeCmd,
-          sinon.match.array.contains(fakeArgs),
-          sinon.match({ shell: true, env: fakeEnv }),
-        );
-      });
-    }
+    it('should spawn the command directly without a shell', () => {
+      const fakeEnv = { HEY: 'yo' };
+      sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
+      const fakeCmd = 'echo';
+      const fakeArgs = ['"hi there"'];
+      shell.runCommandSync(fakeCmd, fakeArgs);
+      sandbox.assert.calledWithMatch(
+        runSpy,
+        fakeCmd,
+        sinon.match.array.contains(fakeArgs),
+        sinon.match({ shell: false, env: fakeEnv }),
+      );
+    });
   });
 
   describe('spawnProcess method', () => {
@@ -125,7 +109,7 @@ describe('shell module', () => {
       const fakeArgs = ['"hi there"'];
       shell.spawnProcess(fakeCmd, fakeArgs);
       sandbox.assert.calledOnce(assembleSpy);
-      const expectedShell = process.platform !== 'win32';
+      const expectedShell = false;
       sandbox.assert.calledWithMatch(
         spawnSpy,
         sinon.match.string,
@@ -148,35 +132,19 @@ describe('shell module', () => {
         shell.spawnProcess('about to explode', []);
       }, /this is bat country/);
     });
-    if (process.platform === 'win32') {
-      it('on Windows, should spawn the command directly without cmd.exe', () => {
-        const fakeEnv = { HEY: 'yo' };
-        sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-        const fakeCmd = 'echo';
-        const fakeArgs = ['"hi there"'];
-        shell.spawnProcess(fakeCmd, fakeArgs);
-        sandbox.assert.calledWithMatch(
-          spawnSpy,
-          fakeCmd,
-          sinon.match.array.contains(fakeArgs),
-          sinon.match({ shell: false, env: fakeEnv }),
-        );
-      });
-    } else {
-      it('on non-Windows, should shell out to provided command directly', () => {
-        const fakeEnv = { HEY: 'yo' };
-        sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
-        const fakeCmd = 'echo';
-        const fakeArgs = ['"hi there"'];
-        shell.spawnProcess(fakeCmd, fakeArgs);
-        sandbox.assert.calledWithMatch(
-          spawnSpy,
-          fakeCmd,
-          sinon.match.array.contains(fakeArgs),
-          sinon.match({ shell: true, env: fakeEnv }),
-        );
-      });
-    }
+    it('should spawn the command directly without a shell', () => {
+      const fakeEnv = { HEY: 'yo' };
+      sandbox.stub(shell, 'assembleShellEnv').returns(fakeEnv);
+      const fakeCmd = 'echo';
+      const fakeArgs = ['"hi there"'];
+      shell.spawnProcess(fakeCmd, fakeArgs);
+      sandbox.assert.calledWithMatch(
+        spawnSpy,
+        fakeCmd,
+        sinon.match.array.contains(fakeArgs),
+        sinon.match({ shell: false, env: fakeEnv }),
+      );
+    });
   });
 
   describe('waitForOutput method', () => {

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -277,7 +277,7 @@ function getSpawnArguments(
     command,
     args,
     {
-      shell: true,
+      shell: false,
       env,
       ...shellOpts,
     },

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -251,7 +251,7 @@ export const shell = {
 };
 
 /**
- * @description Returns arguments used to pass into child_process.spawn or spawnSync. Handles Windows-specifics hacks.
+ * @description Returns arguments used to pass into child_process.spawn or spawnSync. Handles Windows-specifics.
  */
 function getSpawnArguments(
   command: string,
@@ -260,21 +260,14 @@ function getSpawnArguments(
   shellOpts?: Partial<child.SpawnOptionsWithoutStdio>,
 ): [string, string[], child.SpawnOptionsWithoutStdio] {
   if (process.platform === 'win32') {
-    // In windows, we actually spawn a command prompt and tell it to invoke the CLI command.
-    // The combination of windows and node's child_process spawning is complicated: on windows, child_process strips quotes from arguments. This makes passing JSON difficult.
-    // As a workaround, we:
-    // 1. Wrap the CLI command with a Windows Command Prompt (cmd.exe) process, and
-    // 2. Execute the command to completion (via the /c option), and
-    // 3. Leave spaces intact (via the /s option), and
-    // 4. Feed the arguments as an argument array into `child_process.spawn`.
-    // End-result is a process that looks like:
-    // cmd.exe "/s" "/c" "slack" "app" "list"
-    const windowsArgs = ['/s', '/c'].concat([command]).concat(args);
+    // Spawn the CLI binary directly without cmd.exe. Using cmd.exe or shell:true
+    // causes processes to hang in Windows Docker containers due to pipe handle
+    // inheritance from the Docker entrypoint.
     return [
-      'cmd',
-      windowsArgs,
+      command,
+      args,
       {
-        shell: true,
+        shell: false,
         env,
         ...shellOpts,
       },

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -252,6 +252,8 @@ export const shell = {
 
 /**
  * @description Returns arguments used to pass into child_process.spawn or spawnSync.
+ * On Windows, shell is set to false to avoid Docker pipe handle inheritance hangs.
+ * On other platforms, shell is set to true for compatibility with Go CLI flag parsing.
  */
 function getSpawnArguments(
   command: string,
@@ -259,13 +261,35 @@ function getSpawnArguments(
   env: ReturnType<typeof shell.assembleShellEnv>,
   shellOpts?: Partial<child.SpawnOptionsWithoutStdio>,
 ): [string, string[], child.SpawnOptionsWithoutStdio] {
+  if (process.platform === 'win32') {
+    return [
+      command,
+      args,
+      {
+        shell: false,
+        env,
+        ...shellOpts,
+      },
+    ];
+  }
+  // Shell-quote each argument to protect special characters (e.g. #) and spaces
   return [
     command,
-    args,
+    args.map(shellQuote),
     {
-      shell: false,
+      shell: true,
       env,
       ...shellOpts,
     },
   ];
+}
+
+/**
+ * @description Wraps a string in single quotes for safe shell interpolation.
+ * Single quotes prevent all shell interpretation; embedded single quotes are
+ * handled by ending the quoted segment, adding an escaped single quote, and
+ * restarting the quoted segment.
+ */
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -252,8 +252,6 @@ export const shell = {
 
 /**
  * @description Returns arguments used to pass into child_process.spawn or spawnSync.
- * On Windows, shell is set to false to avoid Docker pipe handle inheritance hangs.
- * On other platforms, shell is set to true for compatibility with Go CLI flag parsing.
  */
 function getSpawnArguments(
   command: string,
@@ -261,35 +259,13 @@ function getSpawnArguments(
   env: ReturnType<typeof shell.assembleShellEnv>,
   shellOpts?: Partial<child.SpawnOptionsWithoutStdio>,
 ): [string, string[], child.SpawnOptionsWithoutStdio] {
-  if (process.platform === 'win32') {
-    return [
-      command,
-      args,
-      {
-        shell: false,
-        env,
-        ...shellOpts,
-      },
-    ];
-  }
-  // Shell-quote each argument to protect special characters (e.g. #) and spaces
   return [
     command,
-    args.map(shellQuote),
+    args,
     {
-      shell: true,
+      shell: false,
       env,
       ...shellOpts,
     },
   ];
-}
-
-/**
- * @description Wraps a string in single quotes for safe shell interpolation.
- * Single quotes prevent all shell interpretation; embedded single quotes are
- * handled by ending the quoted segment, adding an escaped single quote, and
- * restarting the quoted segment.
- */
-function shellQuote(arg: string): string {
-  return `'${arg.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/cli-test/src/cli/shell.ts
+++ b/packages/cli-test/src/cli/shell.ts
@@ -251,7 +251,7 @@ export const shell = {
 };
 
 /**
- * @description Returns arguments used to pass into child_process.spawn or spawnSync. Handles Windows-specifics.
+ * @description Returns arguments used to pass into child_process.spawn or spawnSync.
  */
 function getSpawnArguments(
   command: string,
@@ -259,20 +259,6 @@ function getSpawnArguments(
   env: ReturnType<typeof shell.assembleShellEnv>,
   shellOpts?: Partial<child.SpawnOptionsWithoutStdio>,
 ): [string, string[], child.SpawnOptionsWithoutStdio] {
-  if (process.platform === 'win32') {
-    // Spawn the CLI binary directly without cmd.exe. Using cmd.exe or shell:true
-    // causes processes to hang in Windows Docker containers due to pipe handle
-    // inheritance from the Docker entrypoint.
-    return [
-      command,
-      args,
-      {
-        shell: false,
-        env,
-        ...shellOpts,
-      },
-    ];
-  }
   return [
     command,
     args,


### PR DESCRIPTION
### Summary

This PR changes how the `slack` process is spawned. Commands were routed through a shell either `/bin/sh` or as `cmd.exe /s /c` before invoking the provided command. Now `slack` commands are invoked direct.

This fixes:
- **Windows Docker hangs**: Child processes spawned before these changes inherited Docker's pipe handles which prevented the container from exiting.
- **Argument quoting complexity**: The old `cmd.exe /s /c` wrapper on Windows required `escapeJSON` to add outer quotes that cmd.exe would strip. With `shell: false`, `JSON.stringify` values pass through unchanged.
- **Shell interpretation on Linux**: `shell: true` on Linux causes `#` to be treated as a comment character, breaking values like `#/workflows/give_kudos_workflow`.

### Preview

Behind the scenes, this is what happens when spawning a command:

Linux:
```diff
- /bin/sh -c "slack trigger run --workflow #/workflows/give_kudos_workflow"
+ execvp("slack", ["trigger", "run", "--workflow", "#/workflows/give_kudos_workflow"])
```

Windows:
```diff
- cmd.exe /s /c "slack trigger run --workflow #/workflows/give_kudos_workflow"
+ CreateProcessW("slack", ["trigger", "run", "--workflow", "#/workflows/give_kudos_workflow"])
```

### Notes

📚 Reference: https://nodejs.org/api/child_process.html#child-processspawnsynccommand-args-options

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).