### PR TITLE
chore: add a clean script for maintainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "changeset": "npx @changesets/cli",
+    "clean": "git clean -xdf node_modules packages/**/node_modules && git clean -xf '**/package-lock.json'",
     "docs": "npm run docs --workspaces --if-present",
     "lint": "npx @biomejs/biome check packages",
     "lint:fix": "npx @biomejs/biome check --write packages",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "changeset": "npx @changesets/cli",
-    "clean": "git clean -xdf node_modules packages/**/node_modules && git clean -xf '**/package-lock.json'",
+    "clean": "npm run build:clean --workspaces --if-present && git clean -xdf node_modules packages/**/node_modules && git clean -xf '**/package-lock.json'",
     "docs": "npm run docs --workspaces --if-present",
     "lint": "npx @biomejs/biome check packages",
     "lint:fix": "npx @biomejs/biome check --write packages",


### PR DESCRIPTION
### Summary

These changes add a clean script for the project to clean up dependencies and package lock files, this allows for easier local development

- `git clean -xdf node_modules packages/**/node_modules` — recursively removes all node_modules directories (ignored or untracked), including the root one. The -d flag removes directories, -x includes gitignored files, -f forces.
- `git clean -xf '**/package-lock.json'` — removes any package-lock.json that is NOT tracked by git. Git-tracked files are never touched by git clean, so the root lock file stays.
 
### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
