### PR TITLE
feat(web-api): add highlight_type to files.completeUploadExternal and filesUploadV2

### DIFF
--- a/.changeset/deep-knives-tie.md
+++ b/.changeset/deep-knives-tie.md
@@ -1,5 +1,5 @@
 ---
-"@slack/web-api": patch
+"@slack/web-api": minor
 ---
 
 feat: add `highlight_type` to [`files.completeUploadExternal`](https://docs.slack.dev/reference/methods/files.completeUploadExternal) and [`filesUploadV2`](https://docs.slack.dev/tools/node-slack-sdk/web-api#upload-a-file) for optimistic rendering

--- a/.changeset/deep-knives-tie.md
+++ b/.changeset/deep-knives-tie.md
@@ -11,9 +11,9 @@ const client = new WebClient(process.env.SLACK_BOT_TOKEN);
 
 await client.filesUploadV2({
   channel_id: "C0123456789",
-  file: "app.js",
-  filename: "app.js",
-  title: "Example Snippet",
-  highlight_type: "javascript",
+  file: "./image.png",
+  filename: "image.png",
+  title: "Image Upload",
+  highlight_type: "png",
 });
 ```

--- a/.changeset/deep-knives-tie.md
+++ b/.changeset/deep-knives-tie.md
@@ -1,0 +1,19 @@
+---
+"@slack/web-api": patch
+---
+
+feat: add `highlight_type` to [`files.completeUploadExternal`](https://docs.slack.dev/reference/methods/files.completeUploadExternal) and [`filesUploadV2`](https://docs.slack.dev/tools/node-slack-sdk/web-api#upload-a-file) for optimistic rendering
+
+```js
+import { WebClient } from "@slack/web-api";
+
+const client = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+await client.filesUploadV2({
+  channel_id: "C0123456789",
+  file: "app.js",
+  filename: "app.js",
+  title: "Example Snippet",
+  highlight_type: "javascript",
+});
+```

--- a/packages/web-api/src/file-upload.test.ts
+++ b/packages/web-api/src/file-upload.test.ts
@@ -335,7 +335,7 @@ describe('file-upload', () => {
       assert.strictEqual(job.channel_id, 'C123');
       assert.strictEqual(job.thread_ts, '1.0');
       assert.strictEqual(job.initial_comment, 'Here is a snippet');
-      assert.strictEqual(job.highlight_type, 'python');
+      assert.strictEqual(job.files[0].highlight_type, 'python');
       assert.deepStrictEqual(job.blocks, fileUploadJob1.blocks);
     });
     describe('when channel_id is the same', () => {

--- a/packages/web-api/src/file-upload.test.ts
+++ b/packages/web-api/src/file-upload.test.ts
@@ -316,6 +316,28 @@ describe('file-upload', () => {
     });
   });
   describe('getAllFileUploadsToComplete', () => {
+    it('should pass all expected properties through to the completion job', () => {
+      const fileUploadJob1 = {
+        file: Buffer.from('test'),
+        filename: 'test.py',
+        file_id: 'id1',
+        title: 'test1',
+        channel_id: 'C123',
+        thread_ts: '1.0',
+        initial_comment: 'Here is a snippet',
+        highlight_type: 'python',
+        blocks: [{ type: 'section', text: { type: 'plain_text', text: 'hello' } }],
+      };
+      const toComplete = getAllFileUploadsToComplete([fileUploadJob1]);
+      const job = Object.values(toComplete)[0];
+      assert.strictEqual(job.files[0].id, 'id1');
+      assert.strictEqual(job.files[0].title, 'test1');
+      assert.strictEqual(job.channel_id, 'C123');
+      assert.strictEqual(job.thread_ts, '1.0');
+      assert.strictEqual(job.initial_comment, 'Here is a snippet');
+      assert.strictEqual(job.highlight_type, 'python');
+      assert.deepStrictEqual(job.blocks, fileUploadJob1.blocks);
+    });
     describe('when channel_id is the same', () => {
       it('should group uploads with matching thread_ts and initial_comment together', () => {
         const fileUploadJob1 = {

--- a/packages/web-api/src/file-upload.test.ts
+++ b/packages/web-api/src/file-upload.test.ts
@@ -319,13 +319,13 @@ describe('file-upload', () => {
     it('should pass all expected properties through to the completion job', () => {
       const fileUploadJob1 = {
         file: Buffer.from('test'),
-        filename: 'test.py',
+        filename: 'image.png',
         file_id: 'id1',
         title: 'test1',
         channel_id: 'C123',
         thread_ts: '1.0',
-        initial_comment: 'Here is a snippet',
-        highlight_type: 'python',
+        initial_comment: 'Here is an image',
+        highlight_type: 'png',
         blocks: [{ type: 'section', text: { type: 'plain_text', text: 'hello' } }],
       };
       const toComplete = getAllFileUploadsToComplete([fileUploadJob1]);
@@ -334,8 +334,8 @@ describe('file-upload', () => {
       assert.strictEqual(job.files[0].title, 'test1');
       assert.strictEqual(job.channel_id, 'C123');
       assert.strictEqual(job.thread_ts, '1.0');
-      assert.strictEqual(job.initial_comment, 'Here is a snippet');
-      assert.strictEqual(job.files[0].highlight_type, 'python');
+      assert.strictEqual(job.initial_comment, 'Here is an image');
+      assert.strictEqual(job.files[0].highlight_type, 'png');
       assert.deepStrictEqual(job.blocks, fileUploadJob1.blocks);
     });
     describe('when channel_id is the same', () => {

--- a/packages/web-api/src/file-upload.ts
+++ b/packages/web-api/src/file-upload.ts
@@ -30,6 +30,7 @@ export async function getFileUploadJob(
     blocks: options.blocks,
     channel_id: options.channels ?? options.channel_id,
     filename: options.filename ?? fileName,
+    highlight_type: options.highlight_type,
     initial_comment: options.initial_comment,
     snippet_type: options.snippet_type,
     title: options.title ?? options.filename ?? fileName, // default title to filename unless otherwise specified
@@ -234,7 +235,7 @@ export function getAllFileUploadsToComplete(
 ): Record<string, FilesCompleteUploadExternalArguments> {
   const toComplete: Record<string, FilesCompleteUploadExternalArguments> = {};
   for (const upload of fileUploads) {
-    const { blocks, channel_id, thread_ts, initial_comment, file_id, title } = upload;
+    const { blocks, channel_id, thread_ts, highlight_type, initial_comment, file_id, title } = upload;
     if (file_id) {
       const compareString = `:::${channel_id}:::${thread_ts}:::${initial_comment}:::${JSON.stringify(blocks)}`;
       // biome-ignore lint/suspicious/noPrototypeBuiltins: TODO use hasOwn instead of hasOwnProperty
@@ -243,6 +244,7 @@ export function getAllFileUploadsToComplete(
           files: [{ id: file_id, title }],
           channel_id,
           blocks,
+          highlight_type,
           initial_comment,
         };
         if (thread_ts && channel_id) {

--- a/packages/web-api/src/file-upload.ts
+++ b/packages/web-api/src/file-upload.ts
@@ -241,10 +241,9 @@ export function getAllFileUploadsToComplete(
       // biome-ignore lint/suspicious/noPrototypeBuiltins: TODO use hasOwn instead of hasOwnProperty
       if (!Object.prototype.hasOwnProperty.call(toComplete, compareString)) {
         toComplete[compareString] = {
-          files: [{ id: file_id, title }],
+          files: [{ id: file_id, title, highlight_type }],
           channel_id,
           blocks,
-          highlight_type,
           initial_comment,
         };
         if (thread_ts && channel_id) {
@@ -264,6 +263,7 @@ export function getAllFileUploadsToComplete(
         toComplete[compareString].files.push({
           id: file_id,
           title,
+          highlight_type,
         });
       }
     } else {

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -72,7 +72,7 @@ export type FilesCompleteUploadExternalArguments = FileDestinationArgument &
     files: [FileUploadComplete, ...FileUploadComplete[]];
     /**
      * @description Syntax type of the snippet being uploaded. E.g. `python`.
-     * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal#arg_highlight_type}
+     * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal}
      */
     highlight_type?: string;
     /** @description The message text introducing the file in the specified channel. */
@@ -175,7 +175,7 @@ export type FileUploadV2 = FileUpload & {
   channels?: string;
   /**
    * @description Syntax type of the snippet being uploaded. E.g. `python`.
-   * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal#arg_highlight_type}
+   * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal}
    */
   highlight_type?: string;
   /** @description Syntax type of the snippet being uploaded. E.g. `python`. */

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -34,6 +34,11 @@ export interface FileType {
 export interface FileUploadComplete {
   /** @description Encoded file ID. */
   id: string;
+  /**
+   * @description Optional highlight type hint for the file. The upload processing job may overwrite this value.
+   * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal}
+   */
+  highlight_type?: string;
   /** @description File title. */
   title?: string;
 }
@@ -70,11 +75,6 @@ export type FilesCompleteUploadExternalArguments = FileDestinationArgument &
      * @example [{"id":"F044GKUHN9Z", "title":"slack-test"}]
      **/
     files: [FileUploadComplete, ...FileUploadComplete[]];
-    /**
-     * @description Syntax type of the snippet being uploaded. E.g. `python`.
-     * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal}
-     */
-    highlight_type?: string;
     /** @description The message text introducing the file in the specified channel. */
     initial_comment?: string;
     /**

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -70,6 +70,11 @@ export type FilesCompleteUploadExternalArguments = FileDestinationArgument &
      * @example [{"id":"F044GKUHN9Z", "title":"slack-test"}]
      **/
     files: [FileUploadComplete, ...FileUploadComplete[]];
+    /**
+     * @description Syntax type of the snippet being uploaded. E.g. `python`.
+     * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal#arg_highlight_type}
+     */
+    highlight_type?: string;
     /** @description The message text introducing the file in the specified channel. */
     initial_comment?: string;
     /**
@@ -168,6 +173,11 @@ export type FileUploadV2 = FileUpload & {
   channel_id?: string;
   /** @deprecated use channel_id instead */
   channels?: string;
+  /**
+   * @description Syntax type of the snippet being uploaded. E.g. `python`.
+   * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal#arg_highlight_type}
+   */
+  highlight_type?: string;
   /** @description Syntax type of the snippet being uploaded. E.g. `python`. */
   snippet_type?: string;
 };

--- a/packages/web-api/src/types/request/files.ts
+++ b/packages/web-api/src/types/request/files.ts
@@ -174,7 +174,7 @@ export type FileUploadV2 = FileUpload & {
   /** @deprecated use channel_id instead */
   channels?: string;
   /**
-   * @description Syntax type of the snippet being uploaded. E.g. `python`.
+   * @description Optional highlight type hint for the file. The upload processing job may overwrite this value.
    * @see {@link https://docs.slack.dev/reference/methods/files.completeUploadExternal}
    */
   highlight_type?: string;


### PR DESCRIPTION
### Summary

This pull request adds `highlight_type` support to `files.completeUploadExternal` and the `filesUploadV2` method.

The `highlight_type` parameter allows specifying the file type hint for uploads (e.g. `png`, `jpg`, `gif`), enabling optimistic rendering before the async upload processing job completes.

📚 https://docs.slack.dev/reference/methods/files.completeUploadExternal/

#### Changes

- Added `highlight_type` to the `FileUploadComplete` interface (per-file in the `files` array)
- Added `highlight_type` to `FileUploadV2` so it can be specified when using `filesUploadV2`
- Updated `getAllFileUploadsToComplete` to pass `highlight_type` through to each file object

#### Usage

```javascript
import { LogLevel, WebClient } from '@slack/web-api';

const client = new WebClient(process.env.SLACK_BOT_TOKEN, { logLevel: LogLevel.DEBUG });

await client.filesUploadV2({
  channel_id: 'C0123456789',
  file: './image.png',
  filename: 'image.png',
  title: 'Image Upload',
  highlight_type: 'png',
  initial_comment: 'Uploaded with highlight_type for optimistic rendering',
});
```

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).