### PR TITLE
Fix Slack Lists message field response types

### DIFF
--- a/.changeset/slack-lists-message-fields.md
+++ b/.changeset/slack-lists-message-fields.md
@@ -1,0 +1,5 @@
+---
+"@slack/web-api": patch
+---
+
+Correct Slack Lists item message field response typing to accept single and multiple message objects.

--- a/packages/web-api/src/types/request/slackLists.ts
+++ b/packages/web-api/src/types/request/slackLists.ts
@@ -66,6 +66,25 @@ export interface SlackListsItemFieldMessage {
 }
 
 /**
+ * @description Message field value returned for Slack Lists items.
+ */
+export interface SlackListsItemMessage {
+  text?: string;
+  ts?: string;
+  user?: string;
+  team?: string;
+  type?: string;
+}
+
+/**
+ * @description Message field returned for Slack Lists items.
+ */
+export interface SlackListsItemFieldMessageResponse {
+  column_id: string;
+  message: SlackListsItemMessage | SlackListsItemMessage[];
+}
+
+/**
  * @description Number field with numeric values.
  */
 export interface SlackListsItemFieldNumber {
@@ -154,6 +173,26 @@ export type SlackListsItemField =
   | SlackListsItemFieldUser;
 
 /**
+ * @description Union type of all possible Slack Lists item field types returned by the API.
+ */
+export type SlackListsItemResponseField =
+  | SlackListsItemFieldAttachment
+  | SlackListsItemFieldChannel
+  | SlackListsItemFieldCheckbox
+  | SlackListsItemFieldDate
+  | SlackListsItemFieldEmail
+  | SlackListsItemFieldLink
+  | SlackListsItemFieldMessageResponse
+  | SlackListsItemFieldNumber
+  | SlackListsItemFieldPhone
+  | SlackListsItemFieldRating
+  | SlackListsItemFieldReference
+  | SlackListsItemFieldRichText
+  | SlackListsItemFieldSelect
+  | SlackListsItemFieldTimestamp
+  | SlackListsItemFieldUser;
+
+/**
  * @description Slack Lists item structure.
  */
 export interface SlackListsItem {
@@ -180,7 +219,7 @@ export interface SlackListsItem {
   /**
    * @description Array of field data for this item.
    */
-  fields: SlackListsItemField[];
+  fields: SlackListsItemResponseField[];
   /**
    * @description String representation of the last update timestamp.
    */

--- a/packages/web-api/test/types/methods/slacklists.test-d.ts
+++ b/packages/web-api/test/types/methods/slacklists.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
-
+import type { SlackListsItemsListResponse } from '../../../src/types/response/SlackListsItemsListResponse';
 import { WebClient } from '../../../src/WebClient';
 
 const web = new WebClient('TOKEN');
@@ -77,8 +77,15 @@ expectError(web.slackLists.items.create({})); // missing list_id
 expectAssignable<Parameters<typeof web.slackLists.items.create>>([
   {
     list_id: 'L1234567890',
+    initial_fields: [{ column_id: 'Col1234567890', message: ['https://example.slack.com/archives/C123/p123'] }],
   },
 ]);
+expectError(
+  web.slackLists.items.create({
+    list_id: 'L1234567890',
+    initial_fields: [{ column_id: 'Col1234567890', message: { text: 'message objects are only returned by the API' } }],
+  }),
+);
 
 // slackLists.items.delete
 // -- sad path
@@ -159,3 +166,28 @@ expectAssignable<Parameters<typeof web.slackLists.update>>([
     id: 'L1234567890',
   },
 ]);
+
+// slackLists.items.list response fields
+expectAssignable<SlackListsItemsListResponse>({
+  ok: true,
+  items: [
+    {
+      id: 'Rec014K005UQJ',
+      list_id: 'L1234567890',
+      date_created: 1710000000,
+      created_by: 'U01284PCR98',
+      updated_by: 'U01284PCR98',
+      fields: [{ column_id: 'Col014K005UQJ', message: { text: 'hello', ts: '123.456', user: 'U01284PCR98' } }],
+      updated_timestamp: '1710000000.000000',
+    },
+    {
+      id: 'Rec014K005UQK',
+      list_id: 'L1234567890',
+      date_created: 1710000001,
+      created_by: 'U01284PCR98',
+      updated_by: 'U01284PCR98',
+      fields: [{ column_id: 'Col014K005UQJ', message: [{ text: 'first' }, { text: 'second', ts: '123.457' }] }],
+      updated_timestamp: '1710000001.000000',
+    },
+  ],
+});


### PR DESCRIPTION
### Summary

Fixes #2598.

Slack Lists response items reuse the same field type family as request fields. Request message fields should keep accepting message URL strings, but response items can expose `message` as either a single Slack message object or an array of message objects.

This change adds a response-specific Slack Lists field union so `SlackListsItem.fields` accepts both response shapes while `SlackListsItemsCreateArguments.initial_fields` still rejects message objects for request input.

Added tsd coverage for:

- request `message` fields accepting message URL strings
- request `message` fields rejecting message objects
- `SlackListsItemsListResponse` accepting a single message object
- `SlackListsItemsListResponse` accepting an array of message objects

Validation:

- `npx @biomejs/biome check packages/web-api/src/types/request/slackLists.ts packages/web-api/test/types/methods/slacklists.test-d.ts`
- `npm run build --workspace=packages/web-api`
- `npm run test:types --workspace=packages/web-api`
- `node --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts` from `packages/web-api` under Windows Node: 154 tests passed
- `git diff --check` passed with local CRLF warnings only
- `gitleaks detect --pipe --redact --verbose --no-color` on the staged diff: no leaks found

Limitation:

- `npm test --workspace=packages/web-api` builds successfully, then fails in this Windows checkout because the script's `bash -c` invocation runs under WSL/Linux Node against Windows-installed esbuild binaries. I ran the equivalent package node tests directly under Windows Node instead.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
