### PR TITLE
fix(cli-hooks): use correct bolt-js release notes tag format

### DIFF
--- a/.changeset/stale-dolls-shave.md
+++ b/.changeset/stale-dolls-shave.md
@@ -1,0 +1,5 @@
+---
+"@slack/cli-hooks": patch
+---
+
+fix: use correct bolt-js release notes tag format

--- a/packages/cli-hooks/src/check-update.js
+++ b/packages/cli-hooks/src/check-update.js
@@ -216,7 +216,7 @@ async function fetchLatestPackageVersion(packageName) {
  */
 function getReleaseNotesUrl(packageName, latestVersion) {
   if (packageName === SLACK_BOLT_SDK) {
-    return `https://github.com/slackapi/bolt-js/releases/tag/@slack/bolt@${latestVersion}`;
+    return `https://github.com/slackapi/bolt-js/releases/tag/v${latestVersion}`;
   }
   if (packageName === SLACK_CLI_HOOKS) {
     return `https://github.com/slackapi/node-slack-sdk/releases/tag/@slack/cli-hooks@${latestVersion}`;

--- a/packages/cli-hooks/src/check-update.test.js
+++ b/packages/cli-hooks/src/check-update.test.js
@@ -72,13 +72,13 @@ describe('check-update implementation', async () => {
         releases: [
           {
             name: '@slack/bolt',
-            current: '3.0.0',
-            latest: '3.1.4',
+            current: '4.0.0',
+            latest: '4.7.2',
             error: undefined,
             update: true,
             message: undefined,
             breaking: false,
-            url: 'https://github.com/slackapi/bolt-js/releases/tag/v3.1.4',
+            url: 'https://github.com/slackapi/bolt-js/releases/tag/v',
           },
           {
             name: '@slack/cli-hooks',

--- a/packages/cli-hooks/src/check-update.test.js
+++ b/packages/cli-hooks/src/check-update.test.js
@@ -78,7 +78,7 @@ describe('check-update implementation', async () => {
             update: true,
             message: undefined,
             breaking: false,
-            url: 'https://github.com/slackapi/bolt-js/releases/tag/v',
+            url: 'https://github.com/slackapi/bolt-js/releases/tag/v4.7.2',
           },
           {
             name: '@slack/cli-hooks',

--- a/packages/cli-hooks/src/check-update.test.js
+++ b/packages/cli-hooks/src/check-update.test.js
@@ -78,7 +78,7 @@ describe('check-update implementation', async () => {
             update: true,
             message: undefined,
             breaking: false,
-            url: 'https://github.com/slackapi/bolt-js/releases/tag/@slack/bolt@3.1.4',
+            url: 'https://github.com/slackapi/bolt-js/releases/tag/v3.1.4',
           },
           {
             name: '@slack/cli-hooks',

--- a/packages/cli-hooks/src/check-update.test.js
+++ b/packages/cli-hooks/src/check-update.test.js
@@ -18,7 +18,7 @@ import checkForSDKUpdates, {
 const packageJSON = {
   name: 'Example application',
   dependencies: {
-    '@slack/bolt': '^3.0.0',
+    '@slack/bolt': '^4.0.0',
   },
   devDependencies: {
     '@slack/cli-hooks': '^0.0.1',
@@ -32,13 +32,13 @@ const packageJSON = {
  */
 function mockNPM(command) {
   if (command === 'npm info @slack/bolt version --tag latest') {
-    return '3.1.4';
+    return '4.7.2';
   }
   if (command === 'npm info @slack/cli-hooks version --tag latest') {
     return '1.0.1';
   }
   if (command === 'npm list @slack/bolt --depth=0 --json') {
-    return '{"dependencies":{"@slack/bolt":{"version":"3.0.0"}}}';
+    return '{"dependencies":{"@slack/bolt":{"version":"4.0.0"}}}';
   }
   if (command === 'npm list @slack/cli-hooks --depth=0 --json') {
     return '{"dependencies":{"@slack/cli-hooks":{"version":"0.0.1"}}}';


### PR DESCRIPTION
### Summary

This pull request fixes the release notes URL for `@slack/bolt` in the check-update hook. The bolt-js repository changed its release tag format from `@slack/bolt@x.y.z` to `vx.y.z`, so the generated URL was pointing to non-existent release pages.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).