### PR TITLE
chore: extract build script and expand socket-mode test coverage

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,23 +46,7 @@ jobs:
       - name: Install dependencies
         run: npm ci --verbose
       - name: Build packages
-        run: |
-          # Build packages without internal dependencies
-          npm run build --workspace=@slack/cli-hooks
-          npm run build --workspace=@slack/cli-test
-
-          # Build base dependencies
-          npm run build --workspace=@slack/logger
-          npm run build --workspace=@slack/types
-
-          # Build packages requiring base dependencies
-          npm run build --workspace=@slack/web-api
-          npm run build --workspace=@slack/webhook
-
-          # Build packages that depend on the Web API
-          npm run build --workspace=@slack/oauth
-          npm run build --workspace=@slack/rtm-api
-          npm run build --workspace=@slack/socket-mode
+        run: npm run build
       - name: Lint
         run: npm run lint
       - name: Build docs

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "packages/webhook"
   ],
   "scripts": {
+    "build": "bash scripts/build.sh",
     "changeset": "npx @changesets/cli",
     "clean": "npm run build:clean --workspaces --if-present && git clean -xdf node_modules packages/**/node_modules && git clean -xf '**/package-lock.json'",
     "docs": "npm run docs --workspaces --if-present",

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -44,8 +44,8 @@
     "docs": "npx typedoc --plugin typedoc-plugin-markdown",
     "prepack": "npm run build",
     "test": "npm run test:unit && npm run test:integration",
-    "test:coverage": "npm run build && node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts",
-    "test:integration": "npm run build && node --import tsx --test test/integration.test.js",
+    "test:coverage": "npm run build && node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts test/integrations/*.test.js",
+    "test:integration": "npm run build && node --import tsx --test test/integration.test.js test/integrations/*.test.js",
     "test:unit": "npm run build && bash -c 'node --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts'",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm test"
   },

--- a/packages/socket-mode/package.json
+++ b/packages/socket-mode/package.json
@@ -44,8 +44,8 @@
     "docs": "npx typedoc --plugin typedoc-plugin-markdown",
     "prepack": "npm run build",
     "test": "npm run test:unit && npm run test:integration",
-    "test:coverage": "npm run build && node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts test/integrations/*.test.js",
-    "test:integration": "npm run build && node --import tsx --test test/integration.test.js test/integrations/*.test.js",
+    "test:coverage": "npm run build && node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts test/integration.test.js",
+    "test:integration": "npm run build && node --import tsx --test test/integration.test.js",
     "test:unit": "npm run build && bash -c 'node --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts'",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm test"
   },

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Build packages without internal dependencies
+npm run build --workspace=packages/cli-hooks
+npm run build --workspace=packages/cli-test
+
+# Build base dependencies
+npm run build --workspace=packages/logger
+npm run build --workspace=packages/types
+
+# Build packages requiring base dependencies
+npm run build --workspace=packages/web-api
+npm run build --workspace=packages/webhook
+
+# Build packages that depend on the Web API
+npm run build --workspace=packages/oauth
+npm run build --workspace=packages/rtm-api
+npm run build --workspace=packages/socket-mode


### PR DESCRIPTION
## Summary
  - Extract the ordered workspace build steps from the CI workflow into a reusable `scripts/build.sh`, exposed as `npm run build` at the repo root
  - Include integration tests (`test/integrations/*.test.js`) in socket-mode's `test:coverage` and `test:integration` scripts so coverage reporting captures the full test suite

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
