### PR TITLE
feat(web-api): expose public ts property on ChatStream

### DIFF
--- a/.changeset/expose-ts-on-chat-streamer.md
+++ b/.changeset/expose-ts-on-chat-streamer.md
@@ -1,0 +1,24 @@
+---
+"@slack/web-api": minor
+---
+
+feat: expose public read-only `ts` getter on `ChatStreamer` for fallback to [`chat.update`](https://docs.slack.dev/reference/methods/chat.update) when a stream expires server-side
+
+```js
+import { WebClient } from "@slack/web-api";
+
+const client = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+const streamer = client.chatStream({
+  channel: "C0123456789",
+  thread_ts: "1700000001.123456",
+  recipient_team_id: "T0123456789",
+  recipient_user_id: "U0123456789",
+});
+
+await streamer.append({ markdown_text: "hello!" });
+// streamer.ts is now set after the first flush
+console.log(streamer.ts);
+
+await streamer.stop();
+```

--- a/packages/web-api/src/WebClient.test.ts
+++ b/packages/web-api/src/WebClient.test.ts
@@ -1295,6 +1295,34 @@ describe('WebClient', () => {
       scope.done();
     });
 
+    it('ts is undefined before flush and set after', async () => {
+      const scope = nock('https://slack.com')
+        .post('/api/chat.startStream')
+        .reply(200, {
+          ok: true,
+          ts: '123.123',
+        })
+        .post('/api/chat.stopStream')
+        .reply(200, {
+          ok: true,
+        });
+      const streamer = client.chatStream({
+        buffer_size: 5,
+        channel: 'C0123456789',
+        thread_ts: '123.000',
+        recipient_team_id: 'T0123456789',
+        recipient_user_id: 'U0123456789',
+      });
+      assert.strictEqual(streamer.ts, undefined);
+
+      await streamer.append({ markdown_text: 'hello!' });
+      assert.strictEqual(streamer.ts, '123.123');
+
+      await streamer.stop();
+      assert.strictEqual(streamer.ts, '123.123');
+      scope.done();
+    });
+
     it('streams a long message', async () => {
       const contextActionsBlock: ContextActionsBlock = {
         type: 'context_actions',

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -55,6 +55,16 @@ export class ChatStreamer {
   }
 
   /**
+   * @description The message timestamp of the stream. Returns `undefined` until the first flush
+   * (when `chat.startStream` is called). Can be used with `chat.update` as a fallback if the
+   * stream expires server-side.
+   * @see {@link https://docs.slack.dev/reference/methods/chat.update}
+   */
+  get ts(): string | undefined {
+    return this.streamTs;
+  }
+
+  /**
    * Append to the stream.
    *
    * @description The "append" method appends to the chat stream being used. This method can be called multiple times. After the stream is stopped this method cannot be called.

--- a/packages/web-api/src/chat-stream.ts
+++ b/packages/web-api/src/chat-stream.ts
@@ -56,8 +56,7 @@ export class ChatStreamer {
 
   /**
    * @description The message timestamp of the stream. Returns `undefined` until the first flush
-   * (when `chat.startStream` is called). Can be used with `chat.update` as a fallback if the
-   * stream expires server-side.
+   * (when `chat.startStream` is called).
    * @see {@link https://docs.slack.dev/reference/methods/chat.update}
    */
   get ts(): string | undefined {


### PR DESCRIPTION
### Summary
This PR adds a public read-only ts getter to ChatStreamer, enabling users to call chat.update as a fallback when the server closes a stream due to undocumented timeouts.

### Background

When Slack's server-side timeout kills a stream, both `chat.appendStream` and `chat.stopStream` return `message_not_in_streaming_state`. The message still exists but is stuck as a broken pill in the UI. The only recovery path is `chat.update({ ts: ... })`, but `ts` was previously a private field (`streamTs`).

### Changes
- `packages/web-api/src/chat-stream.ts`: Added `ts` getter (read-only, returns `string | undefined`)
- `packages/web-api/src/WebClient.test.ts`: Added test verifying `ts` is undefined before flush and set after
  
 
<details><summary> code snippet </summary>


```js
  import { WebClient } from '@slack/web-api';

  const client = new WebClient(token);

  async function sendStreaming(channel: string, threadTs: string, teamId: string, userId: string, 
  chunks: AsyncIterable<string>) {
    const streamer = client.chatStream({
      channel,
      thread_ts: threadTs,
      recipient_team_id: teamId,
      recipient_user_id: userId,
    });

    let fullText = '';
    let streamAlive = true;

    for await (const chunk of chunks) {
      fullText += chunk;

      if (streamAlive) {
        try {
          await streamer.append({ markdown_text: chunk });
        } catch (error) {
          if (error.data?.error === 'message_not_in_streaming_state') {
            streamAlive = false;
          } else {
            throw error;
          }
        }
      }

      if (!streamAlive) {
        await client.chat.update({ channel, ts: streamer.ts, text: fullText });
      }
    }

    if (streamAlive) {
      await streamer.stop();
    } else {
      await client.chat.update({ channel, ts: streamer.ts, text: fullText });
    }
  }
```


</details>



### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
