### PR TITLE
fix(cli-test)!: remove default "--app deployed" global flag from commands

### DIFF
--- a/.changeset/silver-papers-lick.md
+++ b/.changeset/silver-papers-lick.md
@@ -1,5 +1,5 @@
 ---
-"@slack/cli-test": patch
+"@slack/cli-test": major
 ---
 
 fix: remove default --app global flag from create command tests

--- a/.changeset/silver-papers-lick.md
+++ b/.changeset/silver-papers-lick.md
@@ -1,0 +1,5 @@
+---
+"@slack/cli-test": patch
+---
+
+fix: remove default --app global flag from create command tests

--- a/.changeset/silver-papers-lick.md
+++ b/.changeset/silver-papers-lick.md
@@ -2,4 +2,16 @@
 "@slack/cli-test": major
 ---
 
-fix: remove default --app global flag from create command tests
+fix: remove default "--app deployed" global flag from commands
+
+Commands running for a specific app must now provide the "app" argument:
+
+```diff
+  await SlackCLI.app.delete({
+    appPath: "my-app",
+    team: "T0123456789",
++   app: "deployed",
+  });
+```
+
+The options "local" or "deployed" or app ID all remain available to use.

--- a/packages/cli-test/src/cli/cli-process.test.ts
+++ b/packages/cli-test/src/cli/cli-process.test.ts
@@ -98,18 +98,22 @@ describe('SlackCLIProcess class', () => {
         await cmd.execAsync();
         sandbox.assert.calledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--skip-update']));
       });
-      it('should default to `--app deployed` but allow overriding that via the `app` parameter', async () => {
+      it('should only pass `--app` when explicitly provided via the `app` parameter', async () => {
         let cmd = new SlackCLIProcess(['help']);
         await cmd.execAsync();
-        sandbox.assert.calledWith(
+        sandbox.assert.neverCalledWith(
           spawnProcessSpy,
           sinon.match.string,
-          sinon.match.array.contains(['--app', 'deployed']),
+          sinon.match.array.contains(['--app']),
         );
         spawnProcessSpy.resetHistory();
         cmd = new SlackCLIProcess(['help'], { app: 'local' });
         await cmd.execAsync();
         sandbox.assert.calledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--app', 'local']));
+        spawnProcessSpy.resetHistory();
+        cmd = new SlackCLIProcess(['help'], { app: 'deployed' });
+        await cmd.execAsync();
+        sandbox.assert.calledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--app', 'deployed']));
       });
       it('should default to `--force` but allow overriding that via the `force` parameter', async () => {
         let cmd = new SlackCLIProcess(['help']);

--- a/packages/cli-test/src/cli/cli-process.test.ts
+++ b/packages/cli-test/src/cli/cli-process.test.ts
@@ -101,11 +101,7 @@ describe('SlackCLIProcess class', () => {
       it('should only pass `--app` when explicitly provided via the `app` parameter', async () => {
         let cmd = new SlackCLIProcess(['help']);
         await cmd.execAsync();
-        sandbox.assert.neverCalledWith(
-          spawnProcessSpy,
-          sinon.match.string,
-          sinon.match.array.contains(['--app']),
-        );
+        sandbox.assert.neverCalledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--app']));
         spawnProcessSpy.resetHistory();
         cmd = new SlackCLIProcess(['help'], { app: 'local' });
         await cmd.execAsync();
@@ -113,7 +109,11 @@ describe('SlackCLIProcess class', () => {
         spawnProcessSpy.resetHistory();
         cmd = new SlackCLIProcess(['help'], { app: 'deployed' });
         await cmd.execAsync();
-        sandbox.assert.calledWith(spawnProcessSpy, sinon.match.string, sinon.match.array.contains(['--app', 'deployed']));
+        sandbox.assert.calledWith(
+          spawnProcessSpy,
+          sinon.match.string,
+          sinon.match.array.contains(['--app', 'deployed']),
+        );
       });
       it('should default to `--force` but allow overriding that via the `force` parameter', async () => {
         let cmd = new SlackCLIProcess(['help']);

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -131,13 +131,9 @@ export class SlackCLIProcess {
       if (opts.team) {
         cmd = cmd.concat(['--team', opts.team]);
       }
-      // App instance; defaults to `deployed` - TODO(semver:major): remove fallback to "deployed" app
-      if (this.command[0] !== 'create') {
-        if (opts.app) {
-          cmd = cmd.concat(['--app', opts.app]);
-        } else {
-          cmd = cmd.concat(['--app', 'deployed']);
-        }
+      // App instance - TODO(semver:major): remove fallback to "deployed" app
+      if (opts.app) {
+        cmd = cmd.concat(['--app', opts.app]);
       }
       // Ignore warnings via --force; defaults to true
       if (opts.force || typeof opts.force === 'undefined') {
@@ -152,9 +148,6 @@ export class SlackCLIProcess {
       }
     } else {
       cmd = cmd.concat(['--skip-update', '--force']);
-      if (this.command[0] !== 'create') {
-        cmd = cmd.concat(['--app', 'deployed']);
-      }
     }
     cmd = cmd.concat(this.command);
 

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -131,7 +131,7 @@ export class SlackCLIProcess {
       if (opts.team) {
         cmd = cmd.concat(['--team', opts.team]);
       }
-      // App instance; defaults to `deployed`
+      // App instance; defaults to `deployed` - TODO(semver:major): remove fallback to "deployed" app
       if (this.command[0] !== 'create') {
         if (opts.app) {
           cmd = cmd.concat(['--app', opts.app]);

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -131,7 +131,7 @@ export class SlackCLIProcess {
       if (opts.team) {
         cmd = cmd.concat(['--team', opts.team]);
       }
-      // App instance - TODO(semver:major): remove fallback to "deployed" app
+      // App instance
       if (opts.app) {
         cmd = cmd.concat(['--app', opts.app]);
       }

--- a/packages/cli-test/src/cli/cli-process.ts
+++ b/packages/cli-test/src/cli/cli-process.ts
@@ -132,10 +132,12 @@ export class SlackCLIProcess {
         cmd = cmd.concat(['--team', opts.team]);
       }
       // App instance; defaults to `deployed`
-      if (opts.app) {
-        cmd = cmd.concat(['--app', opts.app]);
-      } else {
-        cmd = cmd.concat(['--app', 'deployed']);
+      if (this.command[0] !== 'create') {
+        if (opts.app) {
+          cmd = cmd.concat(['--app', opts.app]);
+        } else {
+          cmd = cmd.concat(['--app', 'deployed']);
+        }
       }
       // Ignore warnings via --force; defaults to true
       if (opts.force || typeof opts.force === 'undefined') {
@@ -149,9 +151,13 @@ export class SlackCLIProcess {
         cmd = cmd.concat(['--verbose']);
       }
     } else {
-      cmd = cmd.concat(['--skip-update', '--force', '--app', 'deployed']);
+      cmd = cmd.concat(['--skip-update', '--force']);
+      if (this.command[0] !== 'create') {
+        cmd = cmd.concat(['--app', 'deployed']);
+      }
     }
     cmd = cmd.concat(this.command);
+
     if (this.commandOptions) {
       for (const [key, value] of Object.entries(this.commandOptions)) {
         if (key && value) {


### PR DESCRIPTION
### Summary

Skip passing a default `--app deployed` flag to commands.

### Notes

- CLI commit [c9f5bb](http://github.com/slackapi/slack-cli/pull/565/changes/c9f5bbf6706c4b3aab17f2b5bcdb6e43f07e9877) in [PR 565](http://github.com/slackapi/slack-cli/pull/565) motivates this change after introducing validation that rejects non-app-ID values (`local, deployed`) when using `--app` with `create`.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
