### PR TITLE
fix: update SlackListsItemFieldMessage to support single and array message shapes

### DIFF
--- a/.changeset/great-seas-swim.md
+++ b/.changeset/great-seas-swim.md
@@ -1,5 +1,5 @@
 ---
-"@slack/web-api": major
+"@slack/web-api": patch
 ---
 
 fix: update SlackListsItemFieldMessage to support single and array message shapes

--- a/.changeset/great-seas-swim.md
+++ b/.changeset/great-seas-swim.md
@@ -1,0 +1,5 @@
+---
+"@slack/web-api": major
+---
+
+fix: update SlackListsItemFieldMessage to support single and array message shapes

--- a/packages/web-api/src/types/request/slackLists.ts
+++ b/packages/web-api/src/types/request/slackLists.ts
@@ -58,11 +58,23 @@ export interface SlackListsItemFieldLink {
 }
 
 /**
- * @description Message field with message URLs.
+ * @description A single message object returned by the Slack API.
+ */
+export interface SlackListsItemMessage {
+  text?: string;
+  ts?: string;
+  user?: string;
+  team?: string;
+  type?: string;
+}
+
+/**
+ * @description Message field. The API may return either a single message object
+ * or an array of message objects.
  */
 export interface SlackListsItemFieldMessage {
   column_id: string;
-  message: string[];
+  message: SlackListsItemMessage | SlackListsItemMessage[];
 }
 
 /**


### PR DESCRIPTION
Fixes #2598

## Problem
`SlackListsItemFieldMessage` typed the `message` field as `string[]`, which was incorrect in two ways:
1. The Slack API can return `message` as either a single object or an array of objects
2. The elements are message objects (with `text`, `ts`, etc.), not strings

## Solution
- Added a new `SlackListsItemMessage` interface with optional fields: `text`, `ts`, `user`, `team`, `type`
- Changed `message: string[]` to `message: SlackListsItemMessage | SlackListsItemMessage[]` to handle both shapes the API can return

## References
- Closes #2598
- Same inconsistency reported on Java SDK: slackapi/java-slack-sdk#1587