### PR TITLE
chore: open changeset release pull requests as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           commit: "chore: release"
+          prDraft: create
           title: "chore: release"
           version: npm run version
         env:


### PR DESCRIPTION
### Summary

Open changeset release PRs as drafts using the `prDraft: create` option from changesets/action. This prevents version PRs from being accidentally merged before they're reviewed.

Reference: https://github.com/changesets/action/blob/main/CHANGELOG.md#180

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).