### PR TITLE
feat: add app_context_changed event type

### DIFF
--- a/.changeset/late-clouds-grow.md
+++ b/.changeset/late-clouds-grow.md
@@ -1,0 +1,5 @@
+---
+"@slack/types": minor
+---
+
+feat: add the `app_context_changed` event type for the agent DM experience

--- a/.changeset/late-clouds-grow.md
+++ b/.changeset/late-clouds-grow.md
@@ -2,4 +2,4 @@
 "@slack/types": minor
 ---
 
-feat: add the `app_context_changed` event type for the agent DM experience
+feat: add the `app_context_changed` event type for agent [active view context](https://docs.slack.dev/ai/agent-context-management/#active-view-context)

--- a/packages/types/src/events/app.ts
+++ b/packages/types/src/events/app.ts
@@ -222,7 +222,7 @@ export interface AppContextChangedEvent {
   channel: string;
   user: string;
   context: {
-    entities: ((
+    entities?: ((
       | {
           type: 'slack#/types/channel_id';
           value: string;
@@ -240,7 +240,6 @@ export interface AppContextChangedEvent {
           value: {
             message_ts: string;
             channel_id?: string;
-            user_id?: string;
           };
         }
     ) & {

--- a/packages/types/src/events/app.ts
+++ b/packages/types/src/events/app.ts
@@ -239,7 +239,7 @@ export interface AppContextChangedEvent {
           type: 'slack#/types/message_context';
           value: {
             message_ts: string;
-            channel_id?: string;
+            channel_id: string;
           };
         }
     ) & {

--- a/packages/types/src/events/app.ts
+++ b/packages/types/src/events/app.ts
@@ -70,6 +70,7 @@ export interface AppHomeOpenedEvent {
   channel: string;
   tab?: 'home' | 'messages';
   view?: View;
+  context?: AppContextChangedEvent['context'];
   event_ts: string;
 }
 
@@ -243,7 +244,6 @@ export interface AppContextChangedEvent {
           };
         }
     ) & {
-      score?: number;
       team_id?: string;
       enterprise_id?: string;
     })[];

--- a/packages/types/src/events/app.ts
+++ b/packages/types/src/events/app.ts
@@ -217,6 +217,41 @@ export interface AppRateLimitedEvent {
 // export interface AppRateLimitedEvent {
 // }
 
+export interface AppContextChangedEvent {
+  type: 'app_context_changed';
+  channel: string;
+  user: string;
+  context: {
+    entities: ((
+      | {
+          type: 'slack#/types/channel_id';
+          value: string;
+        }
+      | {
+          type: 'slack#/types/canvas_id';
+          value: string;
+        }
+      | {
+          type: 'slack#/types/list_id';
+          value: string;
+        }
+      | {
+          type: 'slack#/types/message_context';
+          value: {
+            message_ts: string;
+            channel_id?: string;
+            user_id?: string;
+          };
+        }
+    ) & {
+      score?: number;
+      team_id?: string;
+      enterprise_id?: string;
+    })[];
+  };
+  event_ts: string;
+}
+
 export interface AppUninstalledEvent {
   type: 'app_uninstalled';
 }

--- a/packages/types/src/events/index.ts
+++ b/packages/types/src/events/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AppContextChangedEvent,
   AppDeletedEvent,
   AppHomeOpenedEvent,
   AppInstalledEvent,
@@ -120,6 +121,7 @@ export * from './user';
  * This is a discriminated union. The discriminant is the `type` property.
  */
 export type SlackEvent =
+  | AppContextChangedEvent
   | AppDeletedEvent
   | AppHomeOpenedEvent
   | AppInstalledEvent

--- a/packages/types/src/events/message.ts
+++ b/packages/types/src/events/message.ts
@@ -1,6 +1,7 @@
 import type { Block, KnownBlock } from '../block-kit/blocks';
 import type { BotProfile } from '../common/bot-profile';
 import type { MessageAttachment } from '../message-attachments';
+import type { AppContextChangedEvent } from './app';
 
 type ChannelTypes = 'channel' | 'group' | 'im' | 'mpim' | 'app_home';
 
@@ -60,6 +61,8 @@ export interface GenericMessageEvent {
 
   // TODO: add properties to this field once it's publicly released
   assistant_thread?: Record<string, unknown>;
+
+  app_context?: AppContextChangedEvent['context'];
 }
 
 export interface BotMessageEvent {

--- a/packages/types/test/events/app.test-d.ts
+++ b/packages/types/test/events/app.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
-import type { AppContextChangedEvent, SlackEvent } from '../../src/index';
+import type { AppContextChangedEvent, AppHomeOpenedEvent, SlackEvent } from '../../src/index';
 
 // a channel_id context entity
 const channelContextChangedEvent: AppContextChangedEvent = {
@@ -12,7 +12,6 @@ const channelContextChangedEvent: AppContextChangedEvent = {
         type: 'slack#/types/channel_id',
         value: 'C0123456789',
         team_id: 'T0123456789',
-        score: 75,
         enterprise_id: 'E0123456789',
       },
     ],
@@ -46,7 +45,6 @@ expectAssignable<AppContextChangedEvent>({
         type: 'slack#/types/message_context',
         value: { message_ts: '1234567890.123456', channel_id: 'C0123456789' },
         team_id: 'T0123456789',
-        score: 75,
         enterprise_id: 'E0123456789',
       },
     ],
@@ -71,5 +69,26 @@ expectError<AppContextChangedEvent>({
   context: {
     entities: [{ type: 'slack#/types/message_context', value: { message_ts: '1234567890.123456' } }],
   },
+  event_ts: '1234567890.123456',
+});
+
+// app_home_opened carries the same optional `context` alongside the tab being opened
+expectAssignable<AppHomeOpenedEvent>({
+  type: 'app_home_opened',
+  channel: 'D0123456789',
+  user: 'U0123456789',
+  tab: 'messages',
+  context: {
+    entities: [{ type: 'slack#/types/channel_id', value: 'C0123456789', team_id: 'T0123456789' }],
+  },
+  event_ts: '1234567890.123456',
+});
+
+// the `context` on app_home_opened is optional
+expectAssignable<AppHomeOpenedEvent>({
+  type: 'app_home_opened',
+  channel: 'D0123456789',
+  user: 'U0123456789',
+  tab: 'home',
   event_ts: '1234567890.123456',
 });

--- a/packages/types/test/events/app.test-d.ts
+++ b/packages/types/test/events/app.test-d.ts
@@ -4,74 +4,74 @@ import type { AppContextChangedEvent, GenericMessageEvent, SlackEvent } from '..
 // a channel_id context entity
 const channelContextChangedEvent: AppContextChangedEvent = {
   type: 'app_context_changed',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
+  channel: 'D0123456789',
+  user: 'U0123456789',
   context: {
     entities: [
       {
         type: 'slack#/types/channel_id',
-        value: 'C07U19RTY90',
-        team_id: 'T06M2FAFCF3',
+        value: 'C0123456789',
+        team_id: 'T0123456789',
         score: 75,
-        enterprise_id: 'E06LPMFSSTU',
+        enterprise_id: 'E0123456789',
       },
     ],
   },
-  event_ts: '1782779068.665087',
+  event_ts: '1234567890.123456',
 };
 expectAssignable<SlackEvent>(channelContextChangedEvent);
 
 // canvas_id and list_id entities share the string `value` shape
 expectAssignable<AppContextChangedEvent>({
   type: 'app_context_changed',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
+  channel: 'D0123456789',
+  user: 'U0123456789',
   context: {
     entities: [
-      { type: 'slack#/types/canvas_id', value: 'F0BCK49CC2G' },
-      { type: 'slack#/types/list_id', value: 'F0AE0M8HDGE' },
+      { type: 'slack#/types/canvas_id', value: 'F0123456789' },
+      { type: 'slack#/types/list_id', value: 'F0123456780' },
     ],
   },
-  event_ts: '1782779070.692614',
+  event_ts: '1234567890.123456',
 });
 
 // a message_context entity carries an object `value` with message_ts and channel_id
 expectAssignable<AppContextChangedEvent>({
   type: 'app_context_changed',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
+  channel: 'D0123456789',
+  user: 'U0123456789',
   context: {
     entities: [
       {
         type: 'slack#/types/message_context',
-        value: { message_ts: '1780935307.411989', channel_id: 'C07U19RTY90' },
-        team_id: 'T06M2FAFCF3',
+        value: { message_ts: '1234567890.123456', channel_id: 'C0123456789' },
+        team_id: 'T0123456789',
         score: 75,
-        enterprise_id: 'E06LPMFSSTU',
+        enterprise_id: 'E0123456789',
       },
     ],
   },
-  event_ts: '1782779875.276072',
+  event_ts: '1234567890.123456',
 });
 
 // `entities` is optional — the context can be empty
 expectAssignable<AppContextChangedEvent>({
   type: 'app_context_changed',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
+  channel: 'D0123456789',
+  user: 'U0123456789',
   context: {},
-  event_ts: '1782779875.276072',
+  event_ts: '1234567890.123456',
 });
 
 // a message_context entity requires channel_id alongside message_ts
 expectError<AppContextChangedEvent>({
   type: 'app_context_changed',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
+  channel: 'D0123456789',
+  user: 'U0123456789',
   context: {
-    entities: [{ type: 'slack#/types/message_context', value: { message_ts: '1780935307.411989' } }],
+    entities: [{ type: 'slack#/types/message_context', value: { message_ts: '1234567890.123456' } }],
   },
-  event_ts: '1782779875.276072',
+  event_ts: '1234567890.123456',
 });
 
 // the context is delivered inline on messages via the `app_context` field
@@ -79,19 +79,19 @@ const messageWithAppContext: GenericMessageEvent = {
   type: 'message',
   subtype: undefined,
   channel_type: 'im',
-  channel: 'D0BCDALLUF8',
-  user: 'U06MCF88LQY',
-  ts: '1782781779.324109',
-  event_ts: '1782781779.324109',
+  channel: 'D0123456789',
+  user: 'U0123456789',
+  ts: '1234567890.123456',
+  event_ts: '1234567890.123456',
   text: 'hi',
   app_context: {
     entities: [
       {
         type: 'slack#/types/channel_id',
-        value: 'C07U19RTY90',
-        team_id: 'T06M2FAFCF3',
+        value: 'C0123456789',
+        team_id: 'T0123456789',
         score: 75,
-        enterprise_id: 'E06LPMFSSTU',
+        enterprise_id: 'E0123456789',
       },
     ],
   },

--- a/packages/types/test/events/app.test-d.ts
+++ b/packages/types/test/events/app.test-d.ts
@@ -1,0 +1,99 @@
+import { expectAssignable, expectError } from 'tsd';
+import type { AppContextChangedEvent, GenericMessageEvent, SlackEvent } from '../../src/index';
+
+// a channel_id context entity
+const channelContextChangedEvent: AppContextChangedEvent = {
+  type: 'app_context_changed',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  context: {
+    entities: [
+      {
+        type: 'slack#/types/channel_id',
+        value: 'C07U19RTY90',
+        team_id: 'T06M2FAFCF3',
+        score: 75,
+        enterprise_id: 'E06LPMFSSTU',
+      },
+    ],
+  },
+  event_ts: '1782779068.665087',
+};
+expectAssignable<SlackEvent>(channelContextChangedEvent);
+
+// canvas_id and list_id entities share the string `value` shape
+expectAssignable<AppContextChangedEvent>({
+  type: 'app_context_changed',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  context: {
+    entities: [
+      { type: 'slack#/types/canvas_id', value: 'F0BCK49CC2G' },
+      { type: 'slack#/types/list_id', value: 'F0AE0M8HDGE' },
+    ],
+  },
+  event_ts: '1782779070.692614',
+});
+
+// a message_context entity carries an object `value` with message_ts and channel_id
+expectAssignable<AppContextChangedEvent>({
+  type: 'app_context_changed',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  context: {
+    entities: [
+      {
+        type: 'slack#/types/message_context',
+        value: { message_ts: '1780935307.411989', channel_id: 'C07U19RTY90' },
+        team_id: 'T06M2FAFCF3',
+        score: 75,
+        enterprise_id: 'E06LPMFSSTU',
+      },
+    ],
+  },
+  event_ts: '1782779875.276072',
+});
+
+// `entities` is optional — the context can be empty
+expectAssignable<AppContextChangedEvent>({
+  type: 'app_context_changed',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  context: {},
+  event_ts: '1782779875.276072',
+});
+
+// a message_context entity requires channel_id alongside message_ts
+expectError<AppContextChangedEvent>({
+  type: 'app_context_changed',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  context: {
+    entities: [{ type: 'slack#/types/message_context', value: { message_ts: '1780935307.411989' } }],
+  },
+  event_ts: '1782779875.276072',
+});
+
+// the context is delivered inline on messages via the `app_context` field
+const messageWithAppContext: GenericMessageEvent = {
+  type: 'message',
+  subtype: undefined,
+  channel_type: 'im',
+  channel: 'D0BCDALLUF8',
+  user: 'U06MCF88LQY',
+  ts: '1782781779.324109',
+  event_ts: '1782781779.324109',
+  text: 'hi',
+  app_context: {
+    entities: [
+      {
+        type: 'slack#/types/channel_id',
+        value: 'C07U19RTY90',
+        team_id: 'T06M2FAFCF3',
+        score: 75,
+        enterprise_id: 'E06LPMFSSTU',
+      },
+    ],
+  },
+};
+expectAssignable<GenericMessageEvent>(messageWithAppContext);

--- a/packages/types/test/events/app.test-d.ts
+++ b/packages/types/test/events/app.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
-import type { AppContextChangedEvent, GenericMessageEvent, SlackEvent } from '../../src/index';
+import type { AppContextChangedEvent, SlackEvent } from '../../src/index';
 
 // a channel_id context entity
 const channelContextChangedEvent: AppContextChangedEvent = {
@@ -73,27 +73,3 @@ expectError<AppContextChangedEvent>({
   },
   event_ts: '1234567890.123456',
 });
-
-// the context is delivered inline on messages via the `app_context` field
-const messageWithAppContext: GenericMessageEvent = {
-  type: 'message',
-  subtype: undefined,
-  channel_type: 'im',
-  channel: 'D0123456789',
-  user: 'U0123456789',
-  ts: '1234567890.123456',
-  event_ts: '1234567890.123456',
-  text: 'hi',
-  app_context: {
-    entities: [
-      {
-        type: 'slack#/types/channel_id',
-        value: 'C0123456789',
-        team_id: 'T0123456789',
-        score: 75,
-        enterprise_id: 'E0123456789',
-      },
-    ],
-  },
-};
-expectAssignable<GenericMessageEvent>(messageWithAppContext);

--- a/packages/types/test/events/app.test-d.ts
+++ b/packages/types/test/events/app.test-d.ts
@@ -72,6 +72,15 @@ expectError<AppContextChangedEvent>({
   event_ts: '1234567890.123456',
 });
 
+// the `context` on app_home_opened is optional
+expectAssignable<AppHomeOpenedEvent>({
+  type: 'app_home_opened',
+  channel: 'D0123456789',
+  user: 'U0123456789',
+  tab: 'home',
+  event_ts: '1234567890.123456',
+});
+
 // app_home_opened carries the same optional `context` alongside the tab being opened
 expectAssignable<AppHomeOpenedEvent>({
   type: 'app_home_opened',
@@ -81,14 +90,5 @@ expectAssignable<AppHomeOpenedEvent>({
   context: {
     entities: [{ type: 'slack#/types/channel_id', value: 'C0123456789', team_id: 'T0123456789' }],
   },
-  event_ts: '1234567890.123456',
-});
-
-// the `context` on app_home_opened is optional
-expectAssignable<AppHomeOpenedEvent>({
-  type: 'app_home_opened',
-  channel: 'D0123456789',
-  user: 'U0123456789',
-  tab: 'home',
   event_ts: '1234567890.123456',
 });

--- a/packages/types/test/events/message.test-d.ts
+++ b/packages/types/test/events/message.test-d.ts
@@ -40,7 +40,6 @@ const messageWithAppContext: GenericMessageEvent = {
         type: 'slack#/types/channel_id',
         value: 'C0123456789',
         team_id: 'T0123456789',
-        score: 75,
         enterprise_id: 'E0123456789',
       },
     ],

--- a/packages/types/test/events/message.test-d.ts
+++ b/packages/types/test/events/message.test-d.ts
@@ -23,3 +23,27 @@ const messageDeletedEvent: MessageDeletedEvent = {
   previous_message: anyMessageEvent,
 };
 expectAssignable<MessageEvent>(messageDeletedEvent.previous_message);
+
+// the agent DM context is delivered inline on messages via the `app_context` field
+const messageWithAppContext: GenericMessageEvent = {
+  type: 'message',
+  subtype: undefined,
+  channel_type: 'im',
+  channel: 'D0123456789',
+  user: 'U0123456789',
+  ts: '1234567890.123456',
+  event_ts: '1234567890.123456',
+  text: 'hi',
+  app_context: {
+    entities: [
+      {
+        type: 'slack#/types/channel_id',
+        value: 'C0123456789',
+        team_id: 'T0123456789',
+        score: 75,
+        enterprise_id: 'E0123456789',
+      },
+    ],
+  },
+};
+expectAssignable<GenericMessageEvent>(messageWithAppContext);


### PR DESCRIPTION
### Summary

This pull request adds the `app_context_changed` event type to `@slack/types`. The event fires in the agent DM (`agent_view`) experience when the user's surrounding context changes (e.g. they navigate to a channel, canvas, list, or message).

- Adds `AppContextChangedEvent` to the `SlackEvent` discriminated union, covering the context entity kinds: `slack#/types/channel_id`, `slack#/types/canvas_id`, `slack#/types/list_id`, and `slack#/types/message_context`.
- Adds an `app_context` field to `GenericMessageEvent`, since the same context is delivered inline on messages.

Scoped to the type definitions only — handling the event is left to consumers (e.g. Bolt and the sample apps).

### Testing

Subscribe to the event and let TypeScript narrow each entity by its `type`:

```ts
app.event('app_context_changed', async ({ event }) => {
  if (!event.context.entities) return;

  for (const entity of event.context.entities) {
    switch (entity.type) {
      case 'slack#/types/channel_id':
      case 'slack#/types/canvas_id':
      case 'slack#/types/list_id':
        console.log(entity.type, entity.value); // value: string
        break;
      case 'slack#/types/message_context':
        console.log(entity.value.message_ts, entity.value.channel_id); // value: { message_ts, channel_id }
        break;
    }
  }
});
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).