### PR TITLE
feat: make thread_ts optional for assistant.threads.setSuggestedPrompts

### DIFF
--- a/.changeset/quick-trees-cheer.md
+++ b/.changeset/quick-trees-cheer.md
@@ -1,0 +1,5 @@
+---
+"@slack/web-api": minor
+---
+
+feat: make `thread_ts` optional for `assistant.threads.setSuggestedPrompts`

--- a/packages/web-api/src/types/request/assistant.ts
+++ b/packages/web-api/src/types/request/assistant.ts
@@ -33,8 +33,8 @@ export interface AssistantThreadsSetSuggestedPromptsArguments extends TokenOverr
   channel_id: string;
   /** @description Prompt suggestions that appear when opening assistant thread. */
   prompts: AssistantPrompt[];
-  /** @description Message timestamp of the thread. */
-  thread_ts: string;
+  /** @description Message timestamp of the thread. Optional. */
+  thread_ts?: string;
   /** @description Title for the prompts. */
   title?: string;
 }

--- a/packages/web-api/src/types/request/assistant.ts
+++ b/packages/web-api/src/types/request/assistant.ts
@@ -33,7 +33,7 @@ export interface AssistantThreadsSetSuggestedPromptsArguments extends TokenOverr
   channel_id: string;
   /** @description Prompt suggestions that appear when opening assistant thread. */
   prompts: AssistantPrompt[];
-  /** @description Message timestamp of the thread. Optional. */
+  /** @description Message timestamp of the thread. */
   thread_ts?: string;
   /** @description Title for the prompts. */
   title?: string;

--- a/packages/web-api/test/types/methods/assistant.test-d.ts
+++ b/packages/web-api/test/types/methods/assistant.test-d.ts
@@ -73,14 +73,10 @@ expectError(
     channel_id: 'C1234', // missing prompts and thread_ts
   }),
   web.assistant.threads.setSuggestedPrompts({
-    prompts: [], // missing channel_id and thread_ts
+    prompts: [], // missing channel_id
   }),
   web.assistant.threads.setSuggestedPrompts({
     thread_ts: '123.123', // missing channel_id and prompts
-  }),
-  web.assistant.threads.setSuggestedPrompts({
-    channel_id: 'C1234', // missing thread_ts
-    prompts: [],
   }),
   web.assistant.threads.setSuggestedPrompts({
     channel_id: 'C1234', // missing prompts
@@ -102,6 +98,12 @@ expectError(
   }),
 );
 // -- happy path
+expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
+  {
+    channel_id: 'C1234',
+    prompts: [], // thread_ts is optional
+  },
+]);
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',

--- a/packages/web-api/test/types/methods/assistant.test-d.ts
+++ b/packages/web-api/test/types/methods/assistant.test-d.ts
@@ -101,14 +101,14 @@ expectError(
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
-    prompts: [], // thread_ts is optional
+    prompts: [],
   },
 ]);
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
     prompts: [{ title: 'Summarize this channel', message: 'Summarize the recent activity in this channel.' }],
-    title: 'Suggested Prompts', // thread_ts is optional alongside the other arguments
+    title: 'Suggested Prompts',
   },
 ]);
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([

--- a/packages/web-api/test/types/methods/assistant.test-d.ts
+++ b/packages/web-api/test/types/methods/assistant.test-d.ts
@@ -107,7 +107,14 @@ expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
-    thread_ts: '123.123',
+    prompts: [{ title: 'placeholder', message: 'example' }],
+    title: 'what is up?', // thread_ts is optional alongside the other arguments
+  },
+]);
+expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
+  {
+    channel_id: 'C1234',
+    thread_ts: '123.123', // thread_ts is still accepted when provided
     prompts: [],
   },
 ]);

--- a/packages/web-api/test/types/methods/assistant.test-d.ts
+++ b/packages/web-api/test/types/methods/assistant.test-d.ts
@@ -107,14 +107,14 @@ expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
-    prompts: [{ title: 'placeholder', message: 'example' }],
-    title: 'what is up?', // thread_ts is optional alongside the other arguments
+    prompts: [{ title: 'Summarize this channel', message: 'Summarize the recent activity in this channel.' }],
+    title: 'Suggested Prompts', // thread_ts is optional alongside the other arguments
   },
 ]);
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
-    thread_ts: '123.123', // thread_ts is still accepted when provided
+    thread_ts: '123.123',
     prompts: [],
   },
 ]);
@@ -122,15 +122,15 @@ expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
     thread_ts: '123.123',
-    prompts: [{ title: 'placeholder', message: 'example' }],
+    prompts: [{ title: 'Summarize this channel', message: 'Summarize the recent activity in this channel.' }],
   },
 ]);
 expectAssignable<Parameters<typeof web.assistant.threads.setSuggestedPrompts>>([
   {
     channel_id: 'C1234',
     thread_ts: '123.123',
-    prompts: [{ title: 'placeholder', message: 'example' }],
-    title: 'what is up?',
+    prompts: [{ title: 'Draft a reply', message: 'Draft a reply to the latest message in this thread.' }],
+    title: 'Suggested Prompts',
   },
 ]);
 


### PR DESCRIPTION
### Summary

This pull request makes the `thread_ts` argument of `assistant.threads.setSuggestedPrompts` optional.

### Testing

Confirm `tsc` doesn't complain about this:

```js
await app.client.assistant.threads.setSuggestedPrompts({
  channel_id: "C0123456789",
  prompts: [],
});
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).