### PR TITLE
revert(web-api): keep string[] for slack lists message field request input

### DIFF
--- a/.changeset/great-seas-swim.md
+++ b/.changeset/great-seas-swim.md
@@ -1,5 +1,0 @@
----
-"@slack/web-api": patch
----
-
-fix: update SlackListsItemFieldMessage to support single and array message shapes

--- a/packages/web-api/src/types/request/slackLists.ts
+++ b/packages/web-api/src/types/request/slackLists.ts
@@ -58,23 +58,11 @@ export interface SlackListsItemFieldLink {
 }
 
 /**
- * @description A single message object returned by the Slack API.
- */
-export interface SlackListsItemMessage {
-  text?: string;
-  ts?: string;
-  user?: string;
-  team?: string;
-  type?: string;
-}
-
-/**
- * @description Message field. The API may return either a single message object
- * or an array of message objects.
+ * @description Message field with message URLs.
  */
 export interface SlackListsItemFieldMessage {
   column_id: string;
-  message: SlackListsItemMessage | SlackListsItemMessage[];
+  message: string[];
 }
 
 /**


### PR DESCRIPTION
### Summary

This pull request reverts #2627, restoring the Slack Lists item `message` field to `string[]` for request input.

- #2627 retyped the shared `SlackListsItemFieldMessage.message` from `string[]` to `SlackListsItemMessage | SlackListsItemMessage[]` to correct the **response** shape.
- That same type backs **request** input (`SlackListsItemsCreateArguments.initial_fields` and `SlackListsItemCellUpdate` / `cells`), so it broke request typing.
- Per the [docs](https://docs.slack.dev/reference/methods/slackLists.items.create/#field-types), `slackLists.items.create`/`update` `message` takes **an array of message permalink URL strings**, e.g. `{ "column_id": "Col123", "message": ["https://team.slack.com/archives/C123/p1234567890123456"] }`.
- #2627 is **unreleased** — `@slack/web-api` 7.16.0, 7.17.0, and 8.0.0-rc.1 all still ship `message: string[]` — so this reverts the regression before it reaches a release. Its pending changeset is removed and no new changeset is added (the change nets to zero against the last release).
- The response-side object shape (#2627's original goal, issue #2598) is intentionally deferred to codegen, which will generate per-direction request/response types and prevent this class of drift. Supersedes the still-open duplicate PRs #2599, #2600, and #2621.

> [!NOTE]
> This is a revert to stop the unreleased request-side regression. It does **not** fix the original response-shape issue (#2598), which is being reopened and will be addressed in a **follow-up** — the correct fix is to split request vs. response field types (e.g. via codegen) so both directions are typed correctly.

### Testing

Gather these before running — both must come from your own workspace:

- a **user ID** to grant list access to (`U…`)
- a real **message permalink** (`https://<team>.slack.com/archives/<C…>/p…`)

With a token that has the `lists:write` scope, the docs-correct request shape is accepted by the API:

```js
// Create a list with a message column.
const { list_id, list_metadata } = await client.slackLists.create({
  name: 'Message field probe',
  schema: [
    { key: 'title', name: 'Title', type: 'text', is_primary_column: true },
    { key: 'message_link', name: 'Message', type: 'message' },
  ],
});
const messageColumn = list_metadata.schema.find((c) => c.key === 'message_link');

// Grant a teammate write access (replace with a real user ID).
await client.slackLists.access.set({
  list_id,
  access_level: 'write',
  user_ids: ['U00000000'], // <-- gather before run
});

// Correct: `message` is an array of permalink URL strings — the API accepts this.
await client.slackLists.items.create({
  list_id,
  initial_fields: [
    {
      column_id: messageColumn.id,
      message: ['https://yourteam.slack.com/archives/C00000000/p0000000000000000'], // <-- gather before run
    },
  ],
});
```

To confirm the object shape #2627 allowed is invalid on the request side, send it untyped (the reverted types correctly reject it at compile time) and observe the API reject it too:

```js
// Broken: `message` as a message object. Sent via apiCall to reach the API at runtime.
await client.apiCall('slackLists.items.create', {
  list_id,
  initial_fields: [
    { column_id: messageColumn.id, message: { text: 'message objects are response-only' } },
  ],
});
```

Observed: the correct string-array call succeeds, while the object-shape call is rejected by the API:

```
[ERROR]  bolt-app An API error occurred: internal_error
    at platformErrorFromResult (.../node_modules/@slack/web-api/dist/errors.js:67:33)
    at WebClient.apiCall (.../node_modules/@slack/web-api/dist/WebClient.js:232:56)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async path/to/app.js:62:5 {
  code: 'slack_webapi_platform_error',
  data: {
    ok: false,
    error: 'internal_error',
    response_metadata: { scopes: [Array], acceptedScopes: [Array] }
  }
}
```

This confirms the object `message` shape #2627 typed for requests is invalid against the API; only the `string[]` permalink form is accepted.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
