### PR TITLE
fix(socket-mode): observe reconnect rejections

### DIFF
--- a/packages/socket-mode/src/SocketModeClient.test.ts
+++ b/packages/socket-mode/src/SocketModeClient.test.ts
@@ -83,6 +83,24 @@ describe('SocketModeClient', () => {
     it('should resolve once Disconnected state emitted');
   });
 
+  describe('reconnect', () => {
+    it('should observe a rejected reconnect attempt', async () => {
+      const logger = new ConsoleLogger();
+      const errorLog = sandbox.stub(logger, 'error');
+      const client = new SocketModeClient({
+        appToken: 'xapp-',
+        clientPingTimeout: 1,
+        logger,
+      });
+      sandbox.stub(client, 'start').rejects(new Error('reconnect failed'));
+
+      client.emit('close');
+      await sleep(10);
+
+      sinon.assert.calledWith(errorLog, 'Failed to reconnect Socket Mode client: Error: reconnect failed');
+    });
+  });
+
   describe('onWebSocketMessage', () => {
     // While this method is protected and cannot be invoked directly, emitting the 'message' event directly invokes it
     describe('slash_commands messages', () => {

--- a/packages/socket-mode/src/SocketModeClient.test.ts
+++ b/packages/socket-mode/src/SocketModeClient.test.ts
@@ -99,6 +99,24 @@ describe('SocketModeClient', () => {
 
       sinon.assert.calledWith(errorLog, 'Failed to reconnect Socket Mode client: Error: reconnect failed');
     });
+
+    it('should not reconnect or log an error while shutting down', async () => {
+      const logger = new ConsoleLogger();
+      const errorLog = sandbox.stub(logger, 'error');
+      const client = new SocketModeClient({
+        appToken: 'xapp-',
+        clientPingTimeout: 1,
+        logger,
+      });
+      const start = sandbox.stub(client, 'start').resolves({});
+
+      client.emit('close');
+      await client.disconnect();
+      await sleep(10);
+
+      sinon.assert.notCalled(start);
+      sinon.assert.notCalled(errorLog);
+    });
   });
 
   describe('onWebSocketMessage', () => {

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -18,6 +18,8 @@ import { SlackWebSocket, WS_READY_STATES } from './SlackWebSocket';
 import type { SocketModeDispatcher, SocketModeOptions } from './SocketModeOptions';
 import { UnrecoverableSocketModeStartError } from './UnrecoverableSocketModeStartError';
 
+class SocketModeClientShuttingDownError extends Error {}
+
 // Lifecycle events as described in the README
 enum State {
   Connecting = 'connecting',
@@ -159,7 +161,7 @@ export class SocketModeClient extends EventEmitter {
       // Underlying WebSocket connection was closed, possibly reconnect.
       if (!this.shuttingDown && this.autoReconnectEnabled) {
         void this.delayReconnectAttempt(this.start).catch((error) => {
-          if (!this.shuttingDown) {
+          if (!(error instanceof SocketModeClientShuttingDownError)) {
             this.logger.error(`Failed to reconnect Socket Mode client: ${error}`);
           }
         });
@@ -255,7 +257,7 @@ export class SocketModeClient extends EventEmitter {
         this.reconnectionTimer = undefined;
         if (this.shuttingDown) {
           this.logger.debug('Client shutting down, will not attempt reconnect.');
-          resolve(undefined as T);
+          reject(new SocketModeClientShuttingDownError('Socket Mode client is shutting down'));
         } else {
           this.logger.debug('Continuing with reconnect...');
           this.emit(State.Reconnecting);

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -158,7 +158,11 @@ export class SocketModeClient extends EventEmitter {
     this.on('close', () => {
       // Underlying WebSocket connection was closed, possibly reconnect.
       if (!this.shuttingDown && this.autoReconnectEnabled) {
-        this.delayReconnectAttempt(this.start);
+        void this.delayReconnectAttempt(this.start).catch((error) => {
+          if (!this.shuttingDown) {
+            this.logger.error(`Failed to reconnect Socket Mode client: ${error}`);
+          }
+        });
       } else {
         // If reconnect is disabled or user explicitly called `disconnect()`, emit a disconnected state.
         this.emit(State.Disconnected);
@@ -246,15 +250,16 @@ export class SocketModeClient extends EventEmitter {
     this.numOfConsecutiveReconnectionFailures += 1;
     const msBeforeRetry = this.clientPingTimeoutMS * this.numOfConsecutiveReconnectionFailures;
     this.logger.debug(`Before trying to reconnect, this client will wait for ${msBeforeRetry} milliseconds`);
-    return new Promise((res, _rej) => {
+    return new Promise((resolve, reject) => {
       this.reconnectionTimer = setTimeout(() => {
         this.reconnectionTimer = undefined;
         if (this.shuttingDown) {
           this.logger.debug('Client shutting down, will not attempt reconnect.');
+          resolve(undefined as T);
         } else {
           this.logger.debug('Continuing with reconnect...');
           this.emit(State.Reconnecting);
-          cb.apply(this).then(res);
+          cb.apply(this).then(resolve, reject);
         }
       }, msBeforeRetry);
     });


### PR DESCRIPTION
### Summary

- propagate delayed reconnect callback rejections instead of leaving the returned promise pending
- observe failures from close-triggered reconnect attempts and log them when the client is still active
- settle a delayed reconnect cleanly when shutdown wins the race
- add a regression test for a rejected reconnect attempt

Fixes #2656

### Validation

- `npm run lint`
- `npm run build`
- `npm run test:unit --workspace=@slack/socket-mode` (21 tests passed)

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
