### PR TITLE
chore(webhook): bump p-retry to v7 and fix Node version source of truth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -223,6 +223,11 @@ updates:
           - "@types/mocha"
           - "mocha"
     ignore:
+      # p-retry is pure ESM and raises its minimum Node.js version each major
+      # (v7 requires Node >= 20, v8 requires Node >= 22). Bumping it can force a
+      # change to this package's own supported Node floor, so maintainers must
+      # upgrade it deliberately rather than via automated PRs.
+      - dependency-name: "p-retry"
       - dependency-name: "@types/node"
         versions:
           - "19.x"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -225,8 +225,7 @@ updates:
     ignore:
       # p-retry is pure ESM and raises its minimum Node.js version each major
       # (v7 requires Node >= 20, v8 requires Node >= 22). Bumping it can force a
-      # change to this package's own supported Node floor, so maintainers must
-      # upgrade it deliberately rather than via automated PRs.
+      # change to this package's own supported Node floor.
       - dependency-name: "p-retry"
       - dependency-name: "@types/node"
         versions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ npm run build --workspace=@slack/socket-mode
 2. **Request types ARE manually maintained** — `packages/web-api/src/types/request/` is hand-written code; edit these responsibly.
 3. **Build packages in dependency order** — see the dependency graph above.
 4. **Use Biome**, not ESLint or Prettier — config is in `biome.json` at repo root.
-5. **TypeScript 5.9.3**, Node 18+ (tested on Node 18, 20, 22, 24).
+5. **TypeScript 5.9.3**. The minimum supported Node.js version is the `engines.node` field in each package's `package.json` — that is the source of truth, not this document. Do not hard-code a Node version here; if you need the current floor, read it from `package.json` (at time of writing, `>= 20`).
 
 ## Code Conventions
 
 - **Formatting**: configured in `biome.json`
 - **Test files**: `*.test.{ts,js}` using `node:test` + `node:assert/strict`; coverage via `--experimental-test-coverage`
 - **Type tests**: `*.test-d.ts` using tsd
-- **CI matrix**: Node 18.x, 20.x, 22.x, 24.x on Ubuntu + Windows
+- **CI matrix**: the tested Node versions and operating systems are defined in `.github/workflows/ci-build.yml` (the `matrix` block) — refer to that workflow as the source of truth rather than duplicating the list here.
 
 ## Package-Level AGENTS.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ npm run build --workspace=@slack/socket-mode
 2. **Request types ARE manually maintained** — `packages/web-api/src/types/request/` is hand-written code; edit these responsibly.
 3. **Build packages in dependency order** — see the dependency graph above.
 4. **Use Biome**, not ESLint or Prettier — config is in `biome.json` at repo root.
-5. **TypeScript 5.9.3**. The minimum supported Node.js version is the `engines.node` field in each package's `package.json` — that is the source of truth, not this document. Do not hard-code a Node version here; if you need the current floor, read it from `package.json` (at time of writing, `>= 20`).
+5. **TypeScript 5.9.3**. The minimum supported Node.js version is the `engines.node` field in each package's `package.json`.
 
 ## Code Conventions
 
 - **Formatting**: configured in `biome.json`
 - **Test files**: `*.test.{ts,js}` using `node:test` + `node:assert/strict`; coverage via `--experimental-test-coverage`
 - **Type tests**: `*.test-d.ts` using tsd
-- **CI matrix**: the tested Node versions and operating systems are defined in `.github/workflows/ci-build.yml` (the `matrix` block) — refer to that workflow as the source of truth rather than duplicating the list here.
+- **CI matrix**: the tested Node versions and operating systems are defined in `.github/workflows/ci-build.yml` (the `matrix` block).
 
 ## Package-Level AGENTS.md
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1397,16 +1397,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/sinon": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
-      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
@@ -3401,6 +3391,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-node-process": {
@@ -6922,7 +6924,7 @@
         "@slack/types": "^3.0.0",
         "@types/node": ">=20",
         "@types/retry": "0.12.0",
-        "p-retry": "^4",
+        "p-retry": "^7",
         "retry": "^0.13.1"
       },
       "devDependencies": {
@@ -6940,6 +6942,21 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "packages/webhook/node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/webhook/node_modules/undici-types": {

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -44,7 +44,7 @@
     "@slack/types": "^3.0.0",
     "@types/node": ">=20",
     "@types/retry": "0.12.0",
-    "p-retry": "^4",
+    "p-retry": "^7",
     "retry": "^0.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary

Dependabot opened #2655 to bump `p-retry` to v8, but v8 requires **Node >= 22** — higher than `@slack/webhook`'s supported floor of **`>= 20`** — so its CI failed. This PR resolves that instead of forcing a Node version bump on the SDK:

- **Bumps `p-retry` `^4` → `^7`.** v7 is the newest release whose Node requirement (`>= 20`) still matches our engine floor. (Regenerating the lockfile also fixes the `npm ci` failure from #2655.)
- **Ignores `p-retry` in Dependabot for `/packages/webhook`.** It's pure ESM and raises its minimum Node with every major, so automated bumps keep breaking CI — maintainers should upgrade it deliberately.
- **Fixes stale Node versions in `AGENTS.md`.** It claimed "Node 18+" and an outdated CI matrix; it now points to `package.json` `engines.node` and `ci-build.yml` as the sources of truth so the docs can't drift again.

Verified locally: webhook builds with no type errors and all 35 tests pass. Supersedes #2655.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
