### PR TITLE
chore: raise @types/node ignore floor to Node 20 in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,8 +66,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"
@@ -105,8 +103,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"
@@ -144,8 +140,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"
@@ -194,8 +188,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"
@@ -225,8 +217,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"
@@ -272,8 +262,6 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - "19.x"
-          - "20.x"
           - "21.x"
           - "22.x"
           - "23.x"


### PR DESCRIPTION
### Summary

This pull request updates the `@types/node` ignore rules in `.github/dependabot.yml` so they track the current minimum supported Node version.

- Every package except `rtm-api` now declares `engines.node >= 20`, but the `@types/node` ignore lists were still pinning to the old Node 18 floor by ignoring `19.x`–`26.x`.
- This dropped `19.x` and `20.x` from each of the 6 affected blocks (logger, oauth, socket-mode, web-api, webhook, and root), so `20.x` becomes the allowed version — keeping `@types/node` aligned with the minimum supported Node rather than a stale one.
- The `examples` block is intentionally left unchanged; it tracks the *latest* supported Node (`LATEST_SUPPORTED_NODE`) rather than the minimum.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).