### PR TITLE
fix(webhook): do not retry after a successful trigger delivery

### DIFF
--- a/.changeset/webhook-trigger-retry-after-success.md
+++ b/.changeset/webhook-trigger-retry-after-success.md
@@ -1,0 +1,7 @@
+---
+"@slack/webhook": patch
+---
+
+fix: stop `WebhookTrigger.send()` from retrying after a successful delivery
+
+A 2xx response with an empty or non-JSON body no longer throws. It now resolves to `{ ok: true }`. Before this fix that body threw a parse error, which was retried as a request error and caused duplicate Workflow Builder runs. A valid `{ ok: false, error }` body is still surfaced to the caller.

--- a/packages/webhook/src/WebhookTrigger.test.ts
+++ b/packages/webhook/src/WebhookTrigger.test.ts
@@ -77,6 +77,33 @@ describe('WebhookTrigger', () => {
         assert.strictEqual(result.ok, true);
         scope.done();
       });
+
+      it('should resolve to { ok: true } on an empty 2xx body', async () => {
+        const scope = nock('https://hooks.slack.com')
+          .post(/triggers/)
+          .reply(200);
+        const result = await trigger.send({ key: 'value' });
+        assert.deepStrictEqual(result, { ok: true });
+        scope.done();
+      });
+
+      it('should resolve to { ok: true } on a non-JSON 2xx body', async () => {
+        const scope = nock('https://hooks.slack.com')
+          .post(/triggers/)
+          .reply(200, 'ok');
+        const result = await trigger.send({ key: 'value' });
+        assert.deepStrictEqual(result, { ok: true });
+        scope.done();
+      });
+
+      it('should surface a valid { ok: false } JSON body', async () => {
+        const scope = nock('https://hooks.slack.com')
+          .post(/triggers/)
+          .reply(200, { ok: false, error: 'trigger_error' });
+        const result = await trigger.send({ key: 'value' });
+        assert.deepStrictEqual(result, { ok: false, error: 'trigger_error' });
+        scope.done();
+      });
     });
 
     describe('on failure', () => {
@@ -208,6 +235,16 @@ describe('WebhookTrigger', () => {
         }
         // Only one interceptor is registered; a retry would leave it unmatched
         // and scope.done() would throw.
+        scope.done();
+      });
+
+      it('does not retry an empty 2xx body even when a retry policy is set', async () => {
+        const scope = nock('https://hooks.slack.com')
+          .post(/triggers/)
+          .reply(200);
+        const trigger = new WebhookTrigger(url, { retryConfig: rapidRetryPolicy });
+        const result = await trigger.send({ key: 'value' });
+        assert.deepStrictEqual(result, { ok: true });
         scope.done();
       });
 

--- a/packages/webhook/src/WebhookTrigger.ts
+++ b/packages/webhook/src/WebhookTrigger.ts
@@ -1,7 +1,7 @@
 import pRetry, { AbortError } from 'p-retry';
 
 import { SlackWebhookError, WebhookTriggerHTTPError, WebhookTriggerRequestError } from './errors';
-import type { FetchFunction } from './IncomingWebhook';
+import type { FetchFunction, FetchResponse } from './IncomingWebhook';
 import { getUserAgent } from './instrument';
 import type { RetryOptions } from './retry-policies';
 
@@ -81,7 +81,7 @@ export class WebhookTrigger {
           throw response.status >= 500 ? httpError : new AbortError(httpError);
         }
 
-        return (await response.json()) as WebhookTriggerResult;
+        return await this.buildResult(response);
       } catch (error) {
         // Non-retryable signals (AbortError) and already-wrapped errors pass through untouched.
         if (error instanceof AbortError || error instanceof SlackWebhookError) {
@@ -91,6 +91,15 @@ export class WebhookTrigger {
         throw new WebhookTriggerRequestError(error instanceof Error ? error : new Error(String(error)));
       }
     }, this.retryConfig);
+  }
+
+  private async buildResult(response: FetchResponse): Promise<WebhookTriggerResult> {
+    const text = await response.text();
+    try {
+      return text ? (JSON.parse(text) as WebhookTriggerResult) : { ok: true };
+    } catch {
+      return { ok: true };
+    }
   }
 }
 

--- a/packages/webhook/src/WebhookTrigger.ts
+++ b/packages/webhook/src/WebhookTrigger.ts
@@ -96,7 +96,10 @@ export class WebhookTrigger {
   private async buildResult(response: FetchResponse): Promise<WebhookTriggerResult> {
     const text = await response.text();
     try {
-      return text ? (JSON.parse(text) as WebhookTriggerResult) : { ok: true };
+      if (!text) {
+        return { ok: true };
+      }
+      return JSON.parse(text) as WebhookTriggerResult;
     } catch {
       return { ok: true };
     }


### PR DESCRIPTION
### Summary

Fixes #2673.

`WebhookTrigger.send()` retried after a trigger had already fired. This caused duplicate Workflow Builder runs.

The cause is the success path. It read the body with `response.json()`. That call throws on an empty or non-JSON 2xx body. The thrown error was wrapped as a `WebhookTriggerRequestError`, which `p-retry` treats as retryable. So a trigger that already succeeded got sent again.

The fix reads the 2xx body tolerantly in a new `buildResult()` method. It mirrors `IncomingWebhook`. 

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
