### PR TITLE
docs: remove links to deleted OAuth examples; fix migration-guide cross-references

### DIFF
--- a/.changeset/sweet-badgers-remain.md
+++ b/.changeset/sweet-badgers-remain.md
@@ -1,0 +1,5 @@
+---
+"@slack/oauth": patch
+---
+
+docs: remove links to deleted OAuth examples; fix migration-guide cross-references

--- a/docs/english/migration/socket-mode/migrating-socket-mode-package-to-v3.md
+++ b/docs/english/migration/socket-mode/migrating-socket-mode-package-to-v3.md
@@ -93,7 +93,7 @@ const client = new SocketModeClient({
 
 ### We've updated the dependency on `@slack/web-api@^8`
 
-This package now uses `@slack/web-api@^8` internally. If you're passing `clientOptions`, the web-api breaking changes apply there too. Check the [web-api v8 migration guide](./web-api-v8-migration.md) for details.
+This package now uses `@slack/web-api@^8` internally. If you're passing `clientOptions`, the web-api breaking changes apply there too. Check the [web-api v8 migration guide](../web-api/migrating-web-api-package-to-v8.md) for details.
 
 ```diff
  const client = new SocketModeClient({

--- a/docs/english/migration/web-api/migrating-web-api-package-to-v8.md
+++ b/docs/english/migration/web-api/migrating-web-api-package-to-v8.md
@@ -337,7 +337,7 @@ function handleError(error: WebAPIHTTPError) {
 
 ### We've removed the `RequestConfig` type
 
-The `RequestConfig` type was an alias for axios's `InternalAxiosRequestConfig`. If you were importing it for `requestInterceptor`, [that has also been removed](requestinterceptor-and-requestinterceptor-type-removed). Use a fetch wrapper instead as described above.
+The `RequestConfig` type was an alias for axios's `InternalAxiosRequestConfig`. If you were importing it for `requestInterceptor`, [that has also been removed](#weve-removed-the-requestinterceptor-and-requestinterceptor-types). Use a fetch wrapper instead as described above.
 
 ```diff
 -import type { RequestConfig } from '@slack/web-api';

--- a/docs/english/oauth.md
+++ b/docs/english/oauth.md
@@ -463,12 +463,6 @@ const installer = new InstallProvider({
 ```
 </details>
 
----
-
-## Examples
-
-*  [OAuth Express app](https://github.com/slackapi/node-slack-sdk/tree/main/examples/oauth-v2/README.md). This example uses [Keyv](https://github.com/lukechilds/keyv) library as an installation store.
-*  [Classic Slack app](https://github.com/slackapi/node-slack-sdk/tree/main/examples/oauth-v1/README.md). This example uses the built-in installation store.
 
 ---
 

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -388,12 +388,6 @@ const installer = new InstallProvider({
 ```
 </details>
 
----
-
-### Examples
-
-*  [OAuth Express app](../../examples/oauth-v2/README.md). This example uses [Keyv](https://github.com/lukechilds/keyv) library as an installation store.
-*  [classic Slack App](../../examples/oauth-v1/README.md). This example uses the built-in installation store
 
 ---
 


### PR DESCRIPTION
Three commits:

1. **`packages/oauth/README.md`** — the Examples section links `../../examples/oauth-v2` and `../../examples/oauth-v1`, but those example apps were removed from the repository (only `openid-connect` and `socket-mode` remain), so both links 404. Removed the dead section.
2. **`docs/english/oauth.md`** — the same two examples linked as absolute GitHub URLs; both curl 404 (the parent `examples/` tree is 200). Removed.
3. **Migration guides** — the web-api v8 guide's `requestInterceptor` cross-reference was missing the `#` and used a slug matching no heading (now points at the real `#weve-removed-the-requestinterceptor-and-requestinterceptor-types` anchor, heading present in the same file), and the socket-mode v3 guide linked `./web-api-v8-migration.md`, which doesn't exist anywhere (now `../web-api/migrating-web-api-package-to-v8.md`).

**Verification:** all dead targets confirmed missing (tree + curl), all corrected targets confirmed present; root `npm run build` and the touched package's suite (`npm test --workspace=packages/oauth`) pass locally — 16/16 tests (Node 22, macOS arm64).

Prepared with AI assistance (Claude).