### PR TITLE
feat(types): add min_lines/max_lines to RichTextInput

### DIFF
--- a/.changeset/rich-text-input-min-max-lines.md
+++ b/.changeset/rich-text-input-min-max-lines.md
@@ -1,0 +1,5 @@
+---
+"@slack/types": minor
+---
+
+feat(types): add optional `min_lines` and `max_lines` properties to `RichTextInput` element

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -1071,7 +1071,7 @@ export interface RichTextInput extends Actionable, Dispatchable, Focusable, Plac
    */
   min_lines?: number;
   /**
-   * @description The maximum number of lines of text shown in the input before it scrolls. Must be between 1 and 50.
+   * @description The maximum number of lines of text shown in the input before it scrolls. Must be between 1 and 100.
    * Defaults to `8` when not specified.
    */
   max_lines?: number;

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -1066,4 +1066,13 @@ export interface RichTextInput extends Actionable, Dispatchable, Focusable, Plac
    * @description Initial contents of the input when it is loaded.
    */
   initial_value?: RichTextBlock;
+  /**
+   * @description The minimum number of lines of text shown in the input. Must be between 1 and 50.
+   */
+  min_lines?: number;
+  /**
+   * @description The maximum number of lines of text shown in the input before it scrolls. Must be between 1 and 50.
+   * Defaults to `8` when not specified.
+   */
+  max_lines?: number;
 }

--- a/packages/types/src/block-kit/block-elements.ts
+++ b/packages/types/src/block-kit/block-elements.ts
@@ -1067,7 +1067,7 @@ export interface RichTextInput extends Actionable, Dispatchable, Focusable, Plac
    */
   initial_value?: RichTextBlock;
   /**
-   * @description The minimum number of lines of text shown in the input. Must be between 1 and 50.
+   * @description The minimum number of lines of text shown in the input. Must be between 1 and 100.
    */
   min_lines?: number;
   /**

--- a/packages/types/test/block-elements.test-d.ts
+++ b/packages/types/test/block-elements.test-d.ts
@@ -22,7 +22,7 @@ expectAssignable<RichTextInput>({
 // RichTextInput — sad paths
 expectError<RichTextInput>({
   type: 'rich_text_input',
-  min_lines: '3',
+  min_lines: '3', // Minimum should be integer
 });
 expectError<RichTextInput>({
   type: 'rich_text_input',

--- a/packages/types/test/block-elements.test-d.ts
+++ b/packages/types/test/block-elements.test-d.ts
@@ -1,0 +1,30 @@
+import { expectAssignable, expectError } from 'tsd';
+import type { RichTextInput } from '../src/index';
+
+// RichTextInput — happy paths
+expectAssignable<RichTextInput>({
+  type: 'rich_text_input',
+});
+expectAssignable<RichTextInput>({
+  type: 'rich_text_input',
+  min_lines: 3,
+});
+expectAssignable<RichTextInput>({
+  type: 'rich_text_input',
+  max_lines: 16,
+});
+expectAssignable<RichTextInput>({
+  type: 'rich_text_input',
+  min_lines: 3,
+  max_lines: 16,
+});
+
+// RichTextInput — sad paths
+expectError<RichTextInput>({
+  type: 'rich_text_input',
+  min_lines: '3',
+});
+expectError<RichTextInput>({
+  type: 'rich_text_input',
+  max_lines: '16',
+});


### PR DESCRIPTION
### Summary

Adds optional `min_lines` and `max_lines` integer properties to the `RichTextInput` Block Kit element interface, allowing developers to control the visible height of `rich_text_input` elements.

- `min_lines` — minimum number of visible lines (1–100)
- `max_lines` — maximum number of visible lines before scrolling (1–100, defaults to 8 on the platform when unset)

Both properties are optional, preserving full backward compatibility.

### Testing
<details><summary> Test app.js </summary>


```js

import { App } from '@slack/bolt';

const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  socketMode: true,
  appToken: process.env.SLACK_APP_TOKEN,
});

app.command('/rich-text-test', async ({ ack, client, body }) => {
  await ack();
  await client.views.open({
    trigger_id: body.trigger_id,
    view: {
      type: 'modal',
      title: { type: 'plain_text', text: 'Rich Text Test' },
      submit: { type: 'plain_text', text: 'Submit' },
      blocks: [
        {
          type: 'input',
          block_id: 'rich_text_block',
          label: { type: 'plain_text', text: 'Default (no min/max — should be 8 max)' },
          element: {
            type: 'rich_text_input',
            action_id: 'default_input',
          },
        },
        {
          type: 'input',
          block_id: 'rich_text_min_block',
          label: { type: 'plain_text', text: 'min_lines: 5' },
          element: {
            type: 'rich_text_input',
            action_id: 'min_input',
            min_lines: 5,
          },
        },
        {
          type: 'input',
          block_id: 'rich_text_max_block',
          label: { type: 'plain_text', text: 'max_lines: 16' },
          element: {
            type: 'rich_text_input',
            action_id: 'max_input',
            max_lines: 16,
          },
        },
        {
          type: 'input',
          block_id: 'rich_text_both_block',
          label: { type: 'plain_text', text: 'min_lines: 3, max_lines: 20' },
          element: {
            type: 'rich_text_input',
            action_id: 'both_input',
            min_lines: 3,
            max_lines: 20,
          },
        },
      ],
    },
  });
});

(async () => {
  await app.start();
  app.logger.info('⚡️ Rich Text Test app is running!');
})();

```


</details>

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).