### PR TITLE
fix(socket-mode): suppress heartbeat warning during shutdown

### DIFF
--- a/.changeset/socket-mode-shutdown-heartbeat.md
+++ b/.changeset/socket-mode-shutdown-heartbeat.md
@@ -1,0 +1,5 @@
+---
+'@slack/socket-mode': patch
+---
+
+Suppress heartbeat timeout warnings while a Socket Mode client intentionally closes its WebSocket connection.

--- a/packages/socket-mode/src/SlackWebSocket.test.ts
+++ b/packages/socket-mode/src/SlackWebSocket.test.ts
@@ -92,5 +92,40 @@ describe('SlackWebSocket', () => {
       ws.dispatchEvent(new ErrorEvent('error', { error: new Error('boom'), message: 'boom' }));
       sinon.assert.calledOnce(discStub);
     });
+
+    it('should stop heartbeat monitoring during an intentional disconnect', () => {
+      const ws = new WSMock();
+      SlackWebSocket = proxyquire.load('./SlackWebSocket', {
+        undici: {
+          WebSocket: class Fake {
+            constructor() {
+              // biome-ignore lint/correctness/noConstructorReturn: for test mocking purposes
+              return ws;
+            }
+          },
+          CloseEvent,
+          ErrorEvent,
+          MessageEvent,
+          ping: () => {},
+        },
+      }).SlackWebSocket;
+      const logger = new ConsoleLogger();
+      const warn = sinon.stub(logger, 'warn');
+      const clock = sandbox.useFakeTimers();
+      const sws = new SlackWebSocket({
+        url: 'whatevs',
+        client: new EventEmitter(),
+        clientPingTimeoutMS: 5000,
+        serverPingTimeoutMS: 30000,
+        logger,
+      });
+
+      sws.connect();
+      ws.dispatchEvent(new Event('open'));
+      sws.disconnect({ suppressHeartbeat: true });
+      clock.tick(20000);
+
+      sinon.assert.neverCalledWithMatch(warn, "A pong wasn't received from the server");
+    });
   });
 });

--- a/packages/socket-mode/src/SlackWebSocket.ts
+++ b/packages/socket-mode/src/SlackWebSocket.ts
@@ -208,7 +208,12 @@ export class SlackWebSocket {
   /**
    * Disconnects the WebSocket connection with Slack, if connected.
    */
-  public disconnect(): void {
+  public disconnect({ suppressHeartbeat = false }: { suppressHeartbeat?: boolean } = {}): void {
+    if (suppressHeartbeat) {
+      clearTimeout(this.serverPingTimeout);
+      clearInterval(this.clientPingTimeout);
+    }
+
     if (this.websocket) {
       // Disconnecting a WebSocket involves a close frame handshake so we check if we've already received a close frame.
       // If so, we can terminate the underlying socket connection and let the client know.

--- a/packages/socket-mode/src/SocketModeClient.ts
+++ b/packages/socket-mode/src/SocketModeClient.ts
@@ -231,7 +231,9 @@ export class SocketModeClient extends EventEmitter {
       } else {
         // Resolve (or reject) on disconnect
         this.once(State.Disconnected, resolve);
-        this.websocket?.disconnect();
+        // A manual shutdown should not report heartbeat failures while the
+        // WebSocket close handshake is in progress.
+        this.websocket?.disconnect({ suppressHeartbeat: true });
       }
     });
   }


### PR DESCRIPTION
## Problem
When a Socket Mode application shuts down, the client sends a WebSocket close frame but leaves its heartbeat interval active until the peer completes the close handshake. If Slack does not send a pong in the 5-second heartbeat window, the SDK logs `A pong wasn't received from the server before the timeout of 5000ms!` even though the disconnect was intentional.

## Solution
Stop heartbeat monitoring immediately for explicit `SocketModeClient.disconnect()` calls, while preserving heartbeat detection for unexpected connection failures. The close handshake and disconnected lifecycle event remain unchanged.

## Validation
- `npm run test:unit --workspace @slack/socket-mode`
- `npx @biomejs/biome check packages/socket-mode/src/SocketModeClient.ts packages/socket-mode/src/SlackWebSocket.ts packages/socket-mode/src/SlackWebSocket.test.ts`