### PR TITLE
fix: revert internal packages requiring esm loading for backward compatible support

### DIFF
--- a/.changeset/restore-cjs-loadable-deps.md
+++ b/.changeset/restore-cjs-loadable-deps.md
@@ -1,0 +1,6 @@
+---
+"@slack/web-api": patch
+"@slack/webhook": patch
+---
+
+fix: revert internal packages requiring esm loading for backward compatible support ([#2711](https://github.com/slackapi/node-slack-sdk/issues/2711))

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,10 +186,7 @@ updates:
           - "@types/mocha"
           - "mocha"
     ignore:
-      # p-queue (v7+) and p-retry (v5+) are pure ESM and raise their minimum
-      # Node.js version each major. Bumping either breaks `require()` of this
-      # package's CommonJS build on the declared Node >= 20 range (ERR_REQUIRE_ESM,
-      # see #2711) and can force a change to its supported Node floor.
+      # Avoid pure ESM p-queue (v7+) / p-retry (v5+) to prevent CJS require() breakage on Node >= 20 (see #2711).
       - dependency-name: "p-queue"
       - dependency-name: "p-retry"
       - dependency-name: "@types/node"
@@ -221,10 +218,7 @@ updates:
           - "@types/mocha"
           - "mocha"
     ignore:
-      # p-retry (v5+) is pure ESM and raises its minimum Node.js version each
-      # major (v7 requires Node >= 20, v8 requires Node >= 22). Bumping it breaks
-      # `require()` of this package's CommonJS build (ERR_REQUIRE_ESM, see #2711)
-      # and can force a change to its supported Node floor.
+      # Avoid pure ESM p-retry (v5+) to prevent CJS require() breakage on Node >= 20 (see #2711).
       - dependency-name: "p-retry"
       - dependency-name: "@types/node"
         versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,6 +186,12 @@ updates:
           - "@types/mocha"
           - "mocha"
     ignore:
+      # p-queue (v7+) and p-retry (v5+) are pure ESM and raise their minimum
+      # Node.js version each major. Bumping either breaks `require()` of this
+      # package's CommonJS build on the declared Node >= 20 range (ERR_REQUIRE_ESM,
+      # see #2711) and can force a change to its supported Node floor.
+      - dependency-name: "p-queue"
+      - dependency-name: "p-retry"
       - dependency-name: "@types/node"
         versions:
           - "21.x"
@@ -215,9 +221,10 @@ updates:
           - "@types/mocha"
           - "mocha"
     ignore:
-      # p-retry is pure ESM and raises its minimum Node.js version each major
-      # (v7 requires Node >= 20, v8 requires Node >= 22). Bumping it can force a
-      # change to this package's own supported Node floor.
+      # p-retry (v5+) is pure ESM and raises its minimum Node.js version each
+      # major (v7 requires Node >= 20, v8 requires Node >= 22). Bumping it breaks
+      # `require()` of this package's CommonJS build (ERR_REQUIRE_ESM, see #2711)
+      # and can force a change to its supported Node floor.
       - dependency-name: "p-retry"
       - dependency-name: "@types/node"
         versions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3014,18 +3014,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-network-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
-      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "dev": true,
@@ -3829,22 +3817,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-queue": {
-      "version": "9.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.4",
-        "p-timeout": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-retry": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
@@ -3852,16 +3828,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -5759,8 +5725,8 @@
         "@types/node": ">=20",
         "@types/retry": "0.12.5",
         "eventemitter3": "^5.0.1",
-        "p-queue": "^9",
-        "p-retry": "^8",
+        "p-queue": "^6.6.2",
+        "p-retry": "^4.6.2",
         "retry": "^0.13.1"
       },
       "devDependencies": {
@@ -5789,19 +5755,38 @@
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "license": "MIT"
     },
-    "packages/web-api/node_modules/p-retry": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
-      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
+    "packages/web-api/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
       "dependencies": {
-        "is-network-error": "^1.3.0"
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/web-api/node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "packages/web-api/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/web-api/node_modules/undici-types": {
@@ -5816,7 +5801,7 @@
         "@slack/types": "^3.1.0",
         "@types/node": ">=20",
         "@types/retry": "0.12.5",
-        "p-retry": "^8",
+        "p-retry": "^4.6.2",
         "retry": "^0.13.1"
       },
       "devDependencies": {
@@ -5839,21 +5824,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "license": "MIT"
-    },
-    "packages/webhook/node_modules/p-retry": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
-      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-network-error": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/webhook/node_modules/undici-types": {
       "version": "7.19.2",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -53,8 +53,8 @@
     "@types/node": ">=20",
     "@types/retry": "0.12.5",
     "eventemitter3": "^5.0.1",
-    "p-queue": "^9",
-    "p-retry": "^8",
+    "p-queue": "^6.6.2",
+    "p-retry": "^4.6.2",
     "retry": "^0.13.1"
   },
   "devDependencies": {

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -44,7 +44,7 @@
     "@slack/types": "^3.1.0",
     "@types/node": ">=20",
     "@types/retry": "0.12.5",
-    "p-retry": "^8",
+    "p-retry": "^4.6.2",
     "retry": "^0.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary

This pull request restores CommonJS-loadable dependency versions so `require('@slack/web-api')` and `require('@slack/webhook')` work on every Node.js version in the declared `engines.node: ">= 20"` range. Fixes #2711.

- `@slack/web-api@8.1.0` throws `ERR_REQUIRE_ESM` when `require()`d on Node 20 versions before `require(esm)` was unflagged (i.e. Node 20.0–20.18; unflagged by default only in [20.19+](https://nodejs.org/en/blog/release/v20.19.0) / [22.12+](https://nodejs.org/en/blog/release/v22.12.0)). `@slack/web-api@8.0.0` loads fine because it shipped with the older CommonJS deps.
- Root cause: `p-queue` and `p-retry` each went **pure ESM** (`"type": "module"`) at a major that our ranges silently crossed:
  - `p-queue` — CJS through `6.6.2`; ESM-only from [**v7.0.0**](https://github.com/sindresorhus/p-queue/releases/tag/v7.0.0). We were on `^9`.
  - `p-retry` — CJS through `4.6.2`; ESM-only from [**v5.0.0**](https://github.com/sindresorhus/p-retry/releases/tag/v5.0.0). We were on `^8` ([v8.0.0](https://github.com/sindresorhus/p-retry/releases/tag/v8.0.0) also raised the engine floor to Node 22).
- Fix: pin both back to their last CommonJS releases — **`p-queue@^6.6.2`** and **`p-retry@^4.6.2`** — matching what shipped in the working `@slack/web-api@8.0.0`. `6.6.2` and `4.6.2` are the terminal versions of their CJS majors, so the caret ranges resolve to exactly those releases while staying major-gated against the ESM-only successors. Matching Dependabot `ignore` rules are added for `web-api` (mirroring the existing rule for `webhook`) so a future bump can't silently re-break CJS loading.
- **Not a breaking change for consumers:** `p-queue`/`p-retry` are internal implementation details — never re-exported. The public `RetryOptions` type is defined via the [`retry`](https://www.npmjs.com/package/retry) package, not `p-retry`, and the SDK only uses options common to these versions (`AbortError`, `retries`, `factor`, `minTimeout`, `maxTimeout`, `randomize`). Consumers on Node 20.19+/22.12+ see no change; consumers on plain Node 20 go from broken → working.

### Testing

Simulate the pre-`require(esm)` Node.js behavior with the flag from the issue repro:

```sh
# From packages/web-api, after npm run build:
node --no-experimental-require-module test/integration/commonjs-project/index.js
# → ✅ CJS project integration test succeeded!

# And directly, mirroring the issue:
node --no-experimental-require-module -e "require('@slack/web-api')"   # loads (was ERR_REQUIRE_ESM)
node --no-experimental-require-module -e "require('@slack/webhook')"   # loads (was ERR_REQUIRE_ESM)
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).