### PR TITLE
ci: adjust outputs of changeset releases to reattempt most recent releases

### DIFF
--- a/.changeset/restore-cjs-loadable-deps.md
+++ b/.changeset/restore-cjs-loadable-deps.md
@@ -1,0 +1,6 @@
+---
+"@slack/web-api": patch
+"@slack/webhook": patch
+---
+
+fix: revert internal packages requiring esm loading for backward compatible support ([#2711](https://github.com/slackapi/node-slack-sdk/issues/2711))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Changelog
     runs-on: ubuntu-latest
     outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      hasChangesets: ${{ steps.changesets.outputs.has-changesets }}
       releaseExists: ${{ steps.published.outputs.exists }}
     permissions:
       contents: write
@@ -59,7 +59,7 @@ jobs:
 
       - name: Check if publish is needed
         id: published
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.changesets.outputs.has-changesets == 'false'
         run: |
           EXISTS=true
           for PKG in $(npm query .workspace | jq -r '.[].name'); do
@@ -138,7 +138,7 @@ jobs:
           echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "\(.name)@\(.version)"] | join(", ")')" >> "$GITHUB_OUTPUT"
           echo "action_url=$(echo "$PUBLISHED_PACKAGES" | jq -r '[.[] | "https://github.com/${{ github.repository }}/releases/tag/\(.name)@\(.version)"] | join(", ")')" >> "$GITHUB_OUTPUT"
         env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
 
       - name: Notify Slack
         if: steps.changesets.outputs.published == 'true'

--- a/docs/english/reference/web-api/index.md
+++ b/docs/english/reference/web-api/index.md
@@ -1,4 +1,4 @@
-# @slack/web-api v8.1.1
+# @slack/web-api v8.1.0
 
 ## Enumerations
 

--- a/docs/english/reference/webhook/index.md
+++ b/docs/english/reference/webhook/index.md
@@ -1,4 +1,4 @@
-# @slack/webhook v8.0.2
+# @slack/webhook v8.0.1
 
 ## Enumerations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5466,7 +5466,7 @@
     },
     "packages/web-api": {
       "name": "@slack/web-api",
-      "version": "8.1.1",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^5.0.0",
@@ -5544,7 +5544,7 @@
     },
     "packages/webhook": {
       "name": "@slack/webhook",
-      "version": "8.0.2",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
         "@slack/types": "^3.1.0",

--- a/packages/web-api/CHANGELOG.md
+++ b/packages/web-api/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @slack/web-api
 
-## 8.1.1
-
-### Patch Changes
-
-- aef66ac: fix: revert internal packages requiring esm loading for backward compatible support ([#2711](https://github.com/slackapi/node-slack-sdk/issues/2711))
-
 ## 8.1.0
 
 ### Minor Changes

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/web-api",
-  "version": "8.1.1",
+  "version": "8.1.0",
   "description": "Official library for using the Slack Platform's Web API",
   "author": "Slack Technologies, LLC",
   "license": "MIT",

--- a/packages/webhook/CHANGELOG.md
+++ b/packages/webhook/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @slack/webhook
 
-## 8.0.2
-
-### Patch Changes
-
-- aef66ac: fix: revert internal packages requiring esm loading for backward compatible support ([#2711](https://github.com/slackapi/node-slack-sdk/issues/2711))
-
 ## 8.0.1
 
 ### Patch Changes

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/webhook",
-  "version": "8.0.2",
+  "version": "8.0.1",
   "description": "Official library for using the Slack Platform's Incoming Webhooks",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
### Summary

This pull request recovers a release that silently failed to publish and fixes the underlying workflow bug.

- The `changesets/action` v1→v2 bump (#2714) migrated the action's **inputs** to kebab-case, but the release workflow still read the action's **outputs** by their old camelCase names. v2 renamed the outputs too (changesets/action#668).
- With `outputs.hasChangesets` reading empty, the `has-changesets == 'false'` gate never matched, the "Check if publish is needed" step was skipped, and the publish job's gate failed closed. Release PR #2713 merged and bumped versions on `main` but **never published to npm** (`@slack/web-api` and `@slack/webhook` on `main` were ahead of the npm `latest` tags).
- Reverts #2713 to roll `@slack/web-api` back to `8.1.0` and `@slack/webhook` back to `8.0.1` (matching npm) and restores the consumed changeset, so a corrected release run republishes them cleanly.
- Fixes the three action-output reads in `release.yml`, using bracket notation because hyphenated keys cannot be dot-dereferenced in Actions expressions:
  - `outputs.hasChangesets` → `outputs['has-changesets']`
  - `outputs.publishedPackages` → `outputs['published-packages']`
  - `outputs.published` was **not** renamed in v2 and is left unchanged.

### Testing

- After merge, confirm the release run's `Changelog` job does **not** skip "Check if publish is needed", and that the `Publish` job runs (not skipped).
- Confirm `@slack/web-api@8.1.1` and `@slack/webhook@8.0.2` publish to npm and get GitHub releases.

### Requirements <!-- Place an \`x\` in each \`[ ]\` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).