### PR TITLE
fix: correct SlackListsItemFieldMessage type

### DIFF
--- a/packages/web-api/src/types/request/slackLists.ts
+++ b/packages/web-api/src/types/request/slackLists.ts
@@ -58,11 +58,22 @@ export interface SlackListsItemFieldLink {
 }
 
 /**
+ * @description Message object in Slack Lists message field.
+ */
+export interface SlackListsItemMessage {
+  text?: string;
+  ts?: string;
+  user?: string;
+  team?: string;
+  type?: string;
+}
+
+/**
  * @description Message field with message URLs.
  */
 export interface SlackListsItemFieldMessage {
   column_id: string;
-  message: string[];
+  message: SlackListsItemMessage | SlackListsItemMessage[];
 }
 
 /**


### PR DESCRIPTION
## Summary

The SlackListsItemFieldMessage interface incorrectly defined the message field as string[]. However, the Slack API can return the message field as either a single message object or an array of message objects.

## Fix

This PR introduces a new SlackListsItemMessage interface and updates SlackListsItemFieldMessage to use a union type.

## References

Fixes #2598