### PR TITLE
fix: add error handling for JSON.parse in admin.analytics.getFile response

### DIFF
--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -799,7 +799,12 @@ export class WebClient extends Methods {
       // if it isn't a Gzip response but is from the admin.analytics.getFile request,
       // decode the ArrayBuffer to JSON read the error
       const buffer = await response.arrayBuffer();
-      data = JSON.parse(new TextDecoder().decode(buffer));
+      try {
+        data = JSON.parse(new TextDecoder().decode(buffer));
+      } catch (_) {
+        // failed to parse the response body as JSON
+        data = { ok: false, error: new TextDecoder().decode(buffer) };
+      }
     } else {
       const text = await response.text();
       try {


### PR DESCRIPTION
## Summary

The `JSON.parse` at line 802 in `packages/web-api/src/WebClient.ts` was not wrapped in a try-catch block, which could cause an unhandled exception if the response body from `admin.analytics.getFile` is not valid JSON.

## Problem

When the response from `/admin.analytics.getFile` is not gzip encoded and the response body is not valid JSON, the code at line 802 would throw an unhandled exception:
```typescript
data = JSON.parse(new TextDecoder().decode(buffer));
```

This is inconsistent with the similar operation at line 811 which is properly wrapped in a try-catch.

## Fix

Added try-catch to handle parse failures gracefully, returning `{ ok: false, error: <error message> }` instead of throwing an unhandled exception.

## Testing

- [ ] Run existing tests: `npm test --workspace=packages/web-api`
- [ ] Verify the fix handles malformed JSON responses gracefully