### PR TITLE
feat(types): allow raw_number cells in TableBlock rows

### DIFF
--- a/.changeset/table-raw-number-cell.md
+++ b/.changeset/table-raw-number-cell.md
@@ -1,0 +1,5 @@
+---
+"@slack/types": minor
+---
+
+fix: allow [`raw_number`](https://docs.slack.dev/reference/block-kit/blocks/table-block) cells in `TableBlock` rows (adds `RawNumberElement`)

--- a/.changeset/table-raw-number-cell.md
+++ b/.changeset/table-raw-number-cell.md
@@ -2,4 +2,4 @@
 "@slack/types": minor
 ---
 
-fix: allow `raw_number` cells in [`TableBlock`](https://docs.slack.dev/reference/block-kit/blocks/table-block) rows (adds `RawNumberElement`)
+feat: allow `raw_number` cells in [`TableBlock`](https://docs.slack.dev/reference/block-kit/blocks/table-block) rows (adds `RawNumberElement`)

--- a/.changeset/table-raw-number-cell.md
+++ b/.changeset/table-raw-number-cell.md
@@ -2,4 +2,4 @@
 "@slack/types": minor
 ---
 
-fix: allow [`raw_number`](https://docs.slack.dev/reference/block-kit/blocks/table-block) cells in `TableBlock` rows (adds `RawNumberElement`)
+fix: allow `raw_number` cells in [`TableBlock`](https://docs.slack.dev/reference/block-kit/blocks/table-block) rows (adds `RawNumberElement`)

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -521,7 +521,7 @@ export interface TableBlock extends Block {
    */
   type: 'table';
   /**
-   * @description An array consisting of table rows. Maximum 100 rows. Each row object is an array with a max of 20 table cells. Table cells can have a type of raw_text, raw_number, or rich_text.
+   * @description An array consisting of table rows. Maximum 100 rows. Each row object is an array with a max of 20 table cells. Table cells can have a type of rich_text, raw_text, or raw_number.
    */
   rows: (RichTextBlock | RawTextElement | RawNumberElement)[][];
   /**

--- a/packages/types/src/block-kit/blocks.ts
+++ b/packages/types/src/block-kit/blocks.ts
@@ -28,6 +28,7 @@ import type {
 import type {
   MrkdwnElement,
   PlainTextElement,
+  RawNumberElement,
   RawTextElement,
   SlackFileImageObject,
   TextObject,
@@ -520,9 +521,9 @@ export interface TableBlock extends Block {
    */
   type: 'table';
   /**
-   * @description An array consisting of table rows. Maximum 100 rows. Each row object is an array with a max of 20 table cells. Table cells can have a type of raw_text or rich_text.
+   * @description An array consisting of table rows. Maximum 100 rows. Each row object is an array with a max of 20 table cells. Table cells can have a type of raw_text, raw_number, or rich_text.
    */
-  rows: (RichTextBlock | RawTextElement)[][];
+  rows: (RichTextBlock | RawTextElement | RawNumberElement)[][];
   /**
    * @description An array describing column behavior. If there are fewer items in the column_settings array than there are columns in the table, then the items in the the column_settings array will describe the same number of columns in the table as there are in the array itself. Any additional columns will have the default behavior. Maximum 20 items.
    */

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -174,6 +174,24 @@ export interface MrkdwnElement {
 }
 
 /**
+ * @description Defines an object containing a numeric value.
+ */
+export interface RawNumberElement {
+  /**
+   * @description The formatting to use for this numeric object.
+   */
+  type: 'raw_number';
+  /**
+   * @description The numeric value.
+   */
+  value: number;
+  /**
+   * @description The text used to display the value. The minimum length is 1 character.
+   */
+  text: string;
+}
+
+/**
  * @description Defines an object containing some text.
  * @see {@link https://docs.slack.dev/reference/block-kit/composition-objects/text-object Text object reference}.
  */

--- a/packages/types/test/blocks.test-d.ts
+++ b/packages/types/test/blocks.test-d.ts
@@ -108,7 +108,7 @@ expectAssignable<KnownBlock>({
 expectError<TableBlock>({}); // missing type and rows
 expectError<TableBlock>({ type: 'table' }); // missing required rows
 // -- happy path
-// Table cells can be raw_text, raw_number, or rich_text.
+// Table cells can be rich_text, raw_text, or raw_number.
 expectAssignable<TableBlock>({
   type: 'table',
   rows: [

--- a/packages/types/test/blocks.test-d.ts
+++ b/packages/types/test/blocks.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
-import type { AlertBlock, CardBlock, CarouselBlock, ContainerBlock, KnownBlock } from '../src/index';
+import type { AlertBlock, CardBlock, CarouselBlock, ContainerBlock, KnownBlock, TableBlock } from '../src/index';
 
 // CardBlock
 // -- sad path
@@ -101,4 +101,32 @@ expectAssignable<KnownBlock>({
   type: 'container',
   title: { type: 'plain_text', text: 'Known' },
   child_blocks: [{ type: 'divider' }],
+});
+
+// TableBlock
+// -- sad path
+expectError<TableBlock>({}); // missing type and rows
+expectError<TableBlock>({ type: 'table' }); // missing required rows
+// -- happy path
+// Table cells can be raw_text, raw_number, or rich_text.
+expectAssignable<TableBlock>({
+  type: 'table',
+  rows: [
+    [
+      { type: 'raw_text', text: 'Item' },
+      { type: 'raw_text', text: 'Count' },
+    ],
+    [
+      { type: 'raw_text', text: 'Widgets' },
+      { type: 'raw_number', value: 42, text: '42' },
+    ],
+    [
+      { type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'Gadgets' }] }] },
+      { type: 'raw_number', value: 7, text: '7' },
+    ],
+  ],
+});
+expectAssignable<KnownBlock>({
+  type: 'table',
+  rows: [[{ type: 'raw_number', value: 1, text: '1' }]],
 });

--- a/packages/types/test/blocks.test-d.ts
+++ b/packages/types/test/blocks.test-d.ts
@@ -166,9 +166,10 @@ expectAssignable<KnownBlock>({
 expectError<TableBlock>({}); // missing type and rows
 expectError<TableBlock>({ type: 'table' }); // missing required rows
 // -- happy path
-// Table cells can be rich_text, raw_text, or raw_number.
+// Table cells can be rich_text, raw_text, or raw_number; column_settings describe column behavior.
 expectAssignable<TableBlock>({
   type: 'table',
+  column_settings: [{ is_wrapped: true }, { align: 'right' }],
   rows: [
     [
       { type: 'raw_text', text: 'Item' },

--- a/packages/types/test/composition-objects.test-d.ts
+++ b/packages/types/test/composition-objects.test-d.ts
@@ -1,0 +1,19 @@
+import { expectAssignable, expectError } from 'tsd';
+import type { RawNumberElement, RawTextElement } from '../src/index';
+
+// RawNumberElement
+// -- sad path
+expectError<RawNumberElement>({}); // missing type, value, and text
+expectError<RawNumberElement>({ type: 'raw_number' }); // missing required value and text
+expectError<RawNumberElement>({ type: 'raw_number', value: 42 }); // missing required text
+expectError<RawNumberElement>({ type: 'raw_number', text: '42' }); // missing required value
+expectError<RawNumberElement>({ type: 'raw_number', value: '42', text: '42' }); // value must be a number
+// -- happy path
+expectAssignable<RawNumberElement>({ type: 'raw_number', value: 42, text: '42' });
+
+// RawTextElement
+// -- sad path
+expectError<RawTextElement>({}); // missing type and text
+expectError<RawTextElement>({ type: 'raw_text' }); // missing required text
+// -- happy path
+expectAssignable<RawTextElement>({ type: 'raw_text', text: 'Item' });


### PR DESCRIPTION
### Summary

This pull request fixes the `TableBlock` type in `@slack/types` to allow `raw_number` cells, which the [table-block reference](https://docs.slack.dev/reference/block-kit/blocks/table-block) documents but the type omitted.

- The docs state table cells "can have a type of `rich_text`, `raw_text`, or `raw_number`", but `TableBlock.rows` was typed `(RichTextBlock | RawTextElement)[][]` (no `raw_number`) and its `@description` said only "raw_text or rich_text".
- Adds the `RawNumberElement` composition object (`type: 'raw_number'`, `value`, `text`) — the same definition introduced by the `data_table` PR #2638, so the two share one cell element type and whichever lands second drops the duplicate in a trivial merge.
- Adds `RawNumberElement` to `TableBlock.rows` and corrects the `@description` to match the docs.
- Adds the first tsd type coverage for `TableBlock` (all three cell types); `TableBlock` previously had no type tests.

Closes #2689. A working `raw_number`-in-`table` payload is in [this Block Kit Builder preview](https://app.slack.com/block-kit-builder#%7B%22blocks%22:%5B%7B%22type%22:%22table%22,%22rows%22:%5B%5B%7B%22type%22:%22raw_text%22,%22text%22:%22Item%22%7D,%7B%22type%22:%22raw_text%22,%22text%22:%22Count%22%7D%5D,%5B%7B%22type%22:%22raw_text%22,%22text%22:%22Widgets%22%7D,%7B%22type%22:%22raw_number%22,%22value%22:42,%22text%22:%2242%22%7D%5D%5D%7D%5D%7D) (from the issue).

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
