### PR TITLE
fix(web-api): retry responses interrupted while reading the body

### DIFF
--- a/.changeset/web-api-retry-interrupted-response-body.md
+++ b/.changeset/web-api-retry-interrupted-response-body.md
@@ -1,0 +1,5 @@
+---
+"@slack/web-api": patch
+---
+
+fix(web-api): retry and error-wrap responses whose connection drops while the body is being read

--- a/packages/web-api/src/WebClient.test.ts
+++ b/packages/web-api/src/WebClient.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import http from 'node:http';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import zlib from 'node:zlib';
 import type { ContextActionsBlock } from '@slack/types';
@@ -513,6 +514,108 @@ describe('WebClient', () => {
         assert.ok(error.original instanceof Error);
         assert.strictEqual(error.cause, error.original);
       }
+    });
+
+    describe('when the response body is interrupted', () => {
+      const servers: http.Server[] = [];
+      afterEach(() => {
+        for (const server of servers.splice(0)) {
+          server.closeAllConnections();
+          server.close();
+        }
+      });
+
+      // `fetch` resolves once the response headers arrive, so a connection dropped partway through
+      // the body cannot be simulated with nock. These use a local server that writes a 200 status
+      // line and part of the body before destroying the socket. `Content-Length` deliberately
+      // overstates the body so the client is still waiting on it when the socket goes away.
+      function startFlakyServer(succeedAfter: number): Promise<{ url: string; requests: () => number }> {
+        let requests = 0;
+        const server = http.createServer((req, res) => {
+          req.resume();
+          requests += 1;
+          if (requests > succeedAfter) {
+            res.end('{"ok":true}');
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': '100' });
+          res.write('{"ok":');
+          setTimeout(() => res.destroy(), 10);
+        });
+        servers.push(server);
+        return new Promise((resolve) => {
+          server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            assert.ok(address !== null && typeof address !== 'string');
+            resolve({ url: `http://127.0.0.1:${address.port}/`, requests: () => requests });
+          });
+        });
+      }
+
+      it('should retry the request when the connection drops while reading the body', async () => {
+        const { url, requests } = await startFlakyServer(1);
+        const client = new WebClient(token, {
+          slackApiUrl: url,
+          retryConfig: { retries: 1, minTimeout: 1, maxTimeout: 1 },
+        });
+
+        const result = await client.apiCall('method');
+
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(requests(), 2);
+      });
+
+      it('should retry when reading the body rejects, without depending on socket timing', async () => {
+        // A deterministic counterpart to the socket-level tests above: the body read is what fails,
+        // which is the exact condition #2738 describes, with no reliance on when the connection drops.
+        let calls = 0;
+        const fetchFn: FetchFunction = async () => {
+          calls += 1;
+          const failing = calls === 1;
+          const payload = JSON.stringify({ ok: true });
+          const readBody = async () => {
+            if (failing) throw new TypeError('terminated');
+            return payload;
+          };
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            url: 'https://slack.com/api/method',
+            headers: { get: () => null, entries: () => [] },
+            arrayBuffer: async () => new TextEncoder().encode(await readBody()).buffer as ArrayBuffer,
+            text: readBody,
+            json: async () => JSON.parse(await readBody()),
+          };
+        };
+        const client = new WebClient(token, {
+          fetch: fetchFn,
+          retryConfig: { retries: 1, minTimeout: 1, maxTimeout: 1 },
+        });
+
+        const result = await client.apiCall('method');
+
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(calls, 2);
+      });
+
+      it('should fail with WebAPIRequestError once retries are exhausted', async () => {
+        const { url } = await startFlakyServer(Number.POSITIVE_INFINITY);
+        const client = new WebClient(token, {
+          slackApiUrl: url,
+          retryConfig: { retries: 1, minTimeout: 1, maxTimeout: 1 },
+        });
+
+        try {
+          await client.apiCall('method');
+          assert.fail('expected error to be thrown');
+        } catch (error) {
+          assert.ok(error instanceof WebAPIRequestError);
+          assert.ok(error instanceof SlackError);
+          assert.strictEqual(error.code, ErrorCode.RequestError);
+          assert.ok(error.original instanceof Error);
+        }
+      });
     });
 
     it('should set error.body to the raw string when HTTP error response is not valid JSON', async () => {

--- a/packages/web-api/src/WebClient.ts
+++ b/packages/web-api/src/WebClient.ts
@@ -659,7 +659,11 @@ export class WebClient extends Methods {
             );
           }
 
-          return response;
+          // Read the body here, while still inside the retried task, so that a connection dropped
+          // partway through the response is retried and error-wrapped like any other request
+          // failure. `fetch` resolves as soon as the response headers arrive, so a body read left
+          // to the caller would land outside both this retry loop and the `catch` below.
+          return await bufferResponseBody(response);
         } catch (error) {
           if (error instanceof AbortError) {
             throw error;
@@ -857,6 +861,25 @@ function paginationOptionsForNextPage(
     };
   }
   return undefined;
+}
+
+/**
+ * Read a response body in full and return a {@link FetchResponse} that replays those bytes, so that
+ * the body can be consumed again by callers without touching the network.
+ */
+async function bufferResponseBody(response: FetchResponse): Promise<FetchResponse> {
+  const body = await response.arrayBuffer();
+  const decode = () => new TextDecoder().decode(body);
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url,
+    headers: response.headers,
+    arrayBuffer: async () => body,
+    text: async () => decode(),
+    json: async () => JSON.parse(decode()),
+  };
 }
 
 /**


### PR DESCRIPTION
### Summary

Fixes #2738.

`makeRequest()` wraps `fetch` in `pRetry`, but `fetch` resolves once the response headers arrive. The body was read afterwards by `buildResult()` — and by `postFileUploadsToExternalURL()` — outside both the retry loop and the `catch` that produces a coded `WebAPIRequestError`. A connection dropped mid-body therefore neither retried nor got an `error.code`. Under axios the body was materialized inside the retried request, so v7 retried the same interruption.

The fix reads the body inside the retried task and returns a `FetchResponse` that replays the buffered bytes, so both call sites consume it unchanged. Same shape as the `bufferingFetch` workaround in the issue, moved inside `makeRequest` so it also covers a custom `fetch`.

### Notes

Two side effects of the wider task boundary. Both match v7, neither is fixed here — happy to add either if you want it:

- A concurrency slot is now held until the body is read, rather than freed at the headers. Synthetic worst case (8 requests, `maxRequestConcurrency: 4`, 200ms bodies): ~322ms on 8.1.1, ~561ms here, ~323ms if the body read moves just outside the queue callback.
- Retries now repeat a request the server already acted on. Against a permanently-truncating server at `retries: 10`: 1 request on 8.1.1, 11 here, 2 with a separate one-retry budget for interrupted bodies. Since #2674 narrowed `webhook` recently, capping this seemed like your call rather than mine.

### Validation

- `npm test --workspace=@slack/web-api` — 155 passing, including 3 new tests that all fail on `main`
- `npm test --workspaces` — 310 passing
- `npm run lint`, `npm run build`, `npm run docs` — clean

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
