### PR TITLE
feat(types): allow mrkdwn descriptions on checkbox and radio button options

### DIFF
--- a/.changeset/mrkdwn-option-description.md
+++ b/.changeset/mrkdwn-option-description.md
@@ -1,0 +1,5 @@
+---
+"@slack/types": minor
+---
+
+feat(types): allow `mrkdwn` descriptions on checkbox and radio button [options](https://docs.slack.dev/reference/block-kit/composition-objects/option-object)

--- a/packages/types/src/block-kit/composition-objects.ts
+++ b/packages/types/src/block-kit/composition-objects.ts
@@ -79,10 +79,12 @@ interface OptionDescriptor {
    */
   url?: string;
   /**
-   * @description A {@link PlainTextElement} that defines a line of descriptive text shown below the `text` field.
-   * Maximum length for the `text` within this field is 75 characters.
+   * @description A {@link PlainTextElement} or {@link MrkdwnElement} that defines a line of descriptive text shown
+   * below the `text` field beside a single selectable item in a select menu, multi-select menu, checkbox group,
+   * radio button group, or overflow menu. Only checkbox group and radio button group items can use `mrkdwn`
+   * formatting. Maximum length for the `text` within this field is 75 characters.
    */
-  description?: PlainTextElement;
+  description?: PlainTextElement | MrkdwnElement;
 }
 
 export interface MrkdwnOption extends OptionDescriptor {
@@ -99,6 +101,12 @@ export interface PlainTextOption extends OptionDescriptor {
    * overflow, select and multi-select menus. Maximum length for the `text` in this field is 75 characters.
    */
   text: PlainTextElement;
+  /**
+   * @description A {@link PlainTextElement} that defines a line of descriptive text shown below the `text` field.
+   * Options for overflow, select, and multi-select menus can only use `plain_text` descriptions. Maximum length for
+   * the `text` within this field is 75 characters.
+   */
+  description?: PlainTextElement;
 }
 
 /**

--- a/packages/types/test/composition-objects.test-d.ts
+++ b/packages/types/test/composition-objects.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from 'tsd';
-import type { RawNumberElement, RawTextElement } from '../src/index';
+import type { MrkdwnOption, PlainTextOption, RawNumberElement, RawTextElement } from '../src/index';
 
 // RawNumberElement
 // -- sad path
@@ -17,3 +17,26 @@ expectError<RawTextElement>({}); // missing type and text
 expectError<RawTextElement>({ type: 'raw_text' }); // missing required text
 // -- happy path
 expectAssignable<RawTextElement>({ type: 'raw_text', text: 'Item' });
+
+// MrkdwnOption (checkboxes and radio buttons): description may be plain_text or mrkdwn
+// -- happy path
+expectAssignable<MrkdwnOption>({
+  text: { type: 'mrkdwn', text: '*bold* option' },
+  description: { type: 'plain_text', text: 'plain description' },
+});
+expectAssignable<MrkdwnOption>({
+  text: { type: 'mrkdwn', text: '*bold* option' },
+  description: { type: 'mrkdwn', text: '*bold* description' },
+});
+
+// PlainTextOption (overflow, select, multi-select): description must be plain_text only
+// -- happy path
+expectAssignable<PlainTextOption>({
+  text: { type: 'plain_text', text: 'option' },
+  description: { type: 'plain_text', text: 'plain description' },
+});
+// -- sad path
+expectError<PlainTextOption>({
+  text: { type: 'plain_text', text: 'option' },
+  description: { type: 'mrkdwn', text: '*bold* description' },
+});


### PR DESCRIPTION
## Summary

`OptionDescriptor.description` was typed `PlainTextElement`, so a checkbox or radio button option could not carry a `mrkdwn` description — even though the [option-object docs](https://docs.slack.dev/reference/block-kit/composition-objects/option-object) allow `mrkdwn` descriptions for those two element types.

Closes #1765.

## What changed

- **`OptionDescriptor.description`**: `PlainTextElement` → `PlainTextElement | MrkdwnElement`, so checkbox group and radio button group options (`MrkdwnOption`) can use a `mrkdwn` description.
- **`PlainTextOption.description`**: narrowed back to `PlainTextElement` — overflow, select, and multi-select options remain `plain_text`-only, matching the docs.
- Updated the `@description` JSDoc on both to reflect the plain-vs-mrkdwn split.
- Added `tsd` type tests in `composition-objects.test-d.ts` covering both branches (a `MrkdwnOption` accepts either description type; a `PlainTextOption` rejects a `mrkdwn` description).
- Changeset: `@slack/types` minor.

## Testing

`npm run --workspace=packages/types test` (build + `tsd`) passes; verified the new assertions fail if the widening is reverted. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)